### PR TITLE
docs: remove duplicate title in cloud.mdx

### DIFF
--- a/docs/src/content/docs/docs/user-guide/installation/cloud.mdx
+++ b/docs/src/content/docs/docs/user-guide/installation/cloud.mdx
@@ -3,8 +3,6 @@ title: Cloud Deployment
 description: Deploy DuraGraph on any cloud provider
 ---
 
-# Cloud Deployment
-
 Deploy DuraGraph on any cloud provider with full control over your infrastructure. DuraGraph is designed to be cloud-agnostic and runs anywhere you can deploy containers.
 
 ## Deployment Options


### PR DESCRIPTION
## Summary

- Remove duplicate H1 heading in cloud.mdx (Starlight renders frontmatter title automatically)

## Test plan

- [ ] Verify https://duragraph.ai/docs/user-guide/installation/cloud/ shows single title