### PR TITLE
test: phase 1 — domain and pkg layer unit tests

### DIFF
--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -1,0 +1,114 @@
+---
+applyTo: "**"
+---
+
+# DuraGraph Control Plane — General Instructions
+
+## Build & Test Commands
+
+All commands run from the repository root.
+
+### Required toolchain
+
+- Go 1.25+
+- Python 3.11+ (for pre-commit hooks)
+- `goimports` (`go install golang.org/x/tools/cmd/goimports@latest`)
+- `pre-commit` (`pip install pre-commit`)
+
+### Build
+
+```bash
+go build ./cmd/server/          # Build server binary
+go vet ./...                     # Static analysis (run before every commit)
+```
+
+### Test
+
+```bash
+go test -short ./...             # All unit tests (no external deps)
+go test -short -cover ./...      # Unit tests with coverage
+go test -tags integration ./...  # Integration tests (needs Postgres, NATS, Redis)
+go test -tags e2e ./tests/e2e/   # End-to-end tests (needs running server)
+```
+
+Always run `go test -short ./...` before submitting changes. This is what CI runs.
+
+### Pre-commit hooks (enforced in CI)
+
+```bash
+pre-commit run --all-files       # Run all hooks locally
+```
+
+Hooks that run on every commit:
+- `trailing-whitespace`, `end-of-file-fixer`
+- `check-yaml`, `check-json`
+- `check-added-large-files` (max 1MB)
+- `check-merge-conflict`, `detect-private-key`
+- `go-fmt`, `go-imports`, `go-mod-tidy`, `go-vet`
+- `gitleaks` (secret detection)
+- `commitizen` (conventional commit format on commit messages)
+
+### Taskfile (optional)
+
+```bash
+task dev          # Start server with hot reload
+task up           # Start full Docker Compose environment
+task health       # Check server health
+task test         # Run all tests
+task test:unit    # Unit tests only
+task db:migrate   # Run database migrations
+```
+
+## CI Checks (must all pass on PRs)
+
+| Check | Workflow | What it validates |
+|-------|----------|-------------------|
+| **Pre-commit Checks** | `ci.yml` | go-fmt, go-imports, go-mod-tidy, go-vet, trailing whitespace, YAML/JSON, gitleaks, commitizen |
+| **Go Tests** | `ci.yml` | `go vet ./...` + `go test ./... -cover -short` |
+| **Conformance Tests** | `conformance.yml` | Docker Compose integration test suite against LangGraph Cloud API spec |
+| **OpenAPI Lint** | `contracts.yml` | Spectral lint of `schemas/openapi/duragraph.yaml` |
+| **IR Validate** | `contracts.yml` | JSON Schema validation of IR examples |
+| **CodeQL** | `codeql.yml` | Security analysis (Go, JS/TS, Python) |
+| **Issue Automation** | `issue-automation.yml` | Auto-updates issue labels on PR events |
+
+## Commit Messages
+
+Conventional Commits format is enforced by commitizen pre-commit hook:
+
+```
+feat: add webhook event definitions
+fix: resolve worker reconnection issue
+test: add unit tests for execution state machine
+refactor: extract LLM provider interface
+docs: update API reference
+chore: update dependencies
+```
+
+Scope is optional: `feat(http): add rate limiting middleware`
+
+## File Structure Reference
+
+```
+cmd/server/              # Server entry point and config
+internal/
+├── pkg/                 # Shared utilities (errors, eventbus, uuid)
+├── domain/              # Pure domain logic (aggregates, events, interfaces)
+├── application/         # Use cases (command handlers, query handlers, services)
+└── infrastructure/      # External concerns (HTTP, DB, NATS, LLM, etc.)
+deploy/
+├── sql/                 # Database migrations (001-012)
+└── compose/             # Docker Compose files for testing
+schemas/
+└── openapi/             # OpenAPI 3.0 specification
+tests/
+└── e2e/                 # End-to-end test suite
+```
+
+## Important Constraints
+
+- **Never push to `main` directly** — all changes via PR
+- **Never modify the `events` table** — events are append-only and immutable
+- **Domain packages must not import infrastructure** — strict layer boundaries
+- **The control plane does not make LLM calls** — it dispatches to workers
+- **`go.sum` changes are expected** when dependencies change — always commit both `go.mod` and `go.sum`
+- **No `.env` file loading in code** — server reads raw `os.Getenv()` calls

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,142 @@
+---
+applyTo: "**/*.go"
+---
+
+# Go Code Review Instructions
+
+## Project Overview
+
+DuraGraph is an enterprise-grade, LangGraph Cloud-compatible AI workflow orchestration control plane. It is a single Go module (`github.com/duragraph/duragraph`) built with Go 1.25, Echo v4, PostgreSQL (pgx v5), NATS JetStream, and OpenTelemetry.
+
+The control plane **dispatches tasks to SDK workers** — it does NOT make LLM calls itself. LLM calls happen in Python/Go SDK workers that register with the control plane.
+
+## Architecture — Domain-Driven Design with CQRS + Event Sourcing
+
+```
+internal/
+├── pkg/                 # Shared utilities (errors, eventbus, uuid) — zero dependencies
+├── domain/              # Pure domain logic — NO infrastructure imports allowed
+│   ├── run/             # Run aggregate (workflow execution state machine)
+│   ├── worker/          # Worker aggregate (registration, heartbeat, leases)
+│   ├── workflow/        # Workflow aggregates (Assistant, Thread, Graph)
+│   ├── execution/       # Execution state machine, node executors
+│   ├── checkpoint/      # State snapshots for thread resumption
+│   ├── humanloop/       # Human-in-the-loop interrupts
+│   └── messaging/       # Domain messaging interfaces
+├── application/         # Use cases — orchestrates domain + infrastructure
+│   ├── command/         # Write operations (CreateRun, CreateAssistant, etc.)
+│   ├── query/           # Read operations (GetRun, ListAssistants, etc.)
+│   └── service/         # Domain services (RunService, WorkerService, CronScheduler)
+└── infrastructure/      # External concerns — implements domain interfaces
+    ├── http/            # REST API (handlers, middleware, DTOs)
+    ├── persistence/     # PostgreSQL repositories, event store, outbox
+    ├── messaging/       # NATS publisher/subscriber, outbox relay
+    ├── graph/           # Graph execution engine
+    ├── execution/       # LLM/tool executor wiring
+    ├── llm/             # LLM provider clients (OpenAI, Anthropic)
+    ├── tools/           # Tool registry
+    ├── auth/            # JWT authentication
+    ├── cache/           # Redis caching
+    ├── mcp/             # Model Context Protocol server
+    ├── streaming/       # SSE streaming bridge
+    ├── monitoring/      # Prometheus metrics
+    └── tracing/         # OpenTelemetry tracing
+```
+
+## Strict Layer Rules
+
+1. **`domain/` packages must NEVER import from `application/` or `infrastructure/`**. Domain is pure business logic with no external dependencies.
+2. **`application/` may import `domain/` but never `infrastructure/`**. Application layer depends on domain interfaces, not implementations.
+3. **`infrastructure/` implements interfaces defined in `domain/`** (Repository pattern).
+4. **`pkg/` is shared utilities** — importable by any layer, but must not import from `internal/`.
+
+## Domain Aggregate Pattern
+
+All aggregates follow this pattern:
+- Unexported fields with getter methods
+- Factory function (`NewXxx`) that validates input and records a domain event
+- `Reconstruct` / `Reconstitute` function for rehydration from persistence (no events emitted)
+- `Events() []eventbus.Event` returns uncommitted events
+- `ClearEvents()` resets after persistence
+- State changes MUST record domain events — events are the source of truth
+
+```go
+type Run struct {
+    id     string
+    status RunStatus
+    events []eventbus.Event
+}
+
+func NewRun(...) (*Run, error) {
+    // validate, create, record RunCreated event
+}
+
+func (r *Run) Events() []eventbus.Event { return r.events }
+```
+
+## Run State Machine
+
+```
+queued → in_progress → completed
+       ↓              ↓
+       ↓              failed
+       ↓              ↓
+       ↓              cancelled
+       ↓
+       requires_action → (resume) → in_progress
+```
+
+Only valid transitions are allowed. Invalid state transitions must return `errors.InvalidState()`.
+
+## Error Handling
+
+Use the centralized error package at `internal/pkg/errors`:
+
+```go
+errors.NotFound("assistant", id)
+errors.AlreadyExists("thread", id)
+errors.InvalidInput("field", "reason")
+errors.InvalidState("current", "attempted")
+errors.Internal("message", wrappedErr)
+```
+
+- All domain errors wrap sentinel errors (`ErrNotFound`, `ErrInvalidInput`, etc.) for `errors.Is()` checking
+- Never use raw `fmt.Errorf` in domain code — use `DomainError` types
+- Infrastructure code may use standard Go errors but should wrap with context
+
+## Event Sourcing Rules
+
+- **Events are immutable** — never modify the `events` table
+- **Event store + outbox must be atomic** — always within the same transaction
+- **Events are replayed in order** to reconstruct aggregate state
+- **Aggregates must not call repositories** — keep domain pure
+
+## Code Style
+
+- `gofmt` formatting is enforced (pre-commit hook)
+- `goimports` for import ordering (stdlib, external, internal)
+- No `golangci-lint` yet — use `go vet` for static analysis
+- Conventional commits required: `feat:`, `fix:`, `test:`, `refactor:`, `docs:`, `chore:`
+- Package-level comments explain purpose; exported types have descriptive comments
+- Test files: `*_test.go` in the same package (white-box testing preferred for domain)
+- Integration tests use build tag `//go:build integration`
+- E2E tests use build tag `//go:build e2e`
+
+## Testing Expectations
+
+When reviewing test code:
+- Unit tests must have `-short` flag support and no external dependencies
+- Use `testing.T` standard library — `testify` is available but table-driven tests with stdlib are preferred for new code
+- Test helpers should call `t.Helper()`
+- Domain tests should verify both behavior AND event emission
+- Each aggregate method that changes state should emit a corresponding domain event
+- Verify error types with `errors.Is()`, not string matching
+
+## Key Entry Points
+
+- **Server entry**: `cmd/server/main.go`
+- **Config**: `cmd/server/config/config.go` (reads env vars with `os.Getenv`, no .env loading)
+- **HTTP routes**: registered in `internal/infrastructure/http/handlers/`
+- **Database migrations**: `deploy/sql/001_init.sql` through `deploy/sql/012_crons.sql`
+- **OpenAPI spec**: `schemas/openapi/duragraph.yaml`
+- **Docker Compose**: `docker-compose.yml` (dev), `deploy/compose/docker-compose.test.yml` (CI)

--- a/internal/domain/checkpoint/checkpoint_test.go
+++ b/internal/domain/checkpoint/checkpoint_test.go
@@ -1,0 +1,200 @@
+package checkpoint
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewCheckpoint_Valid(t *testing.T) {
+	cv := map[string]interface{}{"messages": []string{"hello"}}
+	cp, err := NewCheckpoint("thread-1", "default", "", "", cv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cp.ID() == "" {
+		t.Error("ID should not be empty")
+	}
+	if cp.ThreadID() != "thread-1" {
+		t.Errorf("expected ThreadID=thread-1, got %s", cp.ThreadID())
+	}
+	if cp.CheckpointNS() != "default" {
+		t.Error("wrong namespace")
+	}
+	if cp.CheckpointID() == "" {
+		t.Error("CheckpointID should be auto-generated when empty")
+	}
+	if cp.ParentCheckpointID() != "" {
+		t.Error("ParentCheckpointID should be empty")
+	}
+	if cp.ChannelValues()["messages"] == nil {
+		t.Error("channel values not set")
+	}
+	if cp.ChannelVersions() == nil {
+		t.Error("ChannelVersions should be initialized")
+	}
+	if cp.VersionsSeen() == nil {
+		t.Error("VersionsSeen should be initialized")
+	}
+	if cp.PendingSends() == nil {
+		t.Error("PendingSends should be initialized")
+	}
+	if cp.CreatedAt().IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+}
+
+func TestNewCheckpoint_ExplicitCheckpointID(t *testing.T) {
+	cp, err := NewCheckpoint("thread-1", "ns", "explicit-id", "parent-id", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cp.CheckpointID() != "explicit-id" {
+		t.Errorf("expected explicit-id, got %s", cp.CheckpointID())
+	}
+	if cp.ParentCheckpointID() != "parent-id" {
+		t.Error("parent checkpoint ID not set")
+	}
+}
+
+func TestNewCheckpoint_EmptyThreadID(t *testing.T) {
+	_, err := NewCheckpoint("", "ns", "", "", nil)
+	if err == nil {
+		t.Fatal("expected error for empty thread_id")
+	}
+	if err != ErrInvalidThreadID {
+		t.Errorf("expected ErrInvalidThreadID, got %v", err)
+	}
+}
+
+func TestCheckpoint_SetChannelValue(t *testing.T) {
+	cp, _ := NewCheckpoint("thread-1", "ns", "", "", map[string]interface{}{})
+
+	cp.SetChannelValue("messages", "hello")
+	val, ok := cp.GetChannelValue("messages")
+	if !ok {
+		t.Error("should find channel value")
+	}
+	if val != "hello" {
+		t.Errorf("expected 'hello', got %v", val)
+	}
+
+	if cp.ChannelVersions()["messages"] != 1 {
+		t.Errorf("expected version=1, got %d", cp.ChannelVersions()["messages"])
+	}
+
+	cp.SetChannelValue("messages", "world")
+	if cp.ChannelVersions()["messages"] != 2 {
+		t.Errorf("expected version=2 after second set, got %d", cp.ChannelVersions()["messages"])
+	}
+}
+
+func TestCheckpoint_GetChannelValue_NotFound(t *testing.T) {
+	cp, _ := NewCheckpoint("thread-1", "ns", "", "", map[string]interface{}{})
+	_, ok := cp.GetChannelValue("nonexistent")
+	if ok {
+		t.Error("should return false for nonexistent channel")
+	}
+}
+
+func TestCheckpoint_PendingSends(t *testing.T) {
+	cp, _ := NewCheckpoint("thread-1", "ns", "", "", nil)
+
+	cp.AddPendingSend(map[string]interface{}{"channel": "out", "value": "a"})
+	cp.AddPendingSend(map[string]interface{}{"channel": "out", "value": "b"})
+
+	sends := cp.PendingSends()
+	if len(sends) != 2 {
+		t.Fatalf("expected 2 pending sends, got %d", len(sends))
+	}
+
+	cp.ClearPendingSends()
+	if len(cp.PendingSends()) != 0 {
+		t.Error("pending sends should be empty after clear")
+	}
+}
+
+func TestReconstitute(t *testing.T) {
+	now := time.Now()
+	cv := map[string]interface{}{"k": "v"}
+	cver := map[string]int{"k": 3}
+	vs := map[string]map[string]int{"node1": {"k": 2}}
+	ps := []map[string]interface{}{{"channel": "out"}}
+
+	cp := Reconstitute("id-1", "thread-1", "ns", "cp-1", "parent-1", cv, cver, vs, ps, now)
+
+	if cp.ID() != "id-1" {
+		t.Error("wrong ID")
+	}
+	if cp.ThreadID() != "thread-1" {
+		t.Error("wrong ThreadID")
+	}
+	if cp.CheckpointNS() != "ns" {
+		t.Error("wrong CheckpointNS")
+	}
+	if cp.CheckpointID() != "cp-1" {
+		t.Error("wrong CheckpointID")
+	}
+	if cp.ParentCheckpointID() != "parent-1" {
+		t.Error("wrong ParentCheckpointID")
+	}
+	if cp.ChannelValues()["k"] != "v" {
+		t.Error("wrong ChannelValues")
+	}
+	if cp.ChannelVersions()["k"] != 3 {
+		t.Error("wrong ChannelVersions")
+	}
+	if cp.VersionsSeen()["node1"]["k"] != 2 {
+		t.Error("wrong VersionsSeen")
+	}
+	if len(cp.PendingSends()) != 1 {
+		t.Error("wrong PendingSends")
+	}
+	if !cp.CreatedAt().Equal(now) {
+		t.Error("wrong CreatedAt")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if ErrInvalidThreadID.Error() != "thread_id is required" {
+		t.Error("wrong ErrInvalidThreadID message")
+	}
+	if ErrCheckpointNotFound.Error() != "checkpoint not found" {
+		t.Error("wrong ErrCheckpointNotFound message")
+	}
+}
+
+func TestNewCheckpointWrite(t *testing.T) {
+	blob := map[string]interface{}{"data": "test"}
+	w := NewCheckpointWrite("thread-1", "ns", "cp-1", "task-1", 0, "messages", "put", blob)
+
+	if w.ID() == "" {
+		t.Error("ID should not be empty")
+	}
+	if w.ThreadID() != "thread-1" {
+		t.Error("wrong ThreadID")
+	}
+	if w.CheckpointNS() != "ns" {
+		t.Error("wrong CheckpointNS")
+	}
+	if w.CheckpointID() != "cp-1" {
+		t.Error("wrong CheckpointID")
+	}
+	if w.TaskID() != "task-1" {
+		t.Error("wrong TaskID")
+	}
+	if w.Idx() != 0 {
+		t.Errorf("expected Idx=0, got %d", w.Idx())
+	}
+	if w.Channel() != "messages" {
+		t.Error("wrong Channel")
+	}
+	if w.WriteType() != "put" {
+		t.Error("wrong WriteType")
+	}
+	if w.Blob()["data"] != "test" {
+		t.Error("wrong Blob")
+	}
+	if w.CreatedAt().IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+}

--- a/internal/domain/execution/events_test.go
+++ b/internal/domain/execution/events_test.go
@@ -1,0 +1,61 @@
+package execution
+
+import (
+	"testing"
+)
+
+func TestEventTypes(t *testing.T) {
+	tests := []struct {
+		event    interface{ EventType() string }
+		wantType string
+	}{
+		{NodeStarted{}, EventTypeNodeStarted},
+		{NodeCompleted{}, EventTypeNodeCompleted},
+		{NodeFailed{}, EventTypeNodeFailed},
+		{NodeSkipped{}, EventTypeNodeSkipped},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.wantType, func(t *testing.T) {
+			if tc.event.EventType() != tc.wantType {
+				t.Errorf("expected %s, got %s", tc.wantType, tc.event.EventType())
+			}
+		})
+	}
+}
+
+func TestEventAggregateType(t *testing.T) {
+	events := []interface {
+		AggregateType() string
+	}{
+		NodeStarted{},
+		NodeCompleted{},
+		NodeFailed{},
+		NodeSkipped{},
+	}
+
+	for _, e := range events {
+		if e.AggregateType() != "execution" {
+			t.Errorf("expected aggregate type 'execution', got '%s'", e.AggregateType())
+		}
+	}
+}
+
+func TestEventAggregateID(t *testing.T) {
+	runID := "run-abc"
+
+	events := []interface {
+		AggregateID() string
+	}{
+		NodeStarted{RunID: runID},
+		NodeCompleted{RunID: runID},
+		NodeFailed{RunID: runID},
+		NodeSkipped{RunID: runID},
+	}
+
+	for _, e := range events {
+		if e.AggregateID() != runID {
+			t.Errorf("expected aggregate ID %s, got %s", runID, e.AggregateID())
+		}
+	}
+}

--- a/internal/domain/execution/node_test.go
+++ b/internal/domain/execution/node_test.go
@@ -1,0 +1,286 @@
+package execution
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetExecutorForNodeType(t *testing.T) {
+	types := []struct {
+		nodeType string
+		wantType interface{}
+	}{
+		{"start", &StartNodeExecutor{}},
+		{"end", &EndNodeExecutor{}},
+		{"llm", &LLMNodeExecutor{}},
+		{"tool", &ToolNodeExecutor{}},
+		{"condition", &ConditionNodeExecutor{}},
+		{"human", &HumanNodeExecutor{}},
+		{"subgraph", &SubgraphNodeExecutor{}},
+		{"unknown", &StartNodeExecutor{}},
+	}
+
+	for _, tc := range types {
+		t.Run(tc.nodeType, func(t *testing.T) {
+			exec := GetExecutorForNodeType(tc.nodeType)
+			if exec == nil {
+				t.Fatal("executor should not be nil")
+			}
+		})
+	}
+}
+
+func TestStartNodeExecutor(t *testing.T) {
+	exec := &StartNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.UpdateGlobalState("input", "hello")
+
+	output, err := exec.Execute(context.Background(), "start", "start", nil, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["input"] != "hello" {
+		t.Error("start node should pass through global state")
+	}
+}
+
+func TestEndNodeExecutor(t *testing.T) {
+	exec := &EndNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.UpdateGlobalState("result", "done")
+
+	output, err := exec.Execute(context.Background(), "end", "end", nil, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["result"] != "done" {
+		t.Error("end node should pass through global state")
+	}
+}
+
+func TestLLMNodeExecutor(t *testing.T) {
+	exec := &LLMNodeExecutor{}
+	state := NewExecutionState("run-1")
+	config := map[string]interface{}{"model": "gpt-4"}
+
+	output, err := exec.Execute(context.Background(), "llm1", "llm", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["model"] != "gpt-4" {
+		t.Error("LLM executor should return model from config")
+	}
+	if output["response"] != "LLM response placeholder" {
+		t.Error("LLM executor should return placeholder response")
+	}
+}
+
+func TestToolNodeExecutor(t *testing.T) {
+	exec := &ToolNodeExecutor{}
+	state := NewExecutionState("run-1")
+	config := map[string]interface{}{"tool": "web_search"}
+
+	output, err := exec.Execute(context.Background(), "tool1", "tool", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["tool"] != "web_search" {
+		t.Error("tool executor should return tool from config")
+	}
+}
+
+func TestConditionNodeExecutor(t *testing.T) {
+	exec := &ConditionNodeExecutor{}
+	state := NewExecutionState("run-1")
+
+	output, err := exec.Execute(context.Background(), "cond1", "condition", nil, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["condition_result"] != true {
+		t.Error("condition executor should return true")
+	}
+}
+
+func TestHumanNodeExecutor(t *testing.T) {
+	exec := &HumanNodeExecutor{}
+	state := NewExecutionState("run-1")
+	config := map[string]interface{}{"reason": "approval needed"}
+
+	output, err := exec.Execute(context.Background(), "human1", "human", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["requires_human"] != true {
+		t.Error("human executor should set requires_human=true")
+	}
+	if output["reason"] != "approval needed" {
+		t.Error("human executor should return reason from config")
+	}
+}
+
+func TestSubgraphNodeExecutor_DepthExceeded(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.SubgraphDepth = maxSubgraphDepth
+
+	_, err := exec.Execute(context.Background(), "sub1", "subgraph", nil, state)
+	if err == nil {
+		t.Fatal("expected depth exceeded error")
+	}
+	depthErr, ok := err.(*SubgraphDepthError)
+	if !ok {
+		t.Fatalf("expected SubgraphDepthError, got %T", err)
+	}
+	if depthErr.Depth != maxSubgraphDepth {
+		t.Errorf("expected depth=%d, got %d", maxSubgraphDepth, depthErr.Depth)
+	}
+	expectedMsg := "subgraph depth exceeded: 10 > 10"
+	if depthErr.Error() != expectedMsg {
+		t.Errorf("expected %q, got %q", expectedMsg, depthErr.Error())
+	}
+}
+
+func TestSubgraphNodeExecutor_NoCallback(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.SubgraphExec = nil
+
+	config := map[string]interface{}{"graph_id": "g1"}
+	_, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err == nil {
+		t.Fatal("expected error when SubgraphExec is nil")
+	}
+	cfgErr, ok := err.(*SubgraphConfigError)
+	if !ok {
+		t.Fatalf("expected SubgraphConfigError, got %T", err)
+	}
+	if cfgErr.Error() == "" {
+		t.Error("error message should not be empty")
+	}
+}
+
+func TestSubgraphNodeExecutor_NoGraphConfig(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.SubgraphExec = func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		return nil, nil
+	}
+
+	config := map[string]interface{}{}
+	_, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err == nil {
+		t.Fatal("expected error when no graph_id or graph in config")
+	}
+}
+
+func TestSubgraphNodeExecutor_WithGraphID(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.UpdateGlobalState("input", "hello")
+	state.SubgraphExec = func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"output": input["input"]}, nil
+	}
+
+	config := map[string]interface{}{"graph_id": "g1"}
+	output, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["output"] != "hello" {
+		t.Error("subgraph should pass through global state as input")
+	}
+}
+
+func TestSubgraphNodeExecutor_WithSelectiveInputs(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.UpdateGlobalState("a", 1)
+	state.UpdateGlobalState("b", 2)
+	state.SubgraphExec = func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		return input, nil
+	}
+
+	config := map[string]interface{}{
+		"graph_id": "g1",
+		"inputs":   []interface{}{"a"},
+	}
+	output, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["a"] != 1 {
+		t.Error("selected input 'a' should be passed")
+	}
+	if output["b"] != nil {
+		t.Error("non-selected input 'b' should not be passed")
+	}
+}
+
+func TestSubgraphNodeExecutor_WithSelectiveOutputs(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.SubgraphExec = func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"x": 1, "y": 2, "z": 3}, nil
+	}
+
+	config := map[string]interface{}{
+		"graph_id": "g1",
+		"outputs":  []interface{}{"x", "z"},
+	}
+	output, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["x"] != 1 {
+		t.Error("output x should be present")
+	}
+	if output["y"] != nil {
+		t.Error("output y should be filtered")
+	}
+	if output["z"] != 3 {
+		t.Error("output z should be present")
+	}
+}
+
+func TestSubgraphNodeExecutor_RequiresAction(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.SubgraphExec = func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"requires_action": true, "reason": "human approval"}, nil
+	}
+
+	config := map[string]interface{}{"graph_id": "g1"}
+	output, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["requires_action"] != true {
+		t.Error("requires_action should be passed through directly")
+	}
+	if output["reason"] != "human approval" {
+		t.Error("reason should be passed through")
+	}
+}
+
+func TestSubgraphNodeExecutor_WithInlineGraph(t *testing.T) {
+	exec := &SubgraphNodeExecutor{}
+	state := NewExecutionState("run-1")
+	state.SubgraphExec = func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		if inlineGraph == nil {
+			return nil, &SubgraphConfigError{Message: "expected inline graph"}
+		}
+		return map[string]interface{}{"inline": true}, nil
+	}
+
+	config := map[string]interface{}{
+		"graph": map[string]interface{}{"nodes": []interface{}{}},
+	}
+	output, err := exec.Execute(context.Background(), "sub1", "subgraph", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["inline"] != true {
+		t.Error("should use inline graph")
+	}
+}

--- a/internal/domain/execution/state_test.go
+++ b/internal/domain/execution/state_test.go
@@ -1,0 +1,234 @@
+package execution
+
+import (
+	"testing"
+)
+
+func TestNewExecutionState(t *testing.T) {
+	s := NewExecutionState("run-1")
+	if s.RunID != "run-1" {
+		t.Errorf("expected RunID=run-1, got %s", s.RunID)
+	}
+	if len(s.CurrentNodes) != 0 {
+		t.Error("CurrentNodes should be empty")
+	}
+	if len(s.CompletedNodes) != 0 {
+		t.Error("CompletedNodes should be empty")
+	}
+	if len(s.NodeOutputs) != 0 {
+		t.Error("NodeOutputs should be empty")
+	}
+	if len(s.GlobalState) != 0 {
+		t.Error("GlobalState should be empty")
+	}
+	if s.Iteration != 0 {
+		t.Errorf("expected Iteration=0, got %d", s.Iteration)
+	}
+	if s.StreamEnabled {
+		t.Error("StreamEnabled should be false")
+	}
+}
+
+func TestExecutionState_MarkNodeStarted(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.MarkNodeStarted("node-a")
+	s.MarkNodeStarted("node-b")
+
+	if len(s.CurrentNodes) != 2 {
+		t.Fatalf("expected 2 current nodes, got %d", len(s.CurrentNodes))
+	}
+	if s.CurrentNodes[0] != "node-a" || s.CurrentNodes[1] != "node-b" {
+		t.Error("wrong current node order")
+	}
+}
+
+func TestExecutionState_MarkNodeCompleted(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.MarkNodeStarted("node-a")
+	s.MarkNodeStarted("node-b")
+
+	output := map[string]interface{}{"result": "done"}
+	s.MarkNodeCompleted("node-a", output)
+
+	if !s.IsNodeCompleted("node-a") {
+		t.Error("node-a should be completed")
+	}
+	if s.IsNodeCompleted("node-b") {
+		t.Error("node-b should not be completed")
+	}
+	if len(s.CurrentNodes) != 1 {
+		t.Errorf("expected 1 current node, got %d", len(s.CurrentNodes))
+	}
+	if s.CurrentNodes[0] != "node-b" {
+		t.Error("remaining current node should be node-b")
+	}
+
+	nodeOut := s.GetNodeOutput("node-a")
+	if nodeOut["result"] != "done" {
+		t.Error("node output not stored")
+	}
+}
+
+func TestExecutionState_GetNodeOutput_NotFound(t *testing.T) {
+	s := NewExecutionState("run-1")
+	out := s.GetNodeOutput("nonexistent")
+	if out != nil {
+		t.Error("output for nonexistent node should be nil")
+	}
+}
+
+func TestExecutionState_GlobalState(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.UpdateGlobalState("key1", "value1")
+	s.UpdateGlobalState("key2", 42)
+
+	if s.GetGlobalState("key1") != "value1" {
+		t.Error("wrong value for key1")
+	}
+	if s.GetGlobalState("key2") != 42 {
+		t.Error("wrong value for key2")
+	}
+	if s.GetGlobalState("nonexistent") != nil {
+		t.Error("nonexistent key should return nil")
+	}
+}
+
+func TestExecutionState_IncrementIteration(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.IncrementIteration()
+	s.IncrementIteration()
+	if s.Iteration != 2 {
+		t.Errorf("expected iteration=2, got %d", s.Iteration)
+	}
+}
+
+func TestExecutionState_StreamingCallback(t *testing.T) {
+	s := NewExecutionState("run-1")
+
+	err := s.EmitMessageChunk("hello", "assistant", "msg-1")
+	if err != nil {
+		t.Error("EmitMessageChunk without callback should not error")
+	}
+
+	var received []string
+	s.SetStreamingCallback(func(content, role, id string) error {
+		received = append(received, content)
+		return nil
+	})
+
+	if !s.StreamEnabled {
+		t.Error("StreamEnabled should be true after setting callback")
+	}
+
+	_ = s.EmitMessageChunk("chunk1", "assistant", "msg-1")
+	_ = s.EmitMessageChunk("chunk2", "assistant", "msg-1")
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(received))
+	}
+	if received[0] != "chunk1" || received[1] != "chunk2" {
+		t.Error("wrong chunk content")
+	}
+}
+
+func TestExecutionState_SubgraphCallback(t *testing.T) {
+	s := NewExecutionState("run-1")
+
+	result, err := s.ExecuteSubgraph("g1", nil, nil)
+	if err != nil {
+		t.Error("ExecuteSubgraph without callback should not error")
+	}
+	if result != nil {
+		t.Error("result should be nil without callback")
+	}
+
+	s.SetSubgraphCallback(func(graphID string, inlineGraph map[string]interface{}, input map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"from_subgraph": graphID}, nil
+	})
+
+	result, err = s.ExecuteSubgraph("g1", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["from_subgraph"] != "g1" {
+		t.Error("wrong subgraph result")
+	}
+}
+
+func TestExecutionState_Clone(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.UpdateGlobalState("key", "value")
+	s.StreamEnabled = true
+	s.SubgraphDepth = 2
+
+	clone := s.Clone()
+
+	if clone.RunID != "run-1" {
+		t.Error("clone RunID should match")
+	}
+	if clone.ParentRunID != "run-1" {
+		t.Error("clone ParentRunID should be set to original RunID")
+	}
+	if clone.SubgraphDepth != 3 {
+		t.Errorf("clone SubgraphDepth should be 3, got %d", clone.SubgraphDepth)
+	}
+	if clone.StreamEnabled != true {
+		t.Error("clone should inherit StreamEnabled")
+	}
+	if clone.Iteration != 0 {
+		t.Error("clone Iteration should reset to 0")
+	}
+	if clone.GetGlobalState("key") != "value" {
+		t.Error("clone should inherit global state")
+	}
+
+	clone.UpdateGlobalState("key", "modified")
+	if s.GetGlobalState("key") != "value" {
+		t.Error("modifying clone should not affect original")
+	}
+}
+
+func TestExecutionState_CloneForSubgraph(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.UpdateGlobalState("a", 1)
+	s.UpdateGlobalState("b", 2)
+	s.UpdateGlobalState("c", 3)
+
+	clone := s.CloneForSubgraph([]string{"a", "c"})
+	if clone.GetGlobalState("a") != 1 {
+		t.Error("a should be in clone")
+	}
+	if clone.GetGlobalState("b") != nil {
+		t.Error("b should NOT be in clone")
+	}
+	if clone.GetGlobalState("c") != 3 {
+		t.Error("c should be in clone")
+	}
+	if clone.SubgraphDepth != 1 {
+		t.Errorf("expected SubgraphDepth=1, got %d", clone.SubgraphDepth)
+	}
+}
+
+func TestExecutionState_CloneForSubgraph_EmptyKeys(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.UpdateGlobalState("x", "y")
+
+	clone := s.CloneForSubgraph(nil)
+	if clone.GetGlobalState("x") != "y" {
+		t.Error("empty keys should copy all global state")
+	}
+
+	clone2 := s.CloneForSubgraph([]string{})
+	if clone2.GetGlobalState("x") != "y" {
+		t.Error("empty slice should copy all global state")
+	}
+}
+
+func TestExecutionState_MarkNodeCompleted_NotInCurrent(t *testing.T) {
+	s := NewExecutionState("run-1")
+	s.MarkNodeCompleted("phantom", map[string]interface{}{"ok": true})
+
+	if !s.IsNodeCompleted("phantom") {
+		t.Error("should still mark as completed even if not in CurrentNodes")
+	}
+}

--- a/internal/domain/humanloop/interrupt_test.go
+++ b/internal/domain/humanloop/interrupt_test.go
@@ -1,0 +1,182 @@
+package humanloop
+
+import (
+	"errors"
+	"testing"
+
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+func TestNewInterrupt_Valid(t *testing.T) {
+	state := map[string]interface{}{"key": "value"}
+	toolCalls := []map[string]interface{}{
+		{"id": "call-1", "name": "search"},
+	}
+
+	interrupt, err := NewInterrupt("run-1", "node-1", ReasonToolCall, state, toolCalls)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if interrupt.ID() == "" {
+		t.Error("ID should not be empty")
+	}
+	if interrupt.RunID() != "run-1" {
+		t.Error("wrong RunID")
+	}
+	if interrupt.NodeID() != "node-1" {
+		t.Error("wrong NodeID")
+	}
+	if interrupt.Reason() != ReasonToolCall {
+		t.Errorf("expected reason=%s, got %s", ReasonToolCall, interrupt.Reason())
+	}
+	if interrupt.State()["key"] != "value" {
+		t.Error("state not set")
+	}
+	if len(interrupt.ToolCalls()) != 1 {
+		t.Error("tool calls not set")
+	}
+	if interrupt.IsResolved() {
+		t.Error("should not be resolved initially")
+	}
+	if interrupt.ResolvedAt() != nil {
+		t.Error("ResolvedAt should be nil")
+	}
+	if interrupt.CreatedAt().IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+}
+
+func TestNewInterrupt_NilState(t *testing.T) {
+	interrupt, _ := NewInterrupt("run-1", "node-1", ReasonApprovalRequired, nil, nil)
+	if interrupt.State() == nil {
+		t.Error("nil state should be initialized to empty map")
+	}
+	if interrupt.ToolCalls() == nil {
+		t.Error("nil toolCalls should be initialized to empty slice")
+	}
+}
+
+func TestNewInterrupt_MissingRunID(t *testing.T) {
+	_, err := NewInterrupt("", "node-1", ReasonToolCall, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing run_id")
+	}
+}
+
+func TestNewInterrupt_MissingNodeID(t *testing.T) {
+	_, err := NewInterrupt("run-1", "", ReasonToolCall, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing node_id")
+	}
+}
+
+func TestNewInterrupt_EmitsEvent(t *testing.T) {
+	interrupt, _ := NewInterrupt("run-1", "node-1", ReasonToolCall, nil, nil)
+	events := interrupt.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	ic, ok := events[0].(InterruptCreated)
+	if !ok {
+		t.Fatalf("expected InterruptCreated, got %T", events[0])
+	}
+	if ic.InterruptID != interrupt.ID() {
+		t.Error("event ID mismatch")
+	}
+	if ic.RunID != "run-1" {
+		t.Error("event RunID mismatch")
+	}
+	if ic.NodeID != "node-1" {
+		t.Error("event NodeID mismatch")
+	}
+	if ic.Reason != string(ReasonToolCall) {
+		t.Error("event Reason mismatch")
+	}
+	if ic.EventType() != EventTypeInterruptCreated {
+		t.Error("wrong event type")
+	}
+	if ic.AggregateType() != "interrupt" {
+		t.Error("wrong aggregate type")
+	}
+	if ic.AggregateID() != interrupt.ID() {
+		t.Error("wrong aggregate ID")
+	}
+}
+
+func TestInterrupt_Resolve(t *testing.T) {
+	interrupt, _ := NewInterrupt("run-1", "node-1", ReasonToolCall, nil, nil)
+	interrupt.ClearEvents()
+
+	toolOutputs := []map[string]interface{}{
+		{"tool_call_id": "call-1", "output": "result"},
+	}
+	err := interrupt.Resolve(toolOutputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !interrupt.IsResolved() {
+		t.Error("should be resolved")
+	}
+	if interrupt.ResolvedAt() == nil {
+		t.Error("ResolvedAt should be set")
+	}
+
+	events := interrupt.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ir, ok := events[0].(InterruptResolved)
+	if !ok {
+		t.Fatalf("expected InterruptResolved, got %T", events[0])
+	}
+	if ir.EventType() != EventTypeInterruptResolved {
+		t.Error("wrong event type")
+	}
+	if ir.AggregateID() != interrupt.ID() {
+		t.Error("wrong aggregate ID")
+	}
+	if ir.AggregateType() != "interrupt" {
+		t.Error("wrong aggregate type")
+	}
+	if ir.RunID != "run-1" {
+		t.Error("wrong RunID in event")
+	}
+}
+
+func TestInterrupt_ResolveAlreadyResolved(t *testing.T) {
+	interrupt, _ := NewInterrupt("run-1", "node-1", ReasonToolCall, nil, nil)
+	_ = interrupt.Resolve(nil)
+
+	err := interrupt.Resolve(nil)
+	if err == nil {
+		t.Fatal("expected error when resolving already-resolved interrupt")
+	}
+	if !errors.Is(err, pkgerrors.ErrInvalidState) {
+		t.Error("should be an InvalidState error")
+	}
+}
+
+func TestInterrupt_ClearEvents(t *testing.T) {
+	interrupt, _ := NewInterrupt("run-1", "node-1", ReasonToolCall, nil, nil)
+	if len(interrupt.Events()) == 0 {
+		t.Fatal("should have events after creation")
+	}
+	interrupt.ClearEvents()
+	if len(interrupt.Events()) != 0 {
+		t.Error("events should be empty")
+	}
+}
+
+func TestInterruptReasons(t *testing.T) {
+	reasons := map[InterruptReason]string{
+		ReasonToolCall:         "tool_call",
+		ReasonApprovalRequired: "approval_required",
+		ReasonInputNeeded:      "input_needed",
+	}
+	for r, expected := range reasons {
+		if string(r) != expected {
+			t.Errorf("expected %s, got %s", expected, string(r))
+		}
+	}
+}

--- a/internal/domain/workflow/assistant_test.go
+++ b/internal/domain/workflow/assistant_test.go
@@ -1,0 +1,206 @@
+package workflow
+
+import (
+	"testing"
+)
+
+func TestNewAssistant_Valid(t *testing.T) {
+	a, err := NewAssistant("my-bot", "A helpful bot", "gpt-4", "Be helpful", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.ID() == "" {
+		t.Error("ID should not be empty")
+	}
+	if a.Name() != "my-bot" {
+		t.Errorf("expected name=my-bot, got %s", a.Name())
+	}
+	if a.Description() != "A helpful bot" {
+		t.Error("wrong description")
+	}
+	if a.Model() != "gpt-4" {
+		t.Error("wrong model")
+	}
+	if a.Instructions() != "Be helpful" {
+		t.Error("wrong instructions")
+	}
+	if a.Tools() == nil {
+		t.Error("tools should be initialized")
+	}
+	if a.Metadata() == nil {
+		t.Error("metadata should be initialized")
+	}
+	if a.CreatedAt().IsZero() || a.UpdatedAt().IsZero() {
+		t.Error("timestamps should be set")
+	}
+}
+
+func TestNewAssistant_MissingName(t *testing.T) {
+	_, err := NewAssistant("", "desc", "gpt-4", "instructions", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestNewAssistant_EmitsEvent(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	events := a.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ac, ok := events[0].(AssistantCreated)
+	if !ok {
+		t.Fatalf("expected AssistantCreated, got %T", events[0])
+	}
+	if ac.AssistantID != a.ID() {
+		t.Error("event ID should match assistant ID")
+	}
+	if ac.EventType() != EventTypeAssistantCreated {
+		t.Error("wrong event type")
+	}
+	if ac.AggregateType() != "assistant" {
+		t.Error("wrong aggregate type")
+	}
+	if ac.AggregateID() != a.ID() {
+		t.Error("aggregate ID should match")
+	}
+}
+
+func TestAssistant_Update(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	a.ClearEvents()
+
+	newName := "new-bot"
+	newDesc := "new desc"
+	newModel := "claude-3"
+	newInst := "be creative"
+
+	err := a.Update(&newName, &newDesc, &newModel, &newInst, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Name() != "new-bot" {
+		t.Error("name not updated")
+	}
+	if a.Description() != "new desc" {
+		t.Error("description not updated")
+	}
+	if a.Model() != "claude-3" {
+		t.Error("model not updated")
+	}
+	if a.Instructions() != "be creative" {
+		t.Error("instructions not updated")
+	}
+
+	events := a.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	_, ok := events[0].(AssistantUpdated)
+	if !ok {
+		t.Fatalf("expected AssistantUpdated, got %T", events[0])
+	}
+}
+
+func TestAssistant_UpdatePartial(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	a.ClearEvents()
+
+	newName := "updated-bot"
+	err := a.Update(&newName, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Name() != "updated-bot" {
+		t.Error("name not updated")
+	}
+	if a.Description() != "desc" {
+		t.Error("description should remain unchanged")
+	}
+	if a.Model() != "gpt-4" {
+		t.Error("model should remain unchanged")
+	}
+}
+
+func TestAssistant_UpdateEmptyNameIgnored(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	empty := ""
+	_ = a.Update(&empty, nil, nil, nil, nil)
+	if a.Name() != "bot" {
+		t.Error("empty name should not update")
+	}
+}
+
+func TestAssistant_UpdateTools(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	tools := []map[string]interface{}{
+		{"type": "function", "name": "search"},
+	}
+	_ = a.Update(nil, nil, nil, nil, tools)
+	if len(a.Tools()) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(a.Tools()))
+	}
+}
+
+func TestAssistant_Delete(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	a.ClearEvents()
+
+	err := a.Delete()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	events := a.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ad, ok := events[0].(AssistantDeleted)
+	if !ok {
+		t.Fatalf("expected AssistantDeleted, got %T", events[0])
+	}
+	if ad.AssistantID != a.ID() {
+		t.Error("wrong assistant ID in event")
+	}
+	if ad.EventType() != EventTypeAssistantDeleted {
+		t.Error("wrong event type")
+	}
+}
+
+func TestReconstructAssistant(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+
+	reconstructed, err := ReconstructAssistant(
+		a.ID(), a.Name(), a.Description(), a.Model(), a.Instructions(),
+		nil, nil, a.CreatedAt(), a.UpdatedAt(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reconstructed.ID() != a.ID() {
+		t.Error("ID mismatch")
+	}
+	if reconstructed.Name() != a.Name() {
+		t.Error("name mismatch")
+	}
+	if len(reconstructed.Events()) != 0 {
+		t.Error("reconstructed should have no uncommitted events")
+	}
+	if reconstructed.Tools() == nil {
+		t.Error("nil tools should be initialized")
+	}
+	if reconstructed.Metadata() == nil {
+		t.Error("nil metadata should be initialized")
+	}
+}
+
+func TestAssistant_ClearEvents(t *testing.T) {
+	a, _ := NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	if len(a.Events()) == 0 {
+		t.Fatal("should have events after creation")
+	}
+	a.ClearEvents()
+	if len(a.Events()) != 0 {
+		t.Error("events should be empty after ClearEvents")
+	}
+}

--- a/internal/domain/workflow/graph_test.go
+++ b/internal/domain/workflow/graph_test.go
@@ -1,0 +1,320 @@
+package workflow
+
+import (
+	"testing"
+)
+
+func validNodes() []Node {
+	return []Node{
+		{ID: "start", Type: NodeTypeStart},
+		{ID: "llm1", Type: NodeTypeLLM, Config: map[string]interface{}{"model": "gpt-4"}},
+		{ID: "end", Type: NodeTypeEnd},
+	}
+}
+
+func validEdges() []Edge {
+	return []Edge{
+		{ID: "e1", Source: "start", Target: "llm1"},
+		{ID: "e2", Source: "llm1", Target: "end"},
+	}
+}
+
+func TestNewGraph_Valid(t *testing.T) {
+	g, err := NewGraph("asst-1", "my-graph", "1.0.0", "A test graph", validNodes(), validEdges(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.ID() == "" {
+		t.Error("ID should not be empty")
+	}
+	if g.AssistantID() != "asst-1" {
+		t.Errorf("expected assistant_id=asst-1, got %s", g.AssistantID())
+	}
+	if g.Name() != "my-graph" {
+		t.Errorf("expected name=my-graph, got %s", g.Name())
+	}
+	if g.Version() != "1.0.0" {
+		t.Errorf("expected version=1.0.0, got %s", g.Version())
+	}
+	if g.Description() != "A test graph" {
+		t.Errorf("expected description='A test graph', got %s", g.Description())
+	}
+	if len(g.Nodes()) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(g.Nodes()))
+	}
+	if len(g.Edges()) != 2 {
+		t.Errorf("expected 2 edges, got %d", len(g.Edges()))
+	}
+	if g.Config() == nil {
+		t.Error("config should be initialized to non-nil map")
+	}
+	if g.CreatedAt().IsZero() {
+		t.Error("createdAt should be set")
+	}
+	if g.UpdatedAt().IsZero() {
+		t.Error("updatedAt should be set")
+	}
+}
+
+func TestNewGraph_DefaultVersion(t *testing.T) {
+	g, err := NewGraph("asst-1", "g", "", "desc", validNodes(), validEdges(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Version() != "1.0.0" {
+		t.Errorf("expected default version 1.0.0, got %s", g.Version())
+	}
+}
+
+func TestNewGraph_EmitsGraphDefinedEvent(t *testing.T) {
+	g, err := NewGraph("asst-1", "g", "1.0.0", "desc", validNodes(), validEdges(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	events := g.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	gd, ok := events[0].(GraphDefined)
+	if !ok {
+		t.Fatalf("expected GraphDefined event, got %T", events[0])
+	}
+	if gd.GraphID != g.ID() {
+		t.Error("event GraphID should match graph ID")
+	}
+	if gd.AssistantID != "asst-1" {
+		t.Error("event AssistantID should match")
+	}
+	if gd.EventType() != EventTypeGraphDefined {
+		t.Errorf("expected event type %s, got %s", EventTypeGraphDefined, gd.EventType())
+	}
+	if gd.AggregateType() != "graph" {
+		t.Errorf("expected aggregate type graph, got %s", gd.AggregateType())
+	}
+}
+
+func TestNewGraph_MissingAssistantID(t *testing.T) {
+	_, err := NewGraph("", "g", "1.0.0", "desc", validNodes(), validEdges(), nil)
+	if err == nil {
+		t.Fatal("expected error for missing assistant_id")
+	}
+}
+
+func TestNewGraph_MissingName(t *testing.T) {
+	_, err := NewGraph("asst-1", "", "1.0.0", "desc", validNodes(), validEdges(), nil)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestNewGraph_NoNodes(t *testing.T) {
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", []Node{}, validEdges(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty nodes")
+	}
+}
+
+func TestNewGraph_NoStartNode(t *testing.T) {
+	nodes := []Node{
+		{ID: "llm1", Type: NodeTypeLLM},
+		{ID: "end", Type: NodeTypeEnd},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", nodes, []Edge{{ID: "e1", Source: "llm1", Target: "end"}}, nil)
+	if err == nil {
+		t.Fatal("expected error for missing start node")
+	}
+}
+
+func TestNewGraph_NoEndNode(t *testing.T) {
+	nodes := []Node{
+		{ID: "start", Type: NodeTypeStart},
+		{ID: "llm1", Type: NodeTypeLLM},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", nodes, []Edge{{ID: "e1", Source: "start", Target: "llm1"}}, nil)
+	if err == nil {
+		t.Fatal("expected error for missing end node")
+	}
+}
+
+func TestNewGraph_DuplicateNodeID(t *testing.T) {
+	nodes := []Node{
+		{ID: "start", Type: NodeTypeStart},
+		{ID: "start", Type: NodeTypeEnd},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", nodes, []Edge{}, nil)
+	if err == nil {
+		t.Fatal("expected error for duplicate node ID")
+	}
+}
+
+func TestNewGraph_EmptyNodeID(t *testing.T) {
+	nodes := []Node{
+		{ID: "", Type: NodeTypeStart},
+		{ID: "end", Type: NodeTypeEnd},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", nodes, []Edge{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty node ID")
+	}
+}
+
+func TestNewGraph_EdgeSourceNotFound(t *testing.T) {
+	edges := []Edge{
+		{ID: "e1", Source: "nonexistent", Target: "end"},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", validNodes(), edges, nil)
+	if err == nil {
+		t.Fatal("expected error for edge with unknown source")
+	}
+}
+
+func TestNewGraph_EdgeTargetNotFound(t *testing.T) {
+	edges := []Edge{
+		{ID: "e1", Source: "start", Target: "nonexistent"},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", validNodes(), edges, nil)
+	if err == nil {
+		t.Fatal("expected error for edge with unknown target")
+	}
+}
+
+func TestNewGraph_EdgeMissingSourceOrTarget(t *testing.T) {
+	edges := []Edge{
+		{ID: "e1", Source: "", Target: "end"},
+	}
+	_, err := NewGraph("asst-1", "g", "1.0.0", "desc", validNodes(), edges, nil)
+	if err == nil {
+		t.Fatal("expected error for edge with empty source")
+	}
+
+	edges2 := []Edge{
+		{ID: "e1", Source: "start", Target: ""},
+	}
+	_, err = NewGraph("asst-1", "g", "1.0.0", "desc", validNodes(), edges2, nil)
+	if err == nil {
+		t.Fatal("expected error for edge with empty target")
+	}
+}
+
+func TestGraph_Update(t *testing.T) {
+	g, _ := NewGraph("asst-1", "original", "1.0.0", "desc", validNodes(), validEdges(), nil)
+	g.ClearEvents()
+
+	newName := "updated"
+	newDesc := "new desc"
+	err := g.Update(&newName, &newDesc, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Name() != "updated" {
+		t.Errorf("expected name=updated, got %s", g.Name())
+	}
+	if g.Description() != "new desc" {
+		t.Errorf("expected description='new desc', got %s", g.Description())
+	}
+
+	events := g.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	gu, ok := events[0].(GraphUpdated)
+	if !ok {
+		t.Fatalf("expected GraphUpdated, got %T", events[0])
+	}
+	if gu.EventType() != EventTypeGraphUpdated {
+		t.Error("wrong event type")
+	}
+}
+
+func TestGraph_UpdateWithNewNodes(t *testing.T) {
+	g, _ := NewGraph("asst-1", "g", "1.0.0", "d", validNodes(), validEdges(), nil)
+	g.ClearEvents()
+
+	newNodes := []Node{
+		{ID: "start", Type: NodeTypeStart},
+		{ID: "tool1", Type: NodeTypeTool},
+		{ID: "end", Type: NodeTypeEnd},
+	}
+	newEdges := []Edge{
+		{ID: "e1", Source: "start", Target: "tool1"},
+		{ID: "e2", Source: "tool1", Target: "end"},
+	}
+
+	err := g.Update(nil, nil, newNodes, newEdges, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.Nodes()) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(g.Nodes()))
+	}
+	if g.Nodes()[1].Type != NodeTypeTool {
+		t.Error("second node should be tool type")
+	}
+}
+
+func TestGraph_UpdateWithInvalidNodes(t *testing.T) {
+	g, _ := NewGraph("asst-1", "g", "1.0.0", "d", validNodes(), validEdges(), nil)
+
+	badNodes := []Node{{ID: "only-llm", Type: NodeTypeLLM}}
+	badEdges := []Edge{}
+	err := g.Update(nil, nil, badNodes, badEdges, nil)
+	if err == nil {
+		t.Fatal("expected validation error for invalid graph update")
+	}
+}
+
+func TestGraph_ClearEvents(t *testing.T) {
+	g, _ := NewGraph("asst-1", "g", "1.0.0", "d", validNodes(), validEdges(), nil)
+	if len(g.Events()) == 0 {
+		t.Fatal("should have events after creation")
+	}
+	g.ClearEvents()
+	if len(g.Events()) != 0 {
+		t.Error("events should be empty after ClearEvents")
+	}
+}
+
+func TestNodeTypes(t *testing.T) {
+	types := map[NodeType]string{
+		NodeTypeStart:     "start",
+		NodeTypeLLM:       "llm",
+		NodeTypeTool:      "tool",
+		NodeTypeCondition: "condition",
+		NodeTypeEnd:       "end",
+		NodeTypeSubgraph:  "subgraph",
+		NodeTypeHuman:     "human",
+	}
+	for nt, expected := range types {
+		if string(nt) != expected {
+			t.Errorf("NodeType %s expected %s", nt, expected)
+		}
+	}
+}
+
+func TestGraph_AllNodeTypes(t *testing.T) {
+	nodes := []Node{
+		{ID: "start", Type: NodeTypeStart},
+		{ID: "llm", Type: NodeTypeLLM},
+		{ID: "tool", Type: NodeTypeTool},
+		{ID: "cond", Type: NodeTypeCondition},
+		{ID: "human", Type: NodeTypeHuman},
+		{ID: "sub", Type: NodeTypeSubgraph},
+		{ID: "end", Type: NodeTypeEnd},
+	}
+	edges := []Edge{
+		{ID: "e1", Source: "start", Target: "llm"},
+		{ID: "e2", Source: "llm", Target: "tool"},
+		{ID: "e3", Source: "tool", Target: "cond"},
+		{ID: "e4", Source: "cond", Target: "human"},
+		{ID: "e5", Source: "human", Target: "sub"},
+		{ID: "e6", Source: "sub", Target: "end"},
+	}
+
+	g, err := NewGraph("asst-1", "full", "1.0.0", "all types", nodes, edges, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.Nodes()) != 7 {
+		t.Errorf("expected 7 nodes, got %d", len(g.Nodes()))
+	}
+}

--- a/internal/domain/workflow/helpers_test.go
+++ b/internal/domain/workflow/helpers_test.go
@@ -1,0 +1,7 @@
+package workflow
+
+import "time"
+
+func th_now() time.Time {
+	return time.Now()
+}

--- a/internal/domain/workflow/thread_test.go
+++ b/internal/domain/workflow/thread_test.go
@@ -1,0 +1,239 @@
+package workflow
+
+import (
+	"testing"
+)
+
+func TestNewThread_Valid(t *testing.T) {
+	th, err := NewThread(map[string]interface{}{"key": "value"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if th.ID() == "" {
+		t.Error("ID should not be empty")
+	}
+	if len(th.Messages()) != 0 {
+		t.Error("new thread should have no messages")
+	}
+	if th.Metadata()["key"] != "value" {
+		t.Error("metadata not set")
+	}
+	if th.CreatedAt().IsZero() || th.UpdatedAt().IsZero() {
+		t.Error("timestamps should be set")
+	}
+}
+
+func TestNewThread_NilMetadata(t *testing.T) {
+	th, err := NewThread(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if th.Metadata() == nil {
+		t.Error("nil metadata should be initialized to empty map")
+	}
+}
+
+func TestNewThread_EmitsEvent(t *testing.T) {
+	th, _ := NewThread(nil)
+	events := th.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	tc, ok := events[0].(ThreadCreated)
+	if !ok {
+		t.Fatalf("expected ThreadCreated, got %T", events[0])
+	}
+	if tc.ThreadID != th.ID() {
+		t.Error("event thread ID should match")
+	}
+	if tc.EventType() != EventTypeThreadCreated {
+		t.Error("wrong event type")
+	}
+	if tc.AggregateType() != "thread" {
+		t.Error("wrong aggregate type")
+	}
+}
+
+func TestThread_AddMessage_Valid(t *testing.T) {
+	th, _ := NewThread(nil)
+	th.ClearEvents()
+
+	msg, err := th.AddMessage("user", "hello world", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.ID == "" {
+		t.Error("message ID should not be empty")
+	}
+	if msg.Role != "user" {
+		t.Error("wrong role")
+	}
+	if msg.Content != "hello world" {
+		t.Error("wrong content")
+	}
+	if msg.Metadata == nil {
+		t.Error("nil metadata should be initialized")
+	}
+	if msg.CreatedAt.IsZero() {
+		t.Error("created_at should be set")
+	}
+	if len(th.Messages()) != 1 {
+		t.Errorf("expected 1 message, got %d", len(th.Messages()))
+	}
+}
+
+func TestThread_AddMessage_AllRoles(t *testing.T) {
+	roles := []string{"user", "assistant", "system"}
+	for _, role := range roles {
+		th, _ := NewThread(nil)
+		_, err := th.AddMessage(role, "content", nil)
+		if err != nil {
+			t.Errorf("AddMessage(%s) should not error: %v", role, err)
+		}
+	}
+}
+
+func TestThread_AddMessage_InvalidRole(t *testing.T) {
+	th, _ := NewThread(nil)
+	_, err := th.AddMessage("admin", "content", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid role")
+	}
+}
+
+func TestThread_AddMessage_EmptyRole(t *testing.T) {
+	th, _ := NewThread(nil)
+	_, err := th.AddMessage("", "content", nil)
+	if err == nil {
+		t.Fatal("expected error for empty role")
+	}
+}
+
+func TestThread_AddMessage_EmptyContent(t *testing.T) {
+	th, _ := NewThread(nil)
+	_, err := th.AddMessage("user", "", nil)
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+}
+
+func TestThread_AddMessage_EmitsEvent(t *testing.T) {
+	th, _ := NewThread(nil)
+	th.ClearEvents()
+
+	_, _ = th.AddMessage("user", "hello", map[string]interface{}{"source": "test"})
+
+	events := th.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ma, ok := events[0].(MessageAdded)
+	if !ok {
+		t.Fatalf("expected MessageAdded, got %T", events[0])
+	}
+	if ma.ThreadID != th.ID() {
+		t.Error("wrong thread ID")
+	}
+	if ma.Role != "user" {
+		t.Error("wrong role")
+	}
+	if ma.Content != "hello" {
+		t.Error("wrong content")
+	}
+	if ma.EventType() != EventTypeMessageAdded {
+		t.Error("wrong event type")
+	}
+	if ma.AggregateType() != "thread" {
+		t.Error("wrong aggregate type")
+	}
+}
+
+func TestThread_AddMultipleMessages(t *testing.T) {
+	th, _ := NewThread(nil)
+	_, _ = th.AddMessage("user", "hello", nil)
+	_, _ = th.AddMessage("assistant", "hi there", nil)
+	_, _ = th.AddMessage("user", "thanks", nil)
+
+	if len(th.Messages()) != 3 {
+		t.Errorf("expected 3 messages, got %d", len(th.Messages()))
+	}
+	if th.Messages()[0].Role != "user" {
+		t.Error("first message should be user")
+	}
+	if th.Messages()[1].Role != "assistant" {
+		t.Error("second message should be assistant")
+	}
+}
+
+func TestThread_UpdateMetadata(t *testing.T) {
+	th, _ := NewThread(map[string]interface{}{"old": true})
+	th.ClearEvents()
+
+	err := th.UpdateMetadata(map[string]interface{}{"new": true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if th.Metadata()["new"] != true {
+		t.Error("metadata not updated")
+	}
+	if _, exists := th.Metadata()["old"]; exists {
+		t.Error("old metadata should be replaced")
+	}
+
+	events := th.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	tu, ok := events[0].(ThreadUpdated)
+	if !ok {
+		t.Fatalf("expected ThreadUpdated, got %T", events[0])
+	}
+	if tu.EventType() != EventTypeThreadUpdated {
+		t.Error("wrong event type")
+	}
+}
+
+func TestReconstructThread(t *testing.T) {
+	th, _ := NewThread(nil)
+	_, _ = th.AddMessage("user", "hello", nil)
+
+	reconstructed, err := ReconstructThread(
+		th.ID(), th.Messages(), th.Metadata(), th.CreatedAt(), th.UpdatedAt(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reconstructed.ID() != th.ID() {
+		t.Error("ID mismatch")
+	}
+	if len(reconstructed.Messages()) != 1 {
+		t.Error("messages not reconstructed")
+	}
+	if len(reconstructed.Events()) != 0 {
+		t.Error("reconstructed should have no uncommitted events")
+	}
+}
+
+func TestReconstructThread_NilFields(t *testing.T) {
+	th, err := ReconstructThread("id-1", nil, nil, th_now(), th_now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if th.Messages() == nil {
+		t.Error("nil messages should be initialized")
+	}
+	if th.Metadata() == nil {
+		t.Error("nil metadata should be initialized")
+	}
+}
+
+func TestThread_ClearEvents(t *testing.T) {
+	th, _ := NewThread(nil)
+	if len(th.Events()) == 0 {
+		t.Fatal("should have events after creation")
+	}
+	th.ClearEvents()
+	if len(th.Events()) != 0 {
+		t.Error("events should be empty")
+	}
+}

--- a/internal/pkg/errors/errors_test.go
+++ b/internal/pkg/errors/errors_test.go
@@ -1,0 +1,216 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestSentinelErrors(t *testing.T) {
+	sentinels := []struct {
+		err  error
+		text string
+	}{
+		{ErrNotFound, "resource not found"},
+		{ErrAlreadyExists, "resource already exists"},
+		{ErrInvalidInput, "invalid input"},
+		{ErrInvalidState, "invalid state"},
+		{ErrConcurrency, "concurrency conflict"},
+		{ErrUnauthorized, "unauthorized"},
+		{ErrForbidden, "forbidden"},
+		{ErrInternal, "internal error"},
+		{ErrTimeout, "operation timeout"},
+		{ErrGraphCycle, "cycle detected in graph"},
+		{ErrMaxIterations, "max iterations exceeded"},
+	}
+
+	for _, tc := range sentinels {
+		t.Run(tc.text, func(t *testing.T) {
+			if tc.err.Error() != tc.text {
+				t.Errorf("expected %q, got %q", tc.text, tc.err.Error())
+			}
+		})
+	}
+}
+
+func TestDomainError_Error(t *testing.T) {
+	t.Run("with wrapped error", func(t *testing.T) {
+		de := NewDomainError("TEST_CODE", "test message", fmt.Errorf("root cause"))
+		want := "TEST_CODE: test message: root cause"
+		if de.Error() != want {
+			t.Errorf("expected %q, got %q", want, de.Error())
+		}
+	})
+
+	t.Run("without wrapped error", func(t *testing.T) {
+		de := NewDomainError("TEST_CODE", "test message", nil)
+		want := "TEST_CODE: test message"
+		if de.Error() != want {
+			t.Errorf("expected %q, got %q", want, de.Error())
+		}
+	})
+}
+
+func TestDomainError_Unwrap(t *testing.T) {
+	root := fmt.Errorf("root")
+	de := NewDomainError("CODE", "msg", root)
+
+	if de.Unwrap() != root {
+		t.Error("Unwrap should return the wrapped error")
+	}
+
+	deNil := NewDomainError("CODE", "msg", nil)
+	if deNil.Unwrap() != nil {
+		t.Error("Unwrap should return nil when no wrapped error")
+	}
+}
+
+func TestDomainError_WithDetails(t *testing.T) {
+	de := NewDomainError("CODE", "msg", nil)
+	if len(de.Details) != 0 {
+		t.Fatalf("expected empty details, got %d", len(de.Details))
+	}
+
+	result := de.WithDetails("key1", "val1").WithDetails("key2", 42)
+	if result != de {
+		t.Error("WithDetails should return the same pointer for chaining")
+	}
+	if de.Details["key1"] != "val1" {
+		t.Error("expected key1=val1")
+	}
+	if de.Details["key2"] != 42 {
+		t.Error("expected key2=42")
+	}
+}
+
+func TestNewDomainError(t *testing.T) {
+	de := NewDomainError("MY_CODE", "my message", ErrNotFound)
+	if de.Code != "MY_CODE" {
+		t.Errorf("expected code MY_CODE, got %s", de.Code)
+	}
+	if de.Message != "my message" {
+		t.Errorf("expected message 'my message', got %s", de.Message)
+	}
+	if de.Err != ErrNotFound {
+		t.Error("expected Err to be ErrNotFound")
+	}
+	if de.Details == nil {
+		t.Error("Details should be initialized to non-nil map")
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	de := NotFound("assistant", "abc-123")
+	if de.Code != "NOT_FOUND" {
+		t.Errorf("expected code NOT_FOUND, got %s", de.Code)
+	}
+	if !errors.Is(de, ErrNotFound) {
+		t.Error("NotFound should wrap ErrNotFound")
+	}
+	if de.Details["resource"] != "assistant" {
+		t.Error("expected resource=assistant in details")
+	}
+	if de.Details["id"] != "abc-123" {
+		t.Error("expected id=abc-123 in details")
+	}
+}
+
+func TestAlreadyExists(t *testing.T) {
+	de := AlreadyExists("thread", "xyz-789")
+	if de.Code != "ALREADY_EXISTS" {
+		t.Errorf("expected code ALREADY_EXISTS, got %s", de.Code)
+	}
+	if !errors.Is(de, ErrAlreadyExists) {
+		t.Error("AlreadyExists should wrap ErrAlreadyExists")
+	}
+	if de.Details["resource"] != "thread" {
+		t.Error("expected resource=thread")
+	}
+	if de.Details["id"] != "xyz-789" {
+		t.Error("expected id=xyz-789")
+	}
+}
+
+func TestInvalidInput(t *testing.T) {
+	de := InvalidInput("email", "must contain @")
+	if de.Code != "INVALID_INPUT" {
+		t.Errorf("expected code INVALID_INPUT, got %s", de.Code)
+	}
+	if !errors.Is(de, ErrInvalidInput) {
+		t.Error("InvalidInput should wrap ErrInvalidInput")
+	}
+	if de.Details["field"] != "email" {
+		t.Error("expected field=email")
+	}
+	if de.Details["reason"] != "must contain @" {
+		t.Error("expected reason='must contain @'")
+	}
+}
+
+func TestInvalidState(t *testing.T) {
+	de := InvalidState("queued", "complete")
+	if de.Code != "INVALID_STATE" {
+		t.Errorf("expected code INVALID_STATE, got %s", de.Code)
+	}
+	if !errors.Is(de, ErrInvalidState) {
+		t.Error("InvalidState should wrap ErrInvalidState")
+	}
+	if de.Details["current_state"] != "queued" {
+		t.Error("expected current_state=queued")
+	}
+	if de.Details["attempted_operation"] != "complete" {
+		t.Error("expected attempted_operation=complete")
+	}
+}
+
+func TestInternal(t *testing.T) {
+	root := fmt.Errorf("db connection failed")
+	de := Internal("database error", root)
+	if de.Code != "INTERNAL_ERROR" {
+		t.Errorf("expected code INTERNAL_ERROR, got %s", de.Code)
+	}
+	if de.Err != root {
+		t.Error("Internal should wrap the provided error")
+	}
+}
+
+func TestIs(t *testing.T) {
+	de := NotFound("x", "1")
+	if !Is(de, ErrNotFound) {
+		t.Error("Is should find ErrNotFound in chain")
+	}
+	if Is(de, ErrAlreadyExists) {
+		t.Error("Is should not match ErrAlreadyExists")
+	}
+}
+
+func TestAs(t *testing.T) {
+	de := NotFound("x", "1")
+	var target *DomainError
+	if !As(de, &target) {
+		t.Error("As should find DomainError in chain")
+	}
+	if target.Code != "NOT_FOUND" {
+		t.Errorf("expected NOT_FOUND, got %s", target.Code)
+	}
+
+	plain := fmt.Errorf("plain error")
+	var target2 *DomainError
+	if As(plain, &target2) {
+		t.Error("As should not find DomainError in a plain error")
+	}
+}
+
+func TestErrorsIs_WithWrappedDomainError(t *testing.T) {
+	de := NotFound("run", "abc")
+	wrapped := fmt.Errorf("outer: %w", de)
+
+	if !errors.Is(wrapped, ErrNotFound) {
+		t.Error("errors.Is should traverse through wrapped DomainError")
+	}
+
+	var target *DomainError
+	if !errors.As(wrapped, &target) {
+		t.Error("errors.As should find DomainError through wrapping")
+	}
+}

--- a/internal/pkg/eventbus/eventbus_test.go
+++ b/internal/pkg/eventbus/eventbus_test.go
@@ -1,0 +1,246 @@
+package eventbus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testEvent struct {
+	eventType     string
+	aggregateID   string
+	aggregateType string
+}
+
+func (e testEvent) EventType() string     { return e.eventType }
+func (e testEvent) AggregateID() string   { return e.aggregateID }
+func (e testEvent) AggregateType() string { return e.aggregateType }
+
+func TestNew(t *testing.T) {
+	bus := New()
+	if bus == nil {
+		t.Fatal("New() should return a non-nil EventBus")
+	}
+	if bus.handlers == nil {
+		t.Fatal("handlers map should be initialized")
+	}
+}
+
+func TestSubscribeAndPublish(t *testing.T) {
+	bus := New()
+	var received bool
+
+	bus.Subscribe("test.event", func(ctx context.Context, event Event) error {
+		received = true
+		if event.EventType() != "test.event" {
+			t.Errorf("expected event type test.event, got %s", event.EventType())
+		}
+		return nil
+	})
+
+	err := bus.Publish(context.Background(), testEvent{
+		eventType:     "test.event",
+		aggregateID:   "123",
+		aggregateType: "test",
+	})
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if !received {
+		t.Error("handler was not called")
+	}
+}
+
+func TestPublish_MultipleHandlers(t *testing.T) {
+	bus := New()
+	var count int32
+
+	for i := 0; i < 5; i++ {
+		bus.Subscribe("multi.event", func(ctx context.Context, event Event) error {
+			atomic.AddInt32(&count, 1)
+			return nil
+		})
+	}
+
+	err := bus.Publish(context.Background(), testEvent{eventType: "multi.event", aggregateID: "1", aggregateType: "t"})
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if atomic.LoadInt32(&count) != 5 {
+		t.Errorf("expected 5 handlers called, got %d", count)
+	}
+}
+
+func TestPublish_NoHandlers(t *testing.T) {
+	bus := New()
+	err := bus.Publish(context.Background(), testEvent{eventType: "no.handlers", aggregateID: "1", aggregateType: "t"})
+	if err != nil {
+		t.Errorf("Publish with no handlers should not error, got: %v", err)
+	}
+}
+
+func TestPublish_HandlerError(t *testing.T) {
+	bus := New()
+	bus.Subscribe("err.event", func(ctx context.Context, event Event) error {
+		return fmt.Errorf("handler failed")
+	})
+
+	err := bus.Publish(context.Background(), testEvent{eventType: "err.event", aggregateID: "1", aggregateType: "t"})
+	if err == nil {
+		t.Error("Publish should return error when handler fails")
+	}
+}
+
+func TestPublishSync(t *testing.T) {
+	bus := New()
+	order := make([]int, 0, 3)
+	var mu sync.Mutex
+
+	for i := 0; i < 3; i++ {
+		idx := i
+		bus.Subscribe("sync.event", func(ctx context.Context, event Event) error {
+			mu.Lock()
+			defer mu.Unlock()
+			order = append(order, idx)
+			return nil
+		})
+	}
+
+	err := bus.PublishSync(context.Background(), testEvent{eventType: "sync.event", aggregateID: "1", aggregateType: "t"})
+	if err != nil {
+		t.Fatalf("PublishSync returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 3 {
+		t.Fatalf("expected 3 handlers called, got %d", len(order))
+	}
+	for i, v := range order {
+		if v != i {
+			t.Errorf("expected sequential order, at index %d got %d", i, v)
+		}
+	}
+}
+
+func TestPublishSync_HandlerError_StopsEarly(t *testing.T) {
+	bus := New()
+	var count int32
+
+	bus.Subscribe("sync.err", func(ctx context.Context, event Event) error {
+		atomic.AddInt32(&count, 1)
+		return fmt.Errorf("fail")
+	})
+	bus.Subscribe("sync.err", func(ctx context.Context, event Event) error {
+		atomic.AddInt32(&count, 1)
+		return nil
+	})
+
+	err := bus.PublishSync(context.Background(), testEvent{eventType: "sync.err", aggregateID: "1", aggregateType: "t"})
+	if err == nil {
+		t.Error("PublishSync should return error when handler fails")
+	}
+	if atomic.LoadInt32(&count) != 1 {
+		t.Errorf("expected 1 handler called (early stop), got %d", count)
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	bus := New()
+	var called bool
+
+	bus.Subscribe("unsub.event", func(ctx context.Context, event Event) error {
+		called = true
+		return nil
+	})
+	bus.Unsubscribe("unsub.event")
+
+	err := bus.Publish(context.Background(), testEvent{eventType: "unsub.event", aggregateID: "1", aggregateType: "t"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("handler should not be called after Unsubscribe")
+	}
+}
+
+func TestClear(t *testing.T) {
+	bus := New()
+	var count int32
+
+	bus.Subscribe("a", func(ctx context.Context, event Event) error {
+		atomic.AddInt32(&count, 1)
+		return nil
+	})
+	bus.Subscribe("b", func(ctx context.Context, event Event) error {
+		atomic.AddInt32(&count, 1)
+		return nil
+	})
+	bus.Clear()
+
+	_ = bus.Publish(context.Background(), testEvent{eventType: "a", aggregateID: "1", aggregateType: "t"})
+	_ = bus.Publish(context.Background(), testEvent{eventType: "b", aggregateID: "1", aggregateType: "t"})
+
+	if atomic.LoadInt32(&count) != 0 {
+		t.Errorf("expected 0 handlers called after Clear, got %d", count)
+	}
+}
+
+func TestConcurrentSubscribeAndPublish(t *testing.T) {
+	bus := New()
+	var count int64
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			bus.Subscribe("concurrent.event", func(ctx context.Context, event Event) error {
+				atomic.AddInt64(&count, 1)
+				return nil
+			})
+		}(i)
+	}
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Millisecond)
+			_ = bus.Publish(context.Background(), testEvent{eventType: "concurrent.event", aggregateID: "1", aggregateType: "t"})
+		}()
+	}
+
+	wg.Wait()
+
+	if atomic.LoadInt64(&count) == 0 {
+		t.Error("expected at least some handlers to be called")
+	}
+}
+
+func TestPublish_DifferentEventTypes(t *testing.T) {
+	bus := New()
+	var aCalled, bCalled bool
+
+	bus.Subscribe("type.a", func(ctx context.Context, event Event) error {
+		aCalled = true
+		return nil
+	})
+	bus.Subscribe("type.b", func(ctx context.Context, event Event) error {
+		bCalled = true
+		return nil
+	})
+
+	_ = bus.Publish(context.Background(), testEvent{eventType: "type.a", aggregateID: "1", aggregateType: "t"})
+
+	if !aCalled {
+		t.Error("type.a handler should have been called")
+	}
+	if bCalled {
+		t.Error("type.b handler should NOT have been called")
+	}
+}

--- a/internal/pkg/uuid/uuid_test.go
+++ b/internal/pkg/uuid/uuid_test.go
@@ -1,0 +1,118 @@
+package uuid
+
+import (
+	"regexp"
+	"testing"
+
+	goUUID "github.com/google/uuid"
+)
+
+var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestNew(t *testing.T) {
+	id := New()
+	if id == "" {
+		t.Fatal("New() should not return empty string")
+	}
+	if !uuidRegex.MatchString(id) {
+		t.Errorf("New() returned invalid UUID v4 format: %s", id)
+	}
+}
+
+func TestNew_Uniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		id := New()
+		if seen[id] {
+			t.Fatalf("duplicate UUID generated: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestParse_Valid(t *testing.T) {
+	original := New()
+	parsed, err := Parse(original)
+	if err != nil {
+		t.Fatalf("Parse failed on valid UUID: %v", err)
+	}
+	if parsed.String() != original {
+		t.Errorf("parsed UUID differs: got %s, want %s", parsed.String(), original)
+	}
+}
+
+func TestParse_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"not-a-uuid",
+		"12345",
+		"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+	}
+	for _, c := range cases {
+		_, err := Parse(c)
+		if err == nil {
+			t.Errorf("Parse(%q) should return error", c)
+		}
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	if !IsValid(New()) {
+		t.Error("IsValid should return true for a valid UUID")
+	}
+	if IsValid("") {
+		t.Error("IsValid should return false for empty string")
+	}
+	if IsValid("garbage") {
+		t.Error("IsValid should return false for garbage input")
+	}
+	if IsValid("not-even-close-to-uuid") {
+		t.Error("IsValid should return false for non-UUID format")
+	}
+}
+
+func TestMustParse(t *testing.T) {
+	valid := New()
+	parsed := MustParse(valid)
+	if parsed.String() != valid {
+		t.Errorf("MustParse returned wrong value")
+	}
+}
+
+func TestMustParse_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustParse should panic on invalid input")
+		}
+	}()
+	MustParse("not-a-uuid")
+}
+
+func TestNewUUID(t *testing.T) {
+	u := NewUUID()
+	if u == goUUID.Nil {
+		t.Error("NewUUID should not return nil UUID")
+	}
+	if u.Version() != 4 {
+		t.Errorf("expected UUID v4, got v%d", u.Version())
+	}
+}
+
+func TestNil(t *testing.T) {
+	n := Nil()
+	if n != goUUID.Nil {
+		t.Error("Nil() should return the nil UUID")
+	}
+	if n.String() != "00000000-0000-0000-0000-000000000000" {
+		t.Error("Nil UUID should be all zeros")
+	}
+}
+
+func TestIsNil(t *testing.T) {
+	if !IsNil(Nil()) {
+		t.Error("IsNil should return true for nil UUID")
+	}
+	if IsNil(NewUUID()) {
+		t.Error("IsNil should return false for non-nil UUID")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds comprehensive unit tests for all pure domain packages and pkg utilities
- Zero external dependencies required — all tests run with `go test -short`

## Coverage changes

| Package | Before | After |
|---------|--------|-------|
| `pkg/errors` | 0% | **100%** |
| `pkg/eventbus` | 0% | **100%** |
| `pkg/uuid` | 0% | **100%** |
| `domain/workflow` | 0% | **92.8%** |
| `domain/execution` | 0% | **99.1%** |
| `domain/checkpoint` | 0% | **100%** |
| `domain/humanloop` | 0% | **100%** |

Tested packages: **9 → 16** of 30.

## What's tested

- **pkg/errors**: DomainError creation, wrapping, code extraction, Is/As chain traversal, all helper constructors (NotFound, AlreadyExists, InvalidInput, InvalidState, Internal)
- **pkg/eventbus**: Subscribe, Publish (async), PublishSync, Unsubscribe, Clear, concurrent access safety, error propagation, event type isolation
- **pkg/uuid**: Generation, format validation, uniqueness (1000 UUIDs), Parse/MustParse, Nil/IsNil
- **domain/workflow**: Graph creation/validation (start/end nodes, duplicate IDs, edge validation), Assistant CRUD + partial update + delete + reconstruction, Thread creation + message handling (all roles) + metadata update, event emission for all aggregates
- **domain/execution**: ExecutionState lifecycle (start/complete/global state), streaming callback, subgraph callback + depth enforcement, Clone/CloneForSubgraph with selective input, all 7 node executor types, event types
- **domain/checkpoint**: Checkpoint creation (auto-generated ID, explicit ID, parent), channel value set/get + version tracking, pending sends, Reconstitute from persisted data, CheckpointWrite
- **domain/humanloop**: Interrupt creation with tool calls, Resolve with tool outputs, double-resolve rejection, InterruptReason constants, event emission

## Test plan

- [x] `go test -short ./internal/domain/... ./internal/pkg/...`
- [x] No external dependencies required
- [x] All tests pass locally
- [x] Full suite `go test -short ./...` passes (no regressions)