### PR TITLE
docs: update documentation to reflect current architecture

### DIFF
--- a/docs/content/docs/README.mdx
+++ b/docs/content/docs/README.mdx
@@ -1,51 +1,32 @@
 ---
 title: Documentation
-description: Documentation
+description: DuraGraph documentation overview
 ---
 
-# Documentation
-
-This directory contains the Markdown sources for the DuraGraph documentation site, built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+This directory contains the documentation sources for the DuraGraph documentation site, built with [Fumadocs](https://fumadocs.vercel.app/).
 
 ## Building the Docs
 
 To preview the documentation locally:
 
 ```bash
-pip install mkdocs-material mike mkdocs-minify-plugin mkdocs-git-revision-date-localized-plugin
-mkdocs serve
+cd docs
+pnpm install
+pnpm dev
 ```
 
-This will launch a local dev server at `http://127.0.0.1:8000`.
-
-## Versioning the Docs
-
-We use [mike](https://github.com/jimporter/mike) to manage versioned documentation.
-
-```bash
-mike deploy 0.1 latest
-mike set-default latest
-```
-
-This makes `0.1` available under `/0.1/` and sets `latest` as the default version.
-
-## Plugins
-
-Enabled plugins in `mkdocs.yml`:
-- `search`
-- `mike`
-- `minify`
-- `git-revision-date-localized`
-- `renderers.openapi`
+This will launch a local dev server at `http://localhost:3000`.
 
 ## Structure
 
 Documentation is organized into sections:
 
-- **Overview**
-- **Getting Started** (includes Quickstart using Docker Compose)
-- **Architecture** (system overview, control plane, Temporal design, IR spec, workers)
-- **Operations** (observability, security, SLOs, runbooks)
-- **Project** (roadmap, contributing, RFCs, ADR index)
+- **Overview** - Mission and architecture
+- **Getting Started** - Quickstart using Docker Compose
+- **User Guide** - Installation, concepts, tutorials, SDKs
+- **Architecture** - System overview, API design, graph engine
+- **API Reference** - REST endpoints and schemas
+- **Operations** - Observability, security, SLOs, runbooks
+- **Project** - Roadmap, contributing, RFCs, ADR index
 
-Stub Markdown files are provided for each section. Expand them as development progresses.
+Expand documentation as development progresses.

--- a/docs/content/docs/architecture/overview.mdx
+++ b/docs/content/docs/architecture/overview.mdx
@@ -1,69 +1,70 @@
 ---
 title: Architecture Overview
-description: Architecture Overview
+description: High-level overview of DuraGraph components and data flows
 ---
 
-# Architecture Overview
-
-This document provides a high-level overview of the components and data flows in the system.
+This document provides a high-level overview of the components and data flows in DuraGraph.
 
 ---
 
 ## Components
 
-- **API Service (`cmd/api`)**
-  Exposes REST + SSE endpoints. Hosts the OpenAPI spec. Handles idempotency and error models.
+- **API Server (`cmd/server`)**
+  Exposes REST + SSE endpoints. Implements LangGraph Cloud-compatible API. Handles request validation and error responses.
 
-- **Runtime Translator (`runtime/translator`)**
-  Validates Intermediate Representation (IR) against JSON Schema and compiles it into a Temporal workflow spec.
+- **Command Handlers (`internal/application/command`)**
+  Process write operations following CQRS. Create and modify domain aggregates, emitting domain events.
 
-- **Runtime Bridge (`runtime/bridge`)**
-  Wraps the Temporal client. Provides APIs for starting, signaling, querying, and canceling runs. Executes generic workflows and activities.
+- **Query Handlers (`internal/application/query`)**
+  Process read operations. Query projections directly for optimized reads.
 
-- **Workers**
-  Language-specific (Python, Go) adapters that execute activities such as LLM calls, tools, checkpoints, and token streaming.
+- **Graph Engine (`internal/infrastructure/graph`)**
+  Executes workflow graphs with support for conditionals, loops, subgraphs, and human-in-the-loop interrupts.
 
-- **Storage Backends**
-  Integration with Postgres and S3 for persisting checkpoints, logs, and workflow states.
+- **Event Store (`internal/infrastructure/persistence`)**
+  PostgreSQL-based event sourcing. Stores all domain events for audit and state reconstruction.
 
-- **Temporal Cluster**
-  Manages workflow execution, retries, signals, versioning, and search attributes.
+- **NATS JetStream (`internal/infrastructure/messaging`)**
+  Reliable event streaming via the outbox pattern. Publishes domain events for real-time updates.
+
+- **Projections**
+  Read-optimized views of domain state. Updated from events for fast queries.
 
 ---
 
 ## Data Flows
 
-1. **Client** calls API (`create run`).
-2. **API** validates request and forwards IR to `translator`.
-3. **Translator** compiles IR into a Temporal workflow spec.
-4. **Bridge** submits workflow to Temporal with search attributes.
-5. **Temporal** schedules Activities on Workers.
-6. **Workers** execute activities (LLM/tool/etc.), stream tokens if needed, and checkpoint state to Postgres/S3.
-7. **Client** consumes updates through `/stream` SSE endpoint.
+1. **Client** calls API (e.g., `POST /runs`).
+2. **API** validates request and invokes command handler.
+3. **Command Handler** creates/modifies aggregate, emitting domain events.
+4. **Repository** saves events to event store + outbox in single transaction.
+5. **Outbox Relay** publishes events to NATS JetStream.
+6. **Graph Engine** executes workflow nodes (LLM, tools, conditions).
+7. **Client** receives real-time updates via SSE stream.
 
 ---
 
-## Sequence Diagram (Mermaid)
+## Sequence Diagram
 
 ```mermaid
 sequenceDiagram
     participant Client
     participant API
-    participant Translator
-    participant Bridge
-    participant Temporal
-    participant Worker
+    participant CommandHandler
+    participant Repository
+    participant EventStore
+    participant GraphEngine
+    participant NATS
 
     Client->>API: POST /runs
-    API->>Translator: Validate + Compile IR
-    Translator-->>API: TemporalWorkflowSpec
-    API->>Bridge: StartRun(spec)
-    Bridge->>Temporal: ExecuteWorkflow
-    Temporal->>Worker: Schedule Activity
-    Worker-->>Temporal: Result / Checkpoint
-    Temporal-->>Bridge: Workflow Events
-    Bridge-->>API: Events
-    API-->>Client: SSE Stream (/stream)
+    API->>CommandHandler: CreateRun
+    CommandHandler->>Repository: Save(run)
+    Repository->>EventStore: Append Events
+    Repository->>NATS: Publish via Outbox
+    API-->>Client: 201 Created
+    GraphEngine->>EventStore: Execute Graph
+    GraphEngine-->>NATS: Emit Events
+    NATS-->>Client: SSE Stream
 ```
 
 ---

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -1,11 +1,9 @@
 ---
 title: Getting Started
-description: Getting Started
+description: Set up DuraGraph and run your first workflow
 ---
 
-# Getting Started
-
-Welcome to the project! This guide will walk you through the basics of setting up your environment, running your first workflow, and exploring the system architecture.
+Welcome to DuraGraph! This guide will walk you through setting up your environment, running your first workflow, and exploring the system architecture.
 
 ---
 
@@ -13,34 +11,46 @@ Welcome to the project! This guide will walk you through the basics of setting u
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/your-org/your-repo.git
-   cd your-repo
+   git clone https://github.com/Duragraph/duragraph.git
+   cd duragraph
    ```
 
-2. Set up your Python environment:
+2. Start all services with Task:
    ```bash
-   python -m venv venv
-   source venv/bin/activate
-   pip install -r requirements.txt
+   task up
    ```
 
-3. (Optional) Build and run with Docker:
+   This starts PostgreSQL, NATS, the API server, and the dashboard.
+
+3. Verify services are running:
    ```bash
-   docker compose up --build
+   task health
    ```
 
 ---
 
 ## 2. Running a Hello World Workflow
 
-1. Start the services:
+1. Create an assistant:
    ```bash
-   ./init_structure.sh
+   curl -X POST http://localhost:8081/api/v1/assistants \
+     -H "Content-Type: application/json" \
+     -d '{"name": "hello-assistant", "graph_schema": {}}'
    ```
 
-2. Run the example workflow defined in [`schemas/ir/examples/hello.json`](../schemas/ir/examples/hello.json).
+2. Create a thread:
+   ```bash
+   curl -X POST http://localhost:8081/api/v1/threads \
+     -H "Content-Type: application/json" \
+     -d '{}'
+   ```
 
-3. Check logs/output to see the results.
+3. Create a run:
+   ```bash
+   curl -X POST http://localhost:8081/api/v1/runs \
+     -H "Content-Type: application/json" \
+     -d '{"thread_id": "<thread_id>", "assistant_id": "<assistant_id>", "input": {"message": "Hello!"}}'
+   ```
 
 ---
 
@@ -48,17 +58,15 @@ Welcome to the project! This guide will walk you through the basics of setting u
 
 To better understand the system, explore the architecture documentation:
 
-- [Overview](architecture/overview.md) – components, data flows, sequence diagrams
-- [API Shim](architecture/api-shim.md) – REST/SSE endpoints, idempotency, error model
-- [Temporal](architecture/temporal.md) – workflows, activities, signals/queries, retries, versioning
-- [Intermediate Representation (IR)](architecture/ir.md) – schema fields, examples, validation
-- [Workers](architecture/workers.md) – adapters, task queues, streaming, checkpointing
+- [Architecture Overview](architecture/overview) – components, data flows, sequence diagrams
+- [API Reference](api-reference/overview) – REST endpoints and schemas
+- [Quickstart Guide](user-guide/quickstart) – step-by-step tutorial
 
 ---
 
 ## 4. Contributing
 
-Please read the [Contributing Guide](../CONTRIBUTING.md), [Code of Conduct](../CODE_OF_CONDUCT.md), and [Security Policy](../SECURITY.md) before contributing.
+Please read the [Contributing Guide](project/contributing) before contributing.
 
 ---
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,9 +1,7 @@
 ---
 title: DuraGraph
-description: DuraGraph
+description: Open-source LangGraph Cloud-compatible API for reliable AI workflow orchestration
 ---
-
-# DuraGraph
 
 ## Mission
 
@@ -12,19 +10,20 @@ Our mission is to enable reliable, observable, and maintainable pipelines that f
 
 ## Compatibility with LangGraph Cloud
 
-DuraGraph implements an **API shim** compatible with **LangGraph Cloud**.
+DuraGraph implements an **API-compatible layer** with **LangGraph Cloud**.
 This means:
 - Tools, clients, and SDKs built for LangGraph Cloud can run against DuraGraph.
 - OpenAPI contracts are aligned for seamless integration.
 - Migration and hybrid deployments are supported.
 
-## Why Temporal?
+## Architecture
 
-We selected [Temporal](https://temporal.io/) for the control plane and core orchestration engine because:
-- It provides stateful, durable workflow management.
-- Built-in retries, error handling, and compensation logic.
-- Proven scalability for high throughput workloads.
-- Rich observability and workflow introspection.
+DuraGraph is built on proven technologies for reliability and performance:
+- **Event Sourcing** for complete audit trails and state reconstruction
+- **CQRS** (Command Query Responsibility Segregation) for scalable reads and writes
+- **PostgreSQL** for durable event storage and projections
+- **NATS JetStream** for reliable event streaming
+- **Custom Graph Engine** for workflow execution with support for conditionals, loops, and human-in-the-loop
 
 This ensures **fault tolerance** and **deterministic execution** for AI-driven processes.
 
@@ -38,7 +37,6 @@ This ensures **fault tolerance** and **deterministic execution** for AI-driven p
 ## Non-Goals
 
 - Providing a custom LLM runtime (we integrate with existing providers).
-- Replacing Temporal itself (we build on top of it).
 - Becoming a full-featured cloud platform (our scope is orchestration, not hosting).
 
 ## Success Metrics
@@ -54,14 +52,15 @@ We measure success by:
 ```mermaid
 flowchart LR
   client["Client SDKs / LangGraph Cloud clients"]
-  shim[API Shim]
-  translator[Translator / IR]
-  temporal[Temporal Control Plane]
-  workers[Worker Adapters]
-  storage[(Storage)]
-  observability[(Observability / Metrics / Tracing)]
+  api[API Layer]
+  commands[Commands / Queries]
+  engine[Graph Engine]
+  events[(Event Store)]
+  nats[NATS JetStream]
+  observability[(Metrics / Tracing)]
 
-  client --> shim --> translator --> temporal --> workers
-  workers --> storage
-  workers --> observability
+  client --> api --> commands --> engine
+  engine --> events
+  engine --> nats
+  nats --> observability
 ```

--- a/docs/content/docs/ops/observability.mdx
+++ b/docs/content/docs/ops/observability.mdx
@@ -1,9 +1,7 @@
 ---
 title: Observability
-description: Observability
+description: Monitoring and observability for DuraGraph
 ---
-
-# Observability
 
 This document describes how we configure OpenTelemetry (OTel) instrumentation, what we export, and how to investigate system behavior using metrics, traces, and logs.
 
@@ -11,11 +9,11 @@ This document describes how we configure OpenTelemetry (OTel) instrumentation, w
 
 ## OTel Setup
 
-The system uses OpenTelemetry SDKs in Go (API, bridge, workers) and Python (adapters). Configuration is driven by environment variables:
+The system uses OpenTelemetry SDKs in Go. Configuration is driven by environment variables:
 
 - `OTEL_EXPORTER_OTLP_ENDPOINT` – OTLP collector endpoint.
 - `OTEL_EXPORTER_OTLP_HEADERS` – additional headers for exports.
-- `OTEL_SERVICE_NAME` – service identifier ("duragraph-api", "duragraph-bridge", "duragraph-pyworker", etc.).
+- `OTEL_SERVICE_NAME` – service identifier ("duragraph-api", "duragraph-server", etc.).
 - `OTEL_LOG_LEVEL` – log verbosity for OTel instrumentation.
 - `OTEL_RESOURCE_ATTRIBUTES` – additional dimensions (deployment, project, region).
 
@@ -24,8 +22,8 @@ The system uses OpenTelemetry SDKs in Go (API, bridge, workers) and Python (adap
 ## Telemetry Data
 
 ### Traces
-- **Run lifecycle** (`/runs` endpoints → Translator → Bridge → Temporal client).
-- **Activities** (e.g. `llm_call`, `tool`).
+- **Run lifecycle** (`/runs` endpoints → Command Handler → Graph Engine).
+- **Node execution** (e.g. `llm`, `tool`, `condition`).
 - **SSE streaming** events correlation.
 - Search attributes (e.g. `run_id`, `thread_id`, `assistant_id`) are added as trace attributes.
 

--- a/docs/content/docs/ops/runbooks.mdx
+++ b/docs/content/docs/ops/runbooks.mdx
@@ -1,9 +1,7 @@
 ---
 title: Runbooks
-description: Runbooks
+description: Operational procedures for DuraGraph deployments
 ---
-
-# Runbooks
 
 This document provides runbooks for common operational procedures including releases, incidents, backups, and upgrades.
 
@@ -36,39 +34,38 @@ We follow a structured release train approach:
 ### SSE Stream Stuck
 - Check API logs for errors around `/stream`.
 - Restart affected API pods.
-- Validate Temporal queue health.
+- Validate NATS connection health.
 
-### Worker Crash
-- Inspect worker pod/container logs.
+### API Server Crash
+- Inspect server pod/container logs.
 - Restart pod in Kubernetes.
-- Verify reconnection to Temporal task queue.
+- Verify database connectivity.
 
-### Queue Backlog
-- Monitor Temporal task queue metrics.
-- Scale worker deployments (HPA or manual).
-- Prioritize critical task queues during incident.
+### Event Queue Backlog
+- Monitor NATS JetStream metrics.
+- Check outbox relay worker logs.
+- Scale API server instances if needed.
 
 ---
 
 ## Backups & Restores
 
-### Postgres
+### PostgreSQL
 - Backups: cron `pg_dump` to S3.
 - Restore: `psql < dump.sql` into new instance.
 
-### MinIO (S3)
-- Backups: versioned buckets enabled.
-- Restore: use `mc` (MinIO client) to copy objects back by version.
+### Event Store
+- Event store is append-only, backup with regular pg_dump.
+- Point-in-time recovery via PostgreSQL WAL archiving.
 
 ---
 
-## Temporal Upgrade / Versioning Checklist
+## Upgrade Checklist
 
-- Upgrade Temporal cluster version-by-version (no skips).
-- Validate worker **build-id** versioning to allow rolling upgrades:
-  - Always register new build-id.
-  - Maintain backwards-compatible workflows.
-- Run canaries to validate new version.
-- Update CLI tools and SDKs in sync with Temporal release.
+- Run database migrations before deploying new code.
+- Test migrations on staging environment first.
+- Validate API compatibility with existing clients.
+- Monitor error rates after deployment.
+- Keep rollback plan ready.
 
 ---

--- a/docs/content/docs/ops/security.mdx
+++ b/docs/content/docs/ops/security.mdx
@@ -1,11 +1,9 @@
 ---
 title: Security
-description: Security
+description: Security model and best practices for DuraGraph
 ---
 
-# Security
-
-This document outlines the security model, mitigations, and known risks in the Duragraph system.
+This document outlines the security model, mitigations, and known risks in the DuraGraph system.
 
 ---
 
@@ -24,8 +22,8 @@ This document outlines the security model, mitigations, and known risks in the D
 
 ## Isolation
 
-- **Namespaces**: Temporal namespaces used for environment isolation (e.g. `duragraph-dev`, `duragraph-prod`).
-- **Task Queues**: Separate queues for Go/Python workers prevent cross-language interference.
+- **Database**: PostgreSQL schema-level isolation for multi-tenant deployments.
+- **NATS**: Separate subjects for different environments (e.g. `duragraph.dev`, `duragraph.prod`).
 
 ---
 

--- a/docs/content/docs/ops/slos.mdx
+++ b/docs/content/docs/ops/slos.mdx
@@ -1,9 +1,7 @@
 ---
 title: Service Level Objectives (SLOs)
-description: Service Level Objectives (SLOs)
+description: SLOs and performance targets for DuraGraph
 ---
-
-# Service Level Objectives (SLOs)
 
 This document outlines our defined SLOs, alerting thresholds, and how we validate system performance under load.
 
@@ -48,7 +46,7 @@ We use load tests (e.g. Locust, k6) to validate SLOs at scale:
 When the system is overloaded:
 - **API** returns `429 Too Many Requests` with `Retry-After` header.
 - Clients must back off and retry after suggested interval.
-- This ensures Temporal queues and worker pools are not overwhelmed.
+- This ensures event queues and API servers are not overwhelmed.
 
 ---
 

--- a/docs/content/docs/project/adrs.mdx
+++ b/docs/content/docs/project/adrs.mdx
@@ -1,33 +1,32 @@
 ---
 title: Architecture Decision Records (ADRs)
-description: Architecture Decision Records (ADRs)
+description: Record of significant technical decisions in DuraGraph
 ---
 
-# Architecture Decision Records (ADRs)
-
-This file indexes all ADRs (Architecture Decision Records) for the Duragraph project.
+This file indexes all ADRs (Architecture Decision Records) for the DuraGraph project.
 ADRs record significant technical and architectural decisions, their context, and consequences.
 
 ---
 
 ## ADR Index
 
-- [0001: Use Temporal Search Attributes for Run Indexing](../adr/0001-use-temporal-search-attributes.md)
-- [0001-template](../adr/0001-template.md) (template for new ADRs)
+- [0001: Use Event Sourcing for Run State](../adr/0001-event-sourcing.md)
+- [0002: Use CQRS Pattern](../adr/0002-cqrs-pattern.md)
+- [0003: Use Outbox Pattern for Reliable Events](../adr/0003-outbox-pattern.md)
 
 ---
 
 ## Process
 
 1. When making an architecture decision, add a new ADR in `docs/adr/`.
-2. Copy from [0001-template](../adr/0001-template.md).
+2. Use the template format with context, decision, and consequences.
 3. Update this index to link the new ADR.
 
 ---
 
 ## References
 
-- [RFC Process](rfcs.md)
-- [Contributing Guide](contributing.md)
+- [RFC Process](rfcs)
+- [Contributing Guide](contributing)
 
 ---

--- a/docs/content/docs/project/contributing.mdx
+++ b/docs/content/docs/project/contributing.mdx
@@ -1,11 +1,9 @@
 ---
 title: Contributing Guide
-description: Contributing Guide
+description: How to contribute to DuraGraph
 ---
 
-# Contributing Guide
-
-This document describes how to contribute to the Duragraph project. Please also review the [Code of Conduct](../../CODE_OF_CONDUCT.md) and [Security Policy](../../SECURITY.md).
+This document describes how to contribute to the DuraGraph project.
 
 ---
 
@@ -13,31 +11,31 @@ This document describes how to contribute to the Duragraph project. Please also 
 
 1. Clone the repo:
    ```bash
-   git clone https://github.com/your-org/duragraph.git
+   git clone https://github.com/Duragraph/duragraph.git
    cd duragraph
    ```
 
 2. Install dependencies:
    - **Go**: `go mod tidy`
-   - **Python**: `poetry install` (see `workers/python-adapter`)
-   - **Node/TypeScript** (if applicable): `npm install`
+   - **Task**: Install [Task](https://taskfile.dev) runner
 
 3. Run services locally:
    ```bash
-   make up
+   task up
    ```
 
 ---
 
-## Make Targets
+## Task Commands
 
-Common `make` targets are provided:
+Common `task` commands are provided:
 
-- `make build` – build Go binaries and containers
-- `make test` – run all tests (Go, Python, etc.)
-- `make lint` – run linting for all languages
-- `make up` – start local environment via Docker Compose
-- `make down` – stop local environment
+- `task build:server` – build Go server binary
+- `task test` – run all tests
+- `task lint:go` – run linting
+- `task up` – start local environment via Docker Compose
+- `task down` – stop local environment
+- `task health` – check health of all services
 
 ---
 
@@ -72,17 +70,16 @@ Consistency is enforced with pre-commit hooks.
 
 - All new features must include corresponding unit tests.
 - Conformance tests must pass before merging.
-- Integration tests validate API ↔ Temporal ↔ Workers.
+- Integration tests validate API ↔ Database ↔ Event streaming.
 
 Run full Go tests:
 ```bash
-go test ./...
+task test
 ```
 
-Python adapter tests:
+Run unit tests only:
 ```bash
-cd workers/python-adapter
-poetry run pytest
+task test:unit
 ```
 
 ---

--- a/docs/content/docs/project/rfcs.mdx
+++ b/docs/content/docs/project/rfcs.mdx
@@ -1,11 +1,9 @@
 ---
 title: Request for Comments (RFC) Process
-description: Request for Comments (RFC) Process
+description: How to propose significant changes to DuraGraph
 ---
 
-# Request for Comments (RFC) Process
-
-RFCs are used for proposing and discussing significant changes to Duragraph.
+RFCs are used for proposing and discussing significant changes to DuraGraph.
 They provide a structured way to capture design decisions, alternatives, and risks.
 
 ---
@@ -13,10 +11,10 @@ They provide a structured way to capture design decisions, alternatives, and ris
 ## When to Write an RFC
 
 You should write an RFC when proposing:
-- Changes to the **IR schema**.
+- Changes to the **domain model** or event schemas.
 - Additions or modifications to **API endpoints**.
-- Major system architecture changes (e.g., worker protocols, data retention).
-- New integrations with external systems (Temporal, storage, model APIs).
+- Major system architecture changes (e.g., graph engine, event streaming).
+- New integrations with external systems (LLM providers, storage, model APIs).
 
 ---
 

--- a/docs/content/docs/user-guide/installation/cloud.mdx
+++ b/docs/content/docs/user-guide/installation/cloud.mdx
@@ -17,7 +17,7 @@ description: Duragraph Cloud
 ## Why Duragraph Cloud?
 
 ### 🚀 **Zero Infrastructure Management**
-- Fully managed Temporal clusters
+- Fully managed orchestration
 - Auto-scaling workers and API servers
 - Managed PostgreSQL with automated backups
 - 99.9% uptime SLA
@@ -114,10 +114,10 @@ print(f"Run started: {run.id}")
 - Automatic scaling based on queue depth
 - Resource optimization and cost control
 
-**Managed Temporal**
-- High-availability Temporal clusters
+**Managed Event Store**
+- High-availability event storage
 - Automatic upgrades and maintenance
-- Custom namespace isolation
+- Tenant isolation
 
 **Database Management**
 - Managed PostgreSQL with automated backups
@@ -270,7 +270,7 @@ else:
 - [Security Best Practices](https://docs.duragraph.ai/cloud/security)
 
 ### **Support Channels**
-- **Community**: [GitHub Discussions](https://github.com/adwiteeymauriya/duragraph/discussions)
+- **Community**: [GitHub Discussions](https://github.com/Duragraph/duragraph/discussions)
 - **Email**: support@duragraph.ai
 - **Enterprise**: 24/7 support with SLA guarantees
 
@@ -317,4 +317,4 @@ Monitor Duragraph Cloud status: [https://status.duragraph.ai](https://status.dur
 🔗 [Join the waitlist](https://duragraph.ai/cloud/waitlist)
 📚 [Compare with self-hosted](self-hosted.md)
 🛠️ [Start with local development](../quickstart.md)
-💬 [Join our community](https://github.com/adwiteeymauriya/duragraph/discussions)
+💬 [Join our community](https://github.com/Duragraph/duragraph/discussions)

--- a/docs/content/docs/user-guide/installation/requirements.mdx
+++ b/docs/content/docs/user-guide/installation/requirements.mdx
@@ -1,9 +1,7 @@
 ---
 title: System Requirements
-description: System Requirements
+description: Hardware and software requirements for running DuraGraph
 ---
-
-# System Requirements
 
 ## Minimum Requirements
 
@@ -24,20 +22,21 @@ description: System Requirements
 ### Required
 - Docker 20.10+
 - Docker Compose 2.0+
-- PostgreSQL 13+ (if using external database)
+- Go 1.23+ (for development)
+- Task (task runner)
 
 ### Optional
 - Kubernetes 1.20+ (for K8s deployments)
 - Helm 3.8+ (for Helm chart deployments)
-- Redis 6.0+ (for caching and job queues)
+- Redis 6.0+ (for caching)
 
 ## Network Requirements
 
 ### Ports
-- `8080` - API Server
-- `7233` - Temporal Server
+- `8081` - API Server
 - `5432` - PostgreSQL
-- `3000` - Dashboard (optional)
+- `4222` - NATS
+- `3000` - Dashboard
 
 ### Firewall
 - Allow inbound traffic on required ports
@@ -46,4 +45,4 @@ description: System Requirements
 
 ---
 
-📚 **Next**: [Self-Hosted Installation](self-hosted.md) | [Cloud Installation](cloud.md)
+📚 **Next**: [Self-Hosted Installation](self-hosted) | [Cloud Installation](cloud)

--- a/docs/content/docs/user-guide/quickstart.mdx
+++ b/docs/content/docs/user-guide/quickstart.mdx
@@ -1,11 +1,9 @@
 ---
 title: Quickstart Guide
-description: Quickstart Guide
+description: Get up and running with DuraGraph in under 5 minutes
 ---
 
-# Quickstart Guide
-
-Get up and running with Duragraph in under 5 minutes! This guide will help you run your first AI workflow.
+Get up and running with DuraGraph in under 5 minutes! This guide will help you run your first AI workflow.
 
 ## Prerequisites
 
@@ -13,21 +11,21 @@ Get up and running with Duragraph in under 5 minutes! This guide will help you r
 - Python 3.8+ (for SDK usage)
 - Git
 
-## 1. Start Duragraph Locally
+## 1. Start DuraGraph Locally
 
-Clone and start the Duragraph services:
+Clone and start the DuraGraph services:
 
 ```bash
-git clone https://github.com/adwiteeymauriya/duragraph.git
+git clone https://github.com/Duragraph/duragraph.git
 cd duragraph
-docker compose up -d
+task up
 ```
 
 This starts:
-- **API Server** (port 8080) - REST API and SSE streaming
-- **Temporal Server** - Workflow orchestration engine
-- **PostgreSQL** - State and checkpoint storage
-- **Workers** - Python/Go execution environments
+- **API Server** (port 8081) - REST API and SSE streaming
+- **PostgreSQL** - Event store and projections
+- **NATS JetStream** - Event streaming
+- **Dashboard** (port 3000) - Workflow monitoring UI
 
 ## 2. Install the Python SDK
 
@@ -118,4 +116,4 @@ curl -X POST http://localhost:8080/runs \
   -d '{"assistant_id": "test", "thread_id": "test"}'
 ```
 
-Need help? [Join our community](https://github.com/adwiteeymauriya/duragraph/discussions) or [report an issue](https://github.com/adwiteeymauriya/duragraph/issues).
+Need help? [Join our community](https://github.com/Duragraph/duragraph/discussions) or [report an issue](https://github.com/Duragraph/duragraph/issues).

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -3,7 +3,14 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: 'My App',
+      title: 'DuraGraph',
     },
+    links: [
+      {
+        text: 'Documentation',
+        url: '/docs',
+        active: 'nested-url',
+      },
+    ],
   };
 }


### PR DESCRIPTION
## Summary
- Fix 'My App' title to 'DuraGraph' in navigation
- Fix home page redundancy (removed duplicate heading)
- Remove all Temporal references across 15 documentation files
- Update architecture documentation to reflect current stack:
  - Event Sourcing + CQRS patterns
  - PostgreSQL event store
  - NATS JetStream for events
  - Custom graph engine
- Update quickstart and getting-started guides with correct commands
- Update ops documentation (runbooks, security, observability, SLOs)
- Update project documentation (ADRs, RFCs, contributing)
- Fix GitHub URLs to point to Duragraph organization
- Update port numbers and service descriptions

## Files Changed (15)
- `docs/lib/layout.shared.tsx` - Fix nav title
- `docs/content/docs/index.mdx` - Fix home page
- `docs/content/docs/architecture/overview.mdx` - Update architecture
- `docs/content/docs/getting-started.mdx` - Update setup guide
- `docs/content/docs/user-guide/quickstart.mdx` - Update quickstart
- `docs/content/docs/user-guide/installation/requirements.mdx` - Update ports
- `docs/content/docs/user-guide/installation/cloud.mdx` - Remove Temporal refs
- `docs/content/docs/ops/runbooks.mdx` - Update runbooks
- `docs/content/docs/ops/security.mdx` - Update isolation docs
- `docs/content/docs/ops/observability.mdx` - Update telemetry docs
- `docs/content/docs/ops/slos.mdx` - Update SLOs
- `docs/content/docs/project/adrs.mdx` - Update ADR index
- `docs/content/docs/project/rfcs.mdx` - Update RFC process
- `docs/content/docs/project/contributing.mdx` - Update contributing guide
- `docs/content/docs/README.mdx` - Update docs overview

## Test plan
- [x] Pre-commit hooks pass
- [ ] Build docs locally to verify rendering