### PR TITLE
feat(api): implement Phase 2 API endpoints for LangGraph parity

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -180,6 +180,10 @@ func main() {
 	getAssistantVersionsHandler := query.NewGetAssistantVersionsHandler(assistantRepo)
 	getAssistantSchemaHandler := query.NewGetAssistantSchemaHandler(assistantRepo, graphRepo)
 
+	// Initialize graph query handlers
+	getAssistantGraphHandler := query.NewGetAssistantGraphHandler(assistantRepo, graphRepo)
+	getSubgraphsHandler := query.NewGetSubgraphsHandler(assistantRepo, graphRepo)
+
 	// Initialize application services
 	runService := service.NewRunService(
 		runRepo,
@@ -212,6 +216,8 @@ func main() {
 		countAssistantsHandler,
 		getAssistantVersionsHandler,
 		getAssistantSchemaHandler,
+		getAssistantGraphHandler,
+		getSubgraphsHandler,
 	)
 	threadHandler := handlers.NewThreadHandler(
 		createThreadHandler,
@@ -292,7 +298,11 @@ func main() {
 	// Stream routes (LangGraph compatible)
 	api.POST("/threads/:thread_id/runs/stream", runHandler.CreateRunWithStream)
 	api.GET("/threads/:thread_id/runs/:run_id/stream", streamHandler.StreamRun)
+	api.GET("/threads/:thread_id/stream", streamHandler.JoinThreadStream)
 	api.GET("/stream", streamHandler.Stream) // Legacy SSE endpoint
+
+	// Thread run wait route (LangGraph compatible)
+	api.POST("/threads/:thread_id/runs/wait", runHandler.CreateThreadRunAndWait)
 
 	// Human-in-the-loop (state update)
 	api.POST("/threads/:thread_id/state", runHandler.UpdateState)
@@ -311,6 +321,11 @@ func main() {
 	api.GET("/assistants/:assistant_id/versions", assistantHandler.GetVersions)
 	api.POST("/assistants/:assistant_id/latest", assistantHandler.SetLatestVersion)
 	api.GET("/assistants/:assistant_id/schemas", assistantHandler.GetSchemas)
+
+	// Assistant graph routes (LangGraph compatible)
+	api.GET("/assistants/:assistant_id/graph", assistantHandler.GetGraph)
+	api.GET("/assistants/:assistant_id/subgraphs", assistantHandler.GetSubgraphs)
+	api.GET("/assistants/:assistant_id/subgraphs/:namespace", assistantHandler.GetSubgraph)
 
 	// Thread routes
 	api.POST("/threads", threadHandler.Create)

--- a/internal/application/query/get_assistant_graph.go
+++ b/internal/application/query/get_assistant_graph.go
@@ -1,0 +1,64 @@
+package query
+
+import (
+	"context"
+
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// GetAssistantGraphHandler handles the get assistant graph query
+type GetAssistantGraphHandler struct {
+	assistantRepo workflow.AssistantRepository
+	graphRepo     workflow.GraphRepository
+}
+
+// NewGetAssistantGraphHandler creates a new get assistant graph handler
+func NewGetAssistantGraphHandler(
+	assistantRepo workflow.AssistantRepository,
+	graphRepo workflow.GraphRepository,
+) *GetAssistantGraphHandler {
+	return &GetAssistantGraphHandler{
+		assistantRepo: assistantRepo,
+		graphRepo:     graphRepo,
+	}
+}
+
+// GraphResult represents the result of a graph query
+type GraphResult struct {
+	Nodes  []workflow.Node
+	Edges  []workflow.Edge
+	Config map[string]interface{}
+}
+
+// Handle executes the get assistant graph query
+func (h *GetAssistantGraphHandler) Handle(ctx context.Context, assistantID string) (*GraphResult, error) {
+	// Verify assistant exists
+	_, err := h.assistantRepo.FindByID(ctx, assistantID)
+	if err != nil {
+		return nil, errors.NotFound("assistant", assistantID)
+	}
+
+	// Get graphs for this assistant
+	graphs, err := h.graphRepo.FindByAssistantID(ctx, assistantID)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no graphs exist, return empty graph structure
+	if len(graphs) == 0 {
+		return &GraphResult{
+			Nodes:  []workflow.Node{},
+			Edges:  []workflow.Edge{},
+			Config: map[string]interface{}{},
+		}, nil
+	}
+
+	// Return the latest graph (first one, ordered by created_at DESC)
+	graph := graphs[0]
+	return &GraphResult{
+		Nodes:  graph.Nodes(),
+		Edges:  graph.Edges(),
+		Config: graph.Config(),
+	}, nil
+}

--- a/internal/application/query/get_subgraphs.go
+++ b/internal/application/query/get_subgraphs.go
@@ -1,0 +1,150 @@
+package query
+
+import (
+	"context"
+
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// GetSubgraphsHandler handles the get subgraphs query
+type GetSubgraphsHandler struct {
+	assistantRepo workflow.AssistantRepository
+	graphRepo     workflow.GraphRepository
+}
+
+// NewGetSubgraphsHandler creates a new get subgraphs handler
+func NewGetSubgraphsHandler(
+	assistantRepo workflow.AssistantRepository,
+	graphRepo workflow.GraphRepository,
+) *GetSubgraphsHandler {
+	return &GetSubgraphsHandler{
+		assistantRepo: assistantRepo,
+		graphRepo:     graphRepo,
+	}
+}
+
+// SubgraphInfo represents information about a subgraph
+type SubgraphInfo struct {
+	Namespace string `json:"namespace"`
+	GraphID   string `json:"graph_id"`
+}
+
+// Handle executes the get subgraphs query
+func (h *GetSubgraphsHandler) Handle(ctx context.Context, assistantID string) ([]SubgraphInfo, error) {
+	// Verify assistant exists
+	_, err := h.assistantRepo.FindByID(ctx, assistantID)
+	if err != nil {
+		return nil, errors.NotFound("assistant", assistantID)
+	}
+
+	// Get graphs for this assistant
+	graphs, err := h.graphRepo.FindByAssistantID(ctx, assistantID)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no graphs exist, return empty list
+	if len(graphs) == 0 {
+		return []SubgraphInfo{}, nil
+	}
+
+	// Find subgraph nodes in the latest graph
+	graph := graphs[0]
+	subgraphs := []SubgraphInfo{}
+
+	for _, node := range graph.Nodes() {
+		if node.Type == workflow.NodeTypeSubgraph {
+			// Extract namespace and graph_id from config
+			namespace := node.ID
+			graphID := ""
+
+			if ns, ok := node.Config["namespace"].(string); ok {
+				namespace = ns
+			}
+			if gid, ok := node.Config["graph_id"].(string); ok {
+				graphID = gid
+			}
+
+			subgraphs = append(subgraphs, SubgraphInfo{
+				Namespace: namespace,
+				GraphID:   graphID,
+			})
+		}
+	}
+
+	return subgraphs, nil
+}
+
+// HandleByNamespace retrieves a specific subgraph by namespace
+func (h *GetSubgraphsHandler) HandleByNamespace(ctx context.Context, assistantID, namespace string) (*GraphResult, error) {
+	// Verify assistant exists
+	_, err := h.assistantRepo.FindByID(ctx, assistantID)
+	if err != nil {
+		return nil, errors.NotFound("assistant", assistantID)
+	}
+
+	// Get graphs for this assistant
+	graphs, err := h.graphRepo.FindByAssistantID(ctx, assistantID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(graphs) == 0 {
+		return nil, errors.NotFound("subgraph", namespace)
+	}
+
+	// Find the subgraph node with matching namespace
+	graph := graphs[0]
+	for _, node := range graph.Nodes() {
+		if node.Type == workflow.NodeTypeSubgraph {
+			nodeNamespace := node.ID
+			if ns, ok := node.Config["namespace"].(string); ok {
+				nodeNamespace = ns
+			}
+
+			if nodeNamespace == namespace {
+				// Extract the subgraph definition from config
+				subNodes := []workflow.Node{}
+				subEdges := []workflow.Edge{}
+				subConfig := map[string]interface{}{}
+
+				if nodes, ok := node.Config["nodes"].([]interface{}); ok {
+					for _, n := range nodes {
+						if nodeMap, ok := n.(map[string]interface{}); ok {
+							subNodes = append(subNodes, workflow.Node{
+								ID:     nodeMap["id"].(string),
+								Type:   workflow.NodeType(nodeMap["type"].(string)),
+								Config: nodeMap,
+							})
+						}
+					}
+				}
+
+				if edges, ok := node.Config["edges"].([]interface{}); ok {
+					for _, e := range edges {
+						if edgeMap, ok := e.(map[string]interface{}); ok {
+							subEdges = append(subEdges, workflow.Edge{
+								ID:     edgeMap["id"].(string),
+								Source: edgeMap["source"].(string),
+								Target: edgeMap["target"].(string),
+							})
+						}
+					}
+				}
+
+				if cfg, ok := node.Config["config"].(map[string]interface{}); ok {
+					subConfig = cfg
+				}
+
+				return &GraphResult{
+					Nodes:  subNodes,
+					Edges:  subEdges,
+					Config: subConfig,
+				}, nil
+			}
+		}
+	}
+
+	return nil, errors.NotFound("subgraph", namespace)
+}

--- a/internal/infrastructure/http/dto/langgraph.go
+++ b/internal/infrastructure/http/dto/langgraph.go
@@ -327,3 +327,32 @@ type InterruptResponse struct {
 	State         map[string]interface{}   `json:"state,omitempty"`
 	ToolCalls     []map[string]interface{} `json:"tool_calls,omitempty"`
 }
+
+// GraphNodeResponse represents a node in a graph
+type GraphNodeResponse struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Config   map[string]interface{} `json:"data,omitempty"`
+	Position map[string]float64     `json:"metadata,omitempty"`
+}
+
+// GraphEdgeResponse represents an edge in a graph
+type GraphEdgeResponse struct {
+	ID        string                 `json:"id,omitempty"`
+	Source    string                 `json:"source"`
+	Target    string                 `json:"target"`
+	Condition map[string]interface{} `json:"data,omitempty"`
+}
+
+// GraphResponse represents the graph structure for an assistant
+type GraphResponse struct {
+	Nodes  []GraphNodeResponse    `json:"nodes"`
+	Edges  []GraphEdgeResponse    `json:"edges"`
+	Config map[string]interface{} `json:"config,omitempty"`
+}
+
+// SubgraphInfoResponse represents information about a subgraph
+type SubgraphInfoResponse struct {
+	Namespace string `json:"namespace"`
+	GraphID   string `json:"graph_id,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Implement GET /assistants/{id}/graph endpoint - returns graph structure with nodes and edges
- Implement GET /assistants/{id}/subgraphs - lists all subgraph namespaces
- Implement GET /assistants/{id}/subgraphs/{namespace} - returns specific subgraph structure
- Implement GET /threads/{id}/stream - joins thread stream for real-time events
- Implement POST /threads/{id}/runs/wait - creates run and blocks until completion

## Test plan
- [x] Build passes with `go build ./...`
- [x] Unit tests pass with `go test -short ./...`
- [ ] Manual testing of new endpoints
- [ ] Integration tests with conformance suite

Closes #62, #63, #64, #65