### PR TITLE
feat: add MCP integration (v1.0)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/duragraph/duragraph/internal/infrastructure/graph"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/handlers"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/middleware"
+	"github.com/duragraph/duragraph/internal/infrastructure/mcp"
 	"github.com/duragraph/duragraph/internal/infrastructure/messaging"
 	"github.com/duragraph/duragraph/internal/infrastructure/messaging/nats"
 	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
@@ -538,6 +539,23 @@ func main() {
 	api.DELETE("/store/items", storeHandler.DeleteItem)
 	api.POST("/store/items/search", storeHandler.SearchItems)
 	api.POST("/store/namespaces", storeHandler.ListNamespaces)
+
+	// MCP routes (Model Context Protocol - Streamable HTTP transport)
+	mcpServer := mcp.NewServer(
+		toolRegistry,
+		getAssistantHandler,
+		listAssistantsHandler,
+		getThreadHandler,
+		createRunHandler,
+		getRunHandler,
+		runService,
+	)
+	mcpHandler := handlers.NewMCPHandler(mcpServer)
+	e.POST("/mcp", mcpHandler.Post)
+	e.GET("/mcp", mcpHandler.Get)
+	e.DELETE("/mcp", mcpHandler.Delete)
+
+	fmt.Println("✅ MCP endpoint enabled at /mcp")
 
 	// Worker protocol routes
 	api.POST("/workers/register", workerHandler.Register)

--- a/internal/infrastructure/http/handlers/mcp.go
+++ b/internal/infrastructure/http/handlers/mcp.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/duragraph/duragraph/internal/infrastructure/mcp"
+	"github.com/labstack/echo/v4"
+)
+
+const mcpSessionHeader = "Mcp-Session-Id"
+
+type MCPHandler struct {
+	server *mcp.Server
+}
+
+func NewMCPHandler(server *mcp.Server) *MCPHandler {
+	return &MCPHandler{server: server}
+}
+
+// Post handles POST /mcp - main JSON-RPC endpoint
+func (h *MCPHandler) Post(c echo.Context) error {
+	contentType := c.Request().Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		return c.JSON(http.StatusUnsupportedMediaType, map[string]string{
+			"error": "Content-Type must be application/json",
+		})
+	}
+
+	var req mcp.Request
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		resp := mcp.Response{
+			JSONRPC: "2.0",
+			Error:   &mcp.RPCError{Code: -32700, Message: "parse error"},
+		}
+		return c.JSON(http.StatusOK, resp)
+	}
+
+	// Get or create session
+	sessionID := c.Request().Header.Get(mcpSessionHeader)
+	if sessionID == "" {
+		sessionID = h.server.CreateSession()
+	}
+
+	resp := h.server.HandleRequest(c.Request().Context(), sessionID, &req)
+
+	// Notifications return no response
+	if resp == nil {
+		c.Response().Header().Set(mcpSessionHeader, sessionID)
+		return c.NoContent(http.StatusAccepted)
+	}
+
+	c.Response().Header().Set(mcpSessionHeader, sessionID)
+	return c.JSON(http.StatusOK, resp)
+}
+
+// Get handles GET /mcp - not supported for Streamable HTTP
+func (h *MCPHandler) Get(c echo.Context) error {
+	return c.JSON(http.StatusMethodNotAllowed, map[string]string{
+		"error": "GET not supported; use POST for JSON-RPC requests",
+	})
+}
+
+// Delete handles DELETE /mcp - terminate session
+func (h *MCPHandler) Delete(c echo.Context) error {
+	sessionID := c.Request().Header.Get(mcpSessionHeader)
+	if sessionID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Mcp-Session-Id header required",
+		})
+	}
+
+	if h.server.DeleteSession(sessionID) {
+		return c.NoContent(http.StatusOK)
+	}
+
+	return c.JSON(http.StatusNotFound, map[string]string{
+		"error": "session not found",
+	})
+}

--- a/internal/infrastructure/http/handlers/mcp_test.go
+++ b/internal/infrastructure/http/handlers/mcp_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/infrastructure/mcp"
+	"github.com/duragraph/duragraph/internal/infrastructure/tools"
+	"github.com/labstack/echo/v4"
+)
+
+func TestMCPHandler_Post_InvalidContentType(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Post(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("expected 415, got %d", rec.Code)
+	}
+}
+
+func TestMCPHandler_Post_ParseError(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`not json`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Post(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 (JSON-RPC error), got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "parse error") {
+		t.Errorf("expected parse error in body, got %s", rec.Body.String())
+	}
+}
+
+func TestMCPHandler_Post_Ping(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	e := echo.New()
+	body := `{"jsonrpc":"2.0","id":1,"method":"ping"}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Post(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Header().Get(mcpSessionHeader) == "" {
+		t.Error("expected Mcp-Session-Id header in response")
+	}
+}
+
+func TestMCPHandler_Get_NotAllowed(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Get(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestMCPHandler_Delete_MissingSession(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Delete(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMCPHandler_Delete_NotFound(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	req.Header.Set(mcpSessionHeader, "nonexistent-session")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Delete(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestMCPHandler_Delete_Success(t *testing.T) {
+	registry := tools.NewRegistry()
+	server := mcp.NewServer(registry, nil, nil, nil, nil, nil, nil)
+	handler := NewMCPHandler(server)
+
+	sessionID := server.CreateSession()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	req.Header.Set(mcpSessionHeader, sessionID)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Delete(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}

--- a/internal/infrastructure/mcp/server.go
+++ b/internal/infrastructure/mcp/server.go
@@ -1,0 +1,483 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/application/command"
+	"github.com/duragraph/duragraph/internal/application/query"
+	"github.com/duragraph/duragraph/internal/application/service"
+	"github.com/duragraph/duragraph/internal/infrastructure/tools"
+	"github.com/google/uuid"
+)
+
+const (
+	ProtocolVersion = "2024-11-05"
+	ServerName      = "duragraph"
+	ServerVersion   = "1.0.0"
+)
+
+// JSON-RPC 2.0 types
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// MCP protocol types
+
+type InitializeParams struct {
+	ProtocolVersion string     `json:"protocolVersion"`
+	Capabilities    Capability `json:"capabilities"`
+	ClientInfo      Info       `json:"clientInfo"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string           `json:"protocolVersion"`
+	Capabilities    ServerCapability `json:"capabilities"`
+	ServerInfo      Info             `json:"serverInfo"`
+	Instructions    string           `json:"instructions,omitempty"`
+}
+
+type Capability struct {
+	Roots    *RootsCapability    `json:"roots,omitempty"`
+	Sampling *SamplingCapability `json:"sampling,omitempty"`
+}
+
+type RootsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type SamplingCapability struct{}
+
+type ServerCapability struct {
+	Tools     *ToolsCapability     `json:"tools,omitempty"`
+	Resources *ResourcesCapability `json:"resources,omitempty"`
+}
+
+type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type ResourcesCapability struct {
+	Subscribe   bool `json:"subscribe,omitempty"`
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type Info struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ToolDef struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type ToolsListResult struct {
+	Tools      []ToolDef `json:"tools"`
+	NextCursor string    `json:"nextCursor,omitempty"`
+}
+
+type ToolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type Content struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type ToolCallResult struct {
+	Content []Content `json:"content"`
+	IsError bool      `json:"isError,omitempty"`
+}
+
+type ResourceDef struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+type ResourcesListResult struct {
+	Resources  []ResourceDef `json:"resources"`
+	NextCursor string        `json:"nextCursor,omitempty"`
+}
+
+type ResourceReadParams struct {
+	URI string `json:"uri"`
+}
+
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
+type ResourceReadResult struct {
+	Contents []ResourceContent `json:"contents"`
+}
+
+// Session tracks an MCP client session
+type Session struct {
+	ID          string
+	Initialized bool
+}
+
+// Server implements the MCP protocol over Streamable HTTP
+type Server struct {
+	toolRegistry   *tools.Registry
+	assistantQuery *query.GetAssistantHandler
+	listAssistants *query.ListAssistantsHandler
+	getThread      *query.GetThreadHandler
+	createRun      *command.CreateRunHandler
+	getRun         *query.GetRunHandler
+	runService     *service.RunService
+
+	sessions   map[string]*Session
+	sessionsMu sync.RWMutex
+}
+
+func NewServer(
+	toolRegistry *tools.Registry,
+	assistantQuery *query.GetAssistantHandler,
+	listAssistants *query.ListAssistantsHandler,
+	getThread *query.GetThreadHandler,
+	createRun *command.CreateRunHandler,
+	getRun *query.GetRunHandler,
+	runService *service.RunService,
+) *Server {
+	return &Server{
+		toolRegistry:   toolRegistry,
+		assistantQuery: assistantQuery,
+		listAssistants: listAssistants,
+		getThread:      getThread,
+		createRun:      createRun,
+		getRun:         getRun,
+		runService:     runService,
+		sessions:       make(map[string]*Session),
+	}
+}
+
+func (s *Server) HandleRequest(ctx context.Context, sessionID string, req *Request) *Response {
+	if req.JSONRPC != "2.0" {
+		return errorResponse(req.ID, -32600, "invalid JSON-RPC version")
+	}
+
+	// Notifications have no ID and expect no response
+	if req.ID == nil {
+		s.handleNotification(sessionID, req)
+		return nil
+	}
+
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "ping":
+		return successResponse(req.ID, map[string]interface{}{})
+	case "tools/list":
+		return s.handleToolsList(ctx, req)
+	case "tools/call":
+		return s.handleToolsCall(ctx, req)
+	case "resources/list":
+		return s.handleResourcesList(ctx, req)
+	case "resources/read":
+		return s.handleResourcesRead(ctx, req)
+	default:
+		return errorResponse(req.ID, -32601, fmt.Sprintf("method not found: %s", req.Method))
+	}
+}
+
+func (s *Server) CreateSession() string {
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+	id := uuid.New().String()
+	s.sessions[id] = &Session{ID: id}
+	return id
+}
+
+func (s *Server) DeleteSession(id string) bool {
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+	if _, ok := s.sessions[id]; ok {
+		delete(s.sessions, id)
+		return true
+	}
+	return false
+}
+
+func (s *Server) HasSession(id string) bool {
+	s.sessionsMu.RLock()
+	defer s.sessionsMu.RUnlock()
+	_, ok := s.sessions[id]
+	return ok
+}
+
+func (s *Server) handleNotification(sessionID string, req *Request) {
+	switch req.Method {
+	case "notifications/initialized":
+		s.sessionsMu.Lock()
+		if sess, ok := s.sessions[sessionID]; ok {
+			sess.Initialized = true
+		}
+		s.sessionsMu.Unlock()
+	}
+}
+
+func (s *Server) handleInitialize(req *Request) *Response {
+	var params InitializeParams
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return errorResponse(req.ID, -32602, "invalid initialize params")
+		}
+	}
+
+	result := InitializeResult{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities: ServerCapability{
+			Tools:     &ToolsCapability{ListChanged: false},
+			Resources: &ResourcesCapability{Subscribe: false, ListChanged: false},
+		},
+		ServerInfo: Info{
+			Name:    ServerName,
+			Version: ServerVersion,
+		},
+		Instructions: "DuraGraph AI workflow orchestration platform. Use tools to invoke assistants and manage threads.",
+	}
+
+	return successResponse(req.ID, result)
+}
+
+func (s *Server) handleToolsList(ctx context.Context, req *Request) *Response {
+	mcpTools := []ToolDef{}
+
+	// Expose registered tools from the tool registry
+	for _, t := range s.toolRegistry.List() {
+		schema := t.Schema()
+		if schema == nil {
+			schema = map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+		}
+		mcpTools = append(mcpTools, ToolDef{
+			Name:        t.Name(),
+			Description: t.Description(),
+			InputSchema: schema,
+		})
+	}
+
+	// Expose each assistant as an invocable tool
+	assistants, err := s.listAssistants.Handle(ctx, 100, 0)
+	if err == nil {
+		for _, a := range assistants {
+			mcpTools = append(mcpTools, ToolDef{
+				Name:        fmt.Sprintf("invoke_assistant_%s", a.ID()),
+				Description: fmt.Sprintf("Invoke assistant '%s'. Creates a run and returns the result.", a.Name()),
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"thread_id": map[string]interface{}{
+							"type":        "string",
+							"description": "Thread ID to run against (optional for stateless runs)",
+						},
+						"input": map[string]interface{}{
+							"type":        "object",
+							"description": "Input data for the run",
+						},
+						"config": map[string]interface{}{
+							"type":        "object",
+							"description": "Runtime configuration overrides",
+						},
+					},
+					"required": []string{},
+				},
+			})
+		}
+	}
+
+	return successResponse(req.ID, ToolsListResult{Tools: mcpTools})
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, req *Request) *Response {
+	var params ToolCallParams
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return errorResponse(req.ID, -32602, "invalid tool call params")
+		}
+	}
+
+	if params.Name == "" {
+		return errorResponse(req.ID, -32602, "tool name is required")
+	}
+
+	// Check if it's an assistant invocation tool
+	if assistantID, ok := parseAssistantToolName(params.Name); ok {
+		return s.invokeAssistant(ctx, req.ID, assistantID, params.Arguments)
+	}
+
+	// Otherwise try the tool registry
+	result, err := s.toolRegistry.Execute(ctx, params.Name, params.Arguments)
+	if err != nil {
+		return successResponse(req.ID, ToolCallResult{
+			Content: []Content{{Type: "text", Text: fmt.Sprintf("Error: %s", err.Error())}},
+			IsError: true,
+		})
+	}
+
+	resultJSON, _ := json.Marshal(result)
+	return successResponse(req.ID, ToolCallResult{
+		Content: []Content{{Type: "text", Text: string(resultJSON)}},
+	})
+}
+
+func (s *Server) invokeAssistant(ctx context.Context, reqID json.RawMessage, assistantID string, args map[string]interface{}) *Response {
+	threadID, _ := args["thread_id"].(string)
+	input, _ := args["input"].(map[string]interface{})
+	config, _ := args["config"].(map[string]interface{})
+
+	if input == nil {
+		input = map[string]interface{}{}
+	}
+
+	cmd := command.CreateRun{
+		AssistantID: assistantID,
+		ThreadID:    threadID,
+		Input:       input,
+		Config:      config,
+	}
+
+	runID, err := s.createRun.Handle(ctx, cmd)
+	if err != nil {
+		return successResponse(reqID, ToolCallResult{
+			Content: []Content{{Type: "text", Text: fmt.Sprintf("Failed to create run: %s", err.Error())}},
+			IsError: true,
+		})
+	}
+
+	resultJSON, _ := json.Marshal(map[string]interface{}{
+		"run_id":       runID,
+		"assistant_id": assistantID,
+		"status":       "queued",
+		"message":      "Run created successfully. Use run_id to check status.",
+	})
+
+	return successResponse(reqID, ToolCallResult{
+		Content: []Content{{Type: "text", Text: string(resultJSON)}},
+	})
+}
+
+func (s *Server) handleResourcesList(ctx context.Context, req *Request) *Response {
+	resources := []ResourceDef{
+		{
+			URI:         "duragraph://assistants",
+			Name:        "Assistants",
+			Description: "List of all configured assistants",
+			MimeType:    "application/json",
+		},
+		{
+			URI:         "duragraph://server/info",
+			Name:        "Server Info",
+			Description: "DuraGraph server information and capabilities",
+			MimeType:    "application/json",
+		},
+	}
+
+	return successResponse(req.ID, ResourcesListResult{Resources: resources})
+}
+
+func (s *Server) handleResourcesRead(ctx context.Context, req *Request) *Response {
+	var params ResourceReadParams
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return errorResponse(req.ID, -32602, "invalid resource read params")
+		}
+	}
+
+	switch params.URI {
+	case "duragraph://assistants":
+		assistants, err := s.listAssistants.Handle(ctx, 100, 0)
+		if err != nil {
+			return errorResponse(req.ID, -32603, fmt.Sprintf("failed to list assistants: %s", err.Error()))
+		}
+
+		list := make([]map[string]interface{}, 0, len(assistants))
+		for _, a := range assistants {
+			list = append(list, map[string]interface{}{
+				"id":   a.ID(),
+				"name": a.Name(),
+
+				"metadata": a.Metadata(),
+			})
+		}
+
+		data, _ := json.MarshalIndent(list, "", "  ")
+		return successResponse(req.ID, ResourceReadResult{
+			Contents: []ResourceContent{{
+				URI:      params.URI,
+				MimeType: "application/json",
+				Text:     string(data),
+			}},
+		})
+
+	case "duragraph://server/info":
+		info := map[string]interface{}{
+			"name":             ServerName,
+			"version":          ServerVersion,
+			"protocol_version": ProtocolVersion,
+			"capabilities":     []string{"tools", "resources", "assistants", "threads", "runs", "store", "crons"},
+		}
+		data, _ := json.MarshalIndent(info, "", "  ")
+		return successResponse(req.ID, ResourceReadResult{
+			Contents: []ResourceContent{{
+				URI:      params.URI,
+				MimeType: "application/json",
+				Text:     string(data),
+			}},
+		})
+
+	default:
+		return errorResponse(req.ID, -32002, fmt.Sprintf("resource not found: %s", params.URI))
+	}
+}
+
+// parseAssistantToolName extracts assistant ID from tool name "invoke_assistant_<uuid>"
+func parseAssistantToolName(name string) (string, bool) {
+	const prefix = "invoke_assistant_"
+	if len(name) > len(prefix) && name[:len(prefix)] == prefix {
+		return name[len(prefix):], true
+	}
+	return "", false
+}
+
+func successResponse(id json.RawMessage, result interface{}) *Response {
+	return &Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+}
+
+func errorResponse(id json.RawMessage, code int, message string) *Response {
+	return &Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &RPCError{Code: code, Message: message},
+	}
+}

--- a/internal/infrastructure/mcp/server_test.go
+++ b/internal/infrastructure/mcp/server_test.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestParseAssistantToolName(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantID string
+		wantOK bool
+	}{
+		{"valid", "invoke_assistant_abc-123", "abc-123", true},
+		{"valid uuid", "invoke_assistant_550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440000", true},
+		{"no prefix", "run_assistant_abc", "", false},
+		{"empty", "", "", false},
+		{"only prefix", "invoke_assistant_", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := parseAssistantToolName(tt.input)
+			if ok != tt.wantOK {
+				t.Errorf("parseAssistantToolName(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if id != tt.wantID {
+				t.Errorf("parseAssistantToolName(%q) id = %q, want %q", tt.input, id, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestSuccessResponse(t *testing.T) {
+	id := json.RawMessage(`1`)
+	resp := successResponse(id, map[string]string{"key": "value"})
+
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("expected jsonrpc 2.0, got %s", resp.JSONRPC)
+	}
+	if resp.Error != nil {
+		t.Error("expected no error")
+	}
+	if resp.Result == nil {
+		t.Error("expected result")
+	}
+}
+
+func TestErrorResponse(t *testing.T) {
+	id := json.RawMessage(`"req-1"`)
+	resp := errorResponse(id, -32601, "method not found")
+
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("expected jsonrpc 2.0, got %s", resp.JSONRPC)
+	}
+	if resp.Result != nil {
+		t.Error("expected no result")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("expected code -32601, got %d", resp.Error.Code)
+	}
+	if resp.Error.Message != "method not found" {
+		t.Errorf("expected message 'method not found', got %s", resp.Error.Message)
+	}
+}
+
+func TestHandleRequest_InvalidVersion(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+	req := &Request{JSONRPC: "1.0", ID: json.RawMessage(`1`), Method: "ping"}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid version")
+	}
+	if resp.Error.Code != -32600 {
+		t.Errorf("expected code -32600, got %d", resp.Error.Code)
+	}
+}
+
+func TestHandleRequest_MethodNotFound(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "unknown/method"}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("expected code -32601, got %d", resp.Error.Code)
+	}
+}
+
+func TestHandleRequest_Ping(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`3`), Method: "ping"}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+	if resp.Result == nil {
+		t.Fatal("expected result for ping")
+	}
+}
+
+func TestHandleRequest_Initialize(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+
+	params, _ := json.Marshal(InitializeParams{
+		ProtocolVersion: "2024-11-05",
+		ClientInfo:      Info{Name: "test", Version: "1.0"},
+	})
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`4`), Method: "initialize", Params: params}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	result, ok := resp.Result.(InitializeResult)
+	if !ok {
+		t.Fatal("expected InitializeResult")
+	}
+	if result.ProtocolVersion != ProtocolVersion {
+		t.Errorf("expected protocol %s, got %s", ProtocolVersion, result.ProtocolVersion)
+	}
+	if result.ServerInfo.Name != ServerName {
+		t.Errorf("expected server name %s, got %s", ServerName, result.ServerInfo.Name)
+	}
+	if result.Capabilities.Tools == nil {
+		t.Error("expected tools capability")
+	}
+}
+
+func TestHandleRequest_Notification(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+	s.sessions["sess-1"] = &Session{ID: "sess-1"}
+
+	req := &Request{JSONRPC: "2.0", Method: "notifications/initialized"}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp != nil {
+		t.Error("notifications should return nil response")
+	}
+
+	if !s.sessions["sess-1"].Initialized {
+		t.Error("session should be marked as initialized")
+	}
+}
+
+func TestSession_CreateAndDelete(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+
+	id := s.CreateSession()
+	if id == "" {
+		t.Fatal("expected non-empty session ID")
+	}
+	if !s.HasSession(id) {
+		t.Error("session should exist after creation")
+	}
+
+	if !s.DeleteSession(id) {
+		t.Error("delete should return true for existing session")
+	}
+	if s.HasSession(id) {
+		t.Error("session should not exist after deletion")
+	}
+	if s.DeleteSession(id) {
+		t.Error("delete should return false for non-existing session")
+	}
+}
+
+func TestHandleRequest_ToolsCall_MissingName(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+
+	params, _ := json.Marshal(ToolCallParams{Name: ""})
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`5`), Method: "tools/call", Params: params}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for missing tool name")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("expected code -32602, got %d", resp.Error.Code)
+	}
+}
+
+func TestHandleRequest_ResourcesRead_NotFound(t *testing.T) {
+	s := &Server{sessions: make(map[string]*Session)}
+
+	params, _ := json.Marshal(ResourceReadParams{URI: "duragraph://nonexistent"})
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`6`), Method: "resources/read", Params: params}
+	resp := s.HandleRequest(context.Background(), "sess-1", req)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown resource")
+	}
+	if resp.Error.Code != -32002 {
+		t.Errorf("expected code -32002, got %d", resp.Error.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements Model Context Protocol (MCP) server with Streamable HTTP transport (JSON-RPC 2.0)
- Exposes DuraGraph assistants as invocable MCP tools and server info/assistants as MCP resources
- Adds session management, protocol lifecycle (initialize, ping), and all core MCP methods

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/mcp` | JSON-RPC 2.0 requests (initialize, ping, tools/list, tools/call, resources/list, resources/read) |
| GET | `/mcp` | Returns 405 (streaming not supported) |
| DELETE | `/mcp` | Terminate MCP session |

## MCP Methods Supported

- `initialize` - Capability negotiation
- `ping` - Health check
- `tools/list` - Lists tool registry tools + assistants as invocable tools
- `tools/call` - Execute tool or invoke assistant (creates a run)
- `resources/list` - Lists available resources (assistants, server info)
- `resources/read` - Read resource content
- `notifications/initialized` - Session initialization notification

## Test Plan

- [x] 11 MCP server unit tests (protocol, session, lifecycle)
- [x] 7 HTTP handler tests (content type, parse error, ping, methods, session CRUD)
- [x] Full test suite passes
- [x] go vet clean

Closes #119