### PR TITLE
feat: add Store API for namespaced key-value storage

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -312,6 +312,9 @@ func main() {
 
 	fmt.Println("✅ Run service configured with worker dispatch + NATS events")
 
+	// Initialize store repository
+	storeRepo := postgres.NewStoreRepositoryWithPools(pools.Write, pools.Read)
+
 	// Initialize HTTP handlers
 	runHandler := handlers.NewRunHandler(
 		createRunHandler,
@@ -507,6 +510,14 @@ func main() {
 	api.GET("/threads/:thread_id/history", threadStateHandler.GetHistory)
 	api.POST("/threads/:thread_id/history", threadStateHandler.PostHistory)
 	api.POST("/threads/:thread_id/copy", threadStateHandler.CopyThread)
+
+	// Store routes (LangGraph compatible)
+	storeHandler := handlers.NewStoreHandler(storeRepo)
+	api.PUT("/store/items", storeHandler.PutItem)
+	api.GET("/store/items", storeHandler.GetItem)
+	api.DELETE("/store/items", storeHandler.DeleteItem)
+	api.POST("/store/items/search", storeHandler.SearchItems)
+	api.POST("/store/namespaces", storeHandler.ListNamespaces)
 
 	// Worker protocol routes
 	api.POST("/workers/register", workerHandler.Register)

--- a/deploy/sql/011_store.sql
+++ b/deploy/sql/011_store.sql
@@ -1,0 +1,28 @@
+-- 011_store.sql: Key-value store for LangGraph Store API compatibility
+-- Provides namespaced key-value storage with JSONB values, TTL support, and search capabilities.
+
+CREATE TABLE IF NOT EXISTS store_items (
+    namespace TEXT[] NOT NULL,
+    key       TEXT   NOT NULL,
+    value     JSONB  NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    PRIMARY KEY (namespace, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_store_items_namespace_prefix
+    ON store_items USING GIN (namespace);
+
+CREATE INDEX IF NOT EXISTS idx_store_items_value
+    ON store_items USING GIN (value jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_store_items_expires_at
+    ON store_items (expires_at)
+    WHERE expires_at IS NOT NULL;
+
+COMMENT ON TABLE store_items IS 'LangGraph-compatible namespaced key-value store';
+COMMENT ON COLUMN store_items.namespace IS 'Hierarchical namespace as text array (e.g. {documents,user123})';
+COMMENT ON COLUMN store_items.key IS 'Item key within namespace';
+COMMENT ON COLUMN store_items.value IS 'Item value as JSONB';
+COMMENT ON COLUMN store_items.expires_at IS 'Optional TTL expiration timestamp';

--- a/internal/infrastructure/http/dto/store.go
+++ b/internal/infrastructure/http/dto/store.go
@@ -1,0 +1,57 @@
+package dto
+
+import "time"
+
+// PutStoreItemRequest represents the request to store an item.
+type PutStoreItemRequest struct {
+	Namespace []string               `json:"namespace"`
+	Key       string                 `json:"key"`
+	Value     map[string]interface{} `json:"value"`
+	TTL       *int                   `json:"ttl,omitempty"`
+}
+
+// GetStoreItemRequest represents query params for retrieving an item.
+type GetStoreItemRequest struct {
+	Namespace  string `query:"namespace"`
+	Key        string `query:"key"`
+	RefreshTTL bool   `query:"refresh_ttl"`
+}
+
+// DeleteStoreItemRequest represents the request to delete an item.
+type DeleteStoreItemRequest struct {
+	Namespace []string `json:"namespace"`
+	Key       string   `json:"key"`
+}
+
+// SearchStoreItemsRequest represents the request to search items.
+type SearchStoreItemsRequest struct {
+	NamespacePrefix []string               `json:"namespace_prefix"`
+	Filter          map[string]interface{} `json:"filter,omitempty"`
+	Limit           int                    `json:"limit,omitempty"`
+	Offset          int                    `json:"offset,omitempty"`
+	Query           string                 `json:"query,omitempty"`
+	RefreshTTL      *bool                  `json:"refresh_ttl,omitempty"`
+}
+
+// ListNamespacesRequest represents the request to list namespaces.
+type ListNamespacesRequest struct {
+	Prefix   []string `json:"prefix,omitempty"`
+	Suffix   []string `json:"suffix,omitempty"`
+	MaxDepth *int     `json:"max_depth,omitempty"`
+	Limit    int      `json:"limit,omitempty"`
+	Offset   int      `json:"offset,omitempty"`
+}
+
+// StoreItemResponse represents a stored item in responses.
+type StoreItemResponse struct {
+	Namespace []string               `json:"namespace"`
+	Key       string                 `json:"key"`
+	Value     map[string]interface{} `json:"value"`
+	CreatedAt time.Time              `json:"created_at"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+// SearchStoreItemsResponse represents the response from searching items.
+type SearchStoreItemsResponse struct {
+	Items []StoreItemResponse `json:"items"`
+}

--- a/internal/infrastructure/http/handlers/store.go
+++ b/internal/infrastructure/http/handlers/store.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/duragraph/duragraph/internal/infrastructure/http/dto"
+	"github.com/duragraph/duragraph/internal/infrastructure/persistence/postgres"
+	"github.com/labstack/echo/v4"
+)
+
+// StoreHandler handles LangGraph-compatible Store API endpoints.
+type StoreHandler struct {
+	repo *postgres.StoreRepository
+}
+
+func NewStoreHandler(repo *postgres.StoreRepository) *StoreHandler {
+	return &StoreHandler{repo: repo}
+}
+
+// PutItem stores or updates a namespaced key-value item.
+// PUT /store/items
+func (h *StoreHandler) PutItem(c echo.Context) error {
+	var req dto.PutStoreItemRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: err.Error(),
+		})
+	}
+
+	if len(req.Namespace) == 0 {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: "namespace is required",
+		})
+	}
+	if req.Key == "" {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: "key is required",
+		})
+	}
+
+	ttl := 0
+	if req.TTL != nil {
+		ttl = *req.TTL
+	}
+
+	if err := h.repo.Put(c.Request().Context(), req.Namespace, req.Key, req.Value, ttl); err != nil {
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error:   "internal_error",
+			Message: err.Error(),
+		})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// GetItem retrieves a single item by namespace and key.
+// GET /store/items?namespace=a.b.c&key=mykey
+func (h *StoreHandler) GetItem(c echo.Context) error {
+	nsParam := c.QueryParam("namespace")
+	key := c.QueryParam("key")
+
+	if nsParam == "" {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: "namespace query parameter is required",
+		})
+	}
+	if key == "" {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: "key query parameter is required",
+		})
+	}
+
+	namespace := strings.Split(nsParam, ".")
+	refreshTTL := c.QueryParam("refresh_ttl") == "true"
+
+	item, err := h.repo.Get(c.Request().Context(), namespace, key, refreshTTL)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error:   "internal_error",
+			Message: err.Error(),
+		})
+	}
+
+	if item == nil {
+		return c.JSON(http.StatusNotFound, dto.ErrorResponse{
+			Error:   "not_found",
+			Message: "item not found",
+		})
+	}
+
+	return c.JSON(http.StatusOK, dto.StoreItemResponse{
+		Namespace: item.Namespace,
+		Key:       item.Key,
+		Value:     item.Value,
+		CreatedAt: item.CreatedAt,
+		UpdatedAt: item.UpdatedAt,
+	})
+}
+
+// DeleteItem removes an item by namespace and key.
+// DELETE /store/items
+func (h *StoreHandler) DeleteItem(c echo.Context) error {
+	var req dto.DeleteStoreItemRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: err.Error(),
+		})
+	}
+
+	if len(req.Namespace) == 0 {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: "namespace is required",
+		})
+	}
+	if req.Key == "" {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: "key is required",
+		})
+	}
+
+	if err := h.repo.Delete(c.Request().Context(), req.Namespace, req.Key); err != nil {
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error:   "internal_error",
+			Message: err.Error(),
+		})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// SearchItems searches for items within a namespace prefix.
+// POST /store/items/search
+func (h *StoreHandler) SearchItems(c echo.Context) error {
+	var req dto.SearchStoreItemsRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: err.Error(),
+		})
+	}
+
+	items, err := h.repo.Search(c.Request().Context(), req.NamespacePrefix, req.Filter, req.Limit, req.Offset)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error:   "internal_error",
+			Message: err.Error(),
+		})
+	}
+
+	resp := dto.SearchStoreItemsResponse{
+		Items: make([]dto.StoreItemResponse, 0, len(items)),
+	}
+	for _, item := range items {
+		resp.Items = append(resp.Items, dto.StoreItemResponse{
+			Namespace: item.Namespace,
+			Key:       item.Key,
+			Value:     item.Value,
+			CreatedAt: item.CreatedAt,
+			UpdatedAt: item.UpdatedAt,
+		})
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// ListNamespaces lists distinct namespaces with optional filtering.
+// POST /store/namespaces
+func (h *StoreHandler) ListNamespaces(c echo.Context) error {
+	var req dto.ListNamespacesRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error:   "invalid_request",
+			Message: err.Error(),
+		})
+	}
+
+	maxDepth := 0
+	if req.MaxDepth != nil {
+		maxDepth = *req.MaxDepth
+	}
+
+	namespaces, err := h.repo.ListNamespaces(c.Request().Context(), req.Prefix, req.Suffix, maxDepth, req.Limit, req.Offset)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error:   "internal_error",
+			Message: err.Error(),
+		})
+	}
+
+	if namespaces == nil {
+		namespaces = [][]string{}
+	}
+
+	return c.JSON(http.StatusOK, namespaces)
+}

--- a/internal/infrastructure/http/handlers/store_test.go
+++ b/internal/infrastructure/http/handlers/store_test.go
@@ -1,0 +1,180 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/infrastructure/http/dto"
+	"github.com/labstack/echo/v4"
+)
+
+func TestStoreHandler_PutItem_Validation(t *testing.T) {
+	e := echo.New()
+	h := NewStoreHandler(nil)
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "missing namespace",
+			body:       `{"key":"k","value":{}}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "namespace is required",
+		},
+		{
+			name:       "empty namespace",
+			body:       `{"namespace":[],"key":"k","value":{}}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "namespace is required",
+		},
+		{
+			name:       "missing key",
+			body:       `{"namespace":["a"],"value":{}}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "/store/items", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := h.PutItem(c)
+			if err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			var resp dto.ErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if resp.Message != tt.wantError {
+				t.Errorf("message = %q, want %q", resp.Message, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestStoreHandler_GetItem_Validation(t *testing.T) {
+	e := echo.New()
+	h := NewStoreHandler(nil)
+
+	tests := []struct {
+		name       string
+		namespace  string
+		key        string
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "missing namespace",
+			namespace:  "",
+			key:        "k",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "namespace query parameter is required",
+		},
+		{
+			name:       "missing key",
+			namespace:  "a.b",
+			key:        "",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "key query parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := "/store/items?"
+			if tt.namespace != "" {
+				target += "namespace=" + tt.namespace + "&"
+			}
+			if tt.key != "" {
+				target += "key=" + tt.key
+			}
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := h.GetItem(c)
+			if err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			var resp dto.ErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if resp.Message != tt.wantError {
+				t.Errorf("message = %q, want %q", resp.Message, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestStoreHandler_DeleteItem_Validation(t *testing.T) {
+	e := echo.New()
+	h := NewStoreHandler(nil)
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "missing namespace",
+			body:       `{"key":"k"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "namespace is required",
+		},
+		{
+			name:       "missing key",
+			body:       `{"namespace":["a"]}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodDelete, "/store/items", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := h.DeleteItem(c)
+			if err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			var resp dto.ErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if resp.Message != tt.wantError {
+				t.Errorf("message = %q, want %q", resp.Message, tt.wantError)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/persistence/postgres/store_repository.go
+++ b/internal/infrastructure/persistence/postgres/store_repository.go
@@ -1,0 +1,187 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// StoreItem represents a namespaced key-value item.
+type StoreItem struct {
+	Namespace []string
+	Key       string
+	Value     map[string]interface{}
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// StoreRepository provides CRUD operations for the namespaced key-value store.
+type StoreRepository struct {
+	writePool *pgxpool.Pool
+	readPool  *pgxpool.Pool
+}
+
+func NewStoreRepository(pool *pgxpool.Pool) *StoreRepository {
+	return &StoreRepository{writePool: pool, readPool: pool}
+}
+
+func NewStoreRepositoryWithPools(writePool, readPool *pgxpool.Pool) *StoreRepository {
+	return &StoreRepository{writePool: writePool, readPool: readPool}
+}
+
+// Put inserts or updates an item. ttlMinutes <= 0 means no expiration.
+func (r *StoreRepository) Put(ctx context.Context, namespace []string, key string, value map[string]interface{}, ttlMinutes int) error {
+	var expiresAt *time.Time
+	if ttlMinutes > 0 {
+		t := time.Now().Add(time.Duration(ttlMinutes) * time.Minute)
+		expiresAt = &t
+	}
+
+	query := `
+		INSERT INTO store_items (namespace, key, value, expires_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (namespace, key)
+		DO UPDATE SET value = $3, updated_at = NOW(), expires_at = $4`
+
+	_, err := r.writePool.Exec(ctx, query, namespace, key, value, expiresAt)
+	if err != nil {
+		return fmt.Errorf("failed to put store item: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves a single item by namespace and key. Returns nil if not found or expired.
+func (r *StoreRepository) Get(ctx context.Context, namespace []string, key string, refreshTTL bool) (*StoreItem, error) {
+	query := `
+		SELECT namespace, key, value, created_at, updated_at
+		FROM store_items
+		WHERE namespace = $1 AND key = $2
+		  AND (expires_at IS NULL OR expires_at > NOW())`
+
+	row := r.readPool.QueryRow(ctx, query, namespace, key)
+
+	var item StoreItem
+	err := row.Scan(&item.Namespace, &item.Key, &item.Value, &item.CreatedAt, &item.UpdatedAt)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get store item: %w", err)
+	}
+
+	if refreshTTL {
+		_, _ = r.writePool.Exec(ctx,
+			`UPDATE store_items SET expires_at = expires_at + (expires_at - updated_at), updated_at = NOW()
+			 WHERE namespace = $1 AND key = $2 AND expires_at IS NOT NULL`,
+			namespace, key)
+	}
+
+	return &item, nil
+}
+
+// Delete removes an item by namespace and key.
+func (r *StoreRepository) Delete(ctx context.Context, namespace []string, key string) error {
+	_, err := r.writePool.Exec(ctx,
+		`DELETE FROM store_items WHERE namespace = $1 AND key = $2`,
+		namespace, key)
+	if err != nil {
+		return fmt.Errorf("failed to delete store item: %w", err)
+	}
+	return nil
+}
+
+// Search finds items within a namespace prefix, with optional value filter, limit, and offset.
+func (r *StoreRepository) Search(ctx context.Context, namespacePrefix []string, filter map[string]interface{}, limit, offset int) ([]StoreItem, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	query := `
+		SELECT namespace, key, value, created_at, updated_at
+		FROM store_items
+		WHERE namespace[1:$1] = $2
+		  AND (expires_at IS NULL OR expires_at > NOW())`
+
+	args := []interface{}{len(namespacePrefix), namespacePrefix}
+	argIdx := 3
+
+	if len(filter) > 0 {
+		query += fmt.Sprintf(" AND value @> $%d", argIdx)
+		args = append(args, filter)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(" ORDER BY updated_at DESC LIMIT $%d OFFSET $%d", argIdx, argIdx+1)
+	args = append(args, limit, offset)
+
+	rows, err := r.readPool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search store items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []StoreItem
+	for rows.Next() {
+		var item StoreItem
+		if err := rows.Scan(&item.Namespace, &item.Key, &item.Value, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan store item: %w", err)
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+// ListNamespaces returns distinct namespaces matching optional prefix/suffix and depth constraints.
+func (r *StoreRepository) ListNamespaces(ctx context.Context, prefix, suffix []string, maxDepth, limit, offset int) ([][]string, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	query := `
+		SELECT DISTINCT namespace
+		FROM store_items
+		WHERE (expires_at IS NULL OR expires_at > NOW())`
+
+	args := []interface{}{}
+	argIdx := 1
+
+	if len(prefix) > 0 {
+		query += fmt.Sprintf(" AND namespace[1:$%d] = $%d", argIdx, argIdx+1)
+		args = append(args, len(prefix), prefix)
+		argIdx += 2
+	}
+
+	if len(suffix) > 0 {
+		query += fmt.Sprintf(" AND namespace[array_length(namespace,1)-$%d+1:] = $%d", argIdx, argIdx+1)
+		args = append(args, len(suffix), suffix)
+		argIdx += 2
+	}
+
+	if maxDepth > 0 {
+		query += fmt.Sprintf(" AND array_length(namespace, 1) <= $%d", argIdx)
+		args = append(args, maxDepth)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(" ORDER BY namespace LIMIT $%d OFFSET $%d", argIdx, argIdx+1)
+	args = append(args, limit, offset)
+
+	rows, err := r.readPool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
+	}
+	defer rows.Close()
+
+	var namespaces [][]string
+	for rows.Next() {
+		var ns []string
+		if err := rows.Scan(&ns); err != nil {
+			return nil, fmt.Errorf("failed to scan namespace: %w", err)
+		}
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces, nil
+}


### PR DESCRIPTION
## Summary

- Implements LangGraph-compatible Store API with 5 endpoints (PUT/GET/DELETE items, search items, list namespaces)
- Adds PostgreSQL migration with GIN indexes for namespace and JSONB value queries, TTL support
- Includes repository layer with read/write pool split and handler validation tests

## Test plan

- [x] Handler validation tests pass (7 test cases)
- [x] Full test suite passes (`go test ./... -short`)
- [x] `go vet` clean
- [ ] Integration test with live PostgreSQL (manual)

Closes #118