### PR TITLE
test: phase 2 — application layer unit tests with mocks

### DIFF
--- a/internal/application/command/command_test.go
+++ b/internal/application/command/command_test.go
@@ -1,0 +1,576 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/domain/humanloop"
+	"github.com/duragraph/duragraph/internal/domain/run"
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/mocks"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+func TestCreateRunHandler_Success(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	handler := NewCreateRunHandler(repo)
+
+	id, err := handler.Handle(context.Background(), CreateRun{
+		ThreadID:    "thread-1",
+		AssistantID: "asst-1",
+		Input:       map[string]interface{}{"message": "hello"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty run ID")
+	}
+	if len(repo.Runs) != 1 {
+		t.Errorf("expected 1 run saved, got %d", len(repo.Runs))
+	}
+}
+
+func TestCreateRunHandler_WithOptions(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	handler := NewCreateRunHandler(repo)
+
+	id, err := handler.Handle(context.Background(), CreateRun{
+		ThreadID:          "thread-1",
+		AssistantID:       "asst-1",
+		Input:             map[string]interface{}{"message": "hello"},
+		Config:            map[string]interface{}{"recursion_limit": 10},
+		Metadata:          map[string]interface{}{"user": "test"},
+		MultitaskStrategy: "enqueue",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	saved := repo.Runs[id]
+	if saved.MultitaskStrategy() != "enqueue" {
+		t.Errorf("expected strategy=enqueue, got %s", saved.MultitaskStrategy())
+	}
+}
+
+func TestCreateRunHandler_MissingThreadID(t *testing.T) {
+	handler := NewCreateRunHandler(mocks.NewRunRepository())
+	_, err := handler.Handle(context.Background(), CreateRun{
+		AssistantID: "asst-1",
+		Input:       map[string]interface{}{},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing thread_id")
+	}
+}
+
+func TestCreateRunHandler_SaveError(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	repo.SaveFunc = func(ctx context.Context, r *run.Run) error {
+		return fmt.Errorf("db error")
+	}
+	handler := NewCreateRunHandler(repo)
+
+	_, err := handler.Handle(context.Background(), CreateRun{
+		ThreadID:    "thread-1",
+		AssistantID: "asst-1",
+		Input:       map[string]interface{}{},
+	})
+	if err == nil {
+		t.Fatal("expected error when save fails")
+	}
+}
+
+func TestDeleteRunHandler_Success(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	r, _ := run.NewRun("t1", "a1", nil)
+	_ = r.Start()
+	_ = r.Complete(map[string]interface{}{"done": true})
+	repo.Runs[r.ID()] = r
+
+	handler := NewDeleteRunHandler(repo)
+	err := handler.Handle(context.Background(), DeleteRunCommand{RunID: r.ID()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.Runs) != 0 {
+		t.Error("run should be deleted")
+	}
+}
+
+func TestDeleteRunHandler_NonTerminalState(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	r, _ := run.NewRun("t1", "a1", nil)
+	repo.Runs[r.ID()] = r
+
+	handler := NewDeleteRunHandler(repo)
+	err := handler.Handle(context.Background(), DeleteRunCommand{RunID: r.ID()})
+	if err == nil {
+		t.Fatal("expected error for non-terminal run")
+	}
+	if !errors.Is(err, errors.ErrInvalidState) {
+		t.Error("should be InvalidState error")
+	}
+}
+
+func TestDeleteRunHandler_NotFound(t *testing.T) {
+	handler := NewDeleteRunHandler(mocks.NewRunRepository())
+	err := handler.Handle(context.Background(), DeleteRunCommand{RunID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for missing run")
+	}
+}
+
+func TestCreateAssistantHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	handler := NewCreateAssistantHandler(repo)
+
+	id, err := handler.Handle(context.Background(), CreateAssistant{
+		Name:         "my-bot",
+		Description:  "A helpful bot",
+		Model:        "gpt-4",
+		Instructions: "Be helpful",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty assistant ID")
+	}
+	if len(repo.Assistants) != 1 {
+		t.Error("expected 1 assistant saved")
+	}
+}
+
+func TestCreateAssistantHandler_MissingName(t *testing.T) {
+	handler := NewCreateAssistantHandler(mocks.NewAssistantRepository())
+	_, err := handler.Handle(context.Background(), CreateAssistant{
+		Model: "gpt-4",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestCreateAssistantHandler_SaveError(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	repo.SaveFunc = func(ctx context.Context, a *workflow.Assistant) error {
+		return fmt.Errorf("db error")
+	}
+	handler := NewCreateAssistantHandler(repo)
+
+	_, err := handler.Handle(context.Background(), CreateAssistant{Name: "bot"})
+	if err == nil {
+		t.Fatal("expected error when save fails")
+	}
+}
+
+func TestUpdateAssistantHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	a, _ := workflow.NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	repo.Assistants[a.ID()] = a
+
+	handler := NewUpdateAssistantHandler(repo)
+	newName := "updated-bot"
+	err := handler.Handle(context.Background(), UpdateAssistantCommand{
+		AssistantID: a.ID(),
+		Name:        &newName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.Assistants[a.ID()].Name() != "updated-bot" {
+		t.Error("name not updated")
+	}
+}
+
+func TestUpdateAssistantHandler_NotFound(t *testing.T) {
+	handler := NewUpdateAssistantHandler(mocks.NewAssistantRepository())
+	name := "x"
+	err := handler.Handle(context.Background(), UpdateAssistantCommand{
+		AssistantID: "nonexistent",
+		Name:        &name,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing assistant")
+	}
+}
+
+func TestDeleteAssistantHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	a, _ := workflow.NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
+	repo.Assistants[a.ID()] = a
+
+	handler := NewDeleteAssistantHandler(repo)
+	err := handler.Handle(context.Background(), DeleteAssistantCommand{AssistantID: a.ID()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.Assistants) != 0 {
+		t.Error("assistant should be deleted")
+	}
+}
+
+func TestDeleteAssistantHandler_NotFound(t *testing.T) {
+	handler := NewDeleteAssistantHandler(mocks.NewAssistantRepository())
+	err := handler.Handle(context.Background(), DeleteAssistantCommand{AssistantID: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing assistant")
+	}
+}
+
+func TestCreateThreadHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	handler := NewCreateThreadHandler(repo)
+
+	id, err := handler.Handle(context.Background(), CreateThread{
+		Metadata: map[string]interface{}{"key": "value"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty thread ID")
+	}
+	if len(repo.Threads) != 1 {
+		t.Error("expected 1 thread saved")
+	}
+}
+
+func TestCreateThreadHandler_SaveError(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	repo.SaveFunc = func(ctx context.Context, t *workflow.Thread) error {
+		return fmt.Errorf("db error")
+	}
+	handler := NewCreateThreadHandler(repo)
+
+	_, err := handler.Handle(context.Background(), CreateThread{})
+	if err == nil {
+		t.Fatal("expected error when save fails")
+	}
+}
+
+func TestUpdateThreadHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	th, _ := workflow.NewThread(map[string]interface{}{"old": true})
+	repo.Threads[th.ID()] = th
+
+	handler := NewUpdateThreadHandler(repo)
+	err := handler.Handle(context.Background(), UpdateThreadCommand{
+		ThreadID: th.ID(),
+		Metadata: map[string]interface{}{"new": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateThreadHandler_NotFound(t *testing.T) {
+	handler := NewUpdateThreadHandler(mocks.NewThreadRepository())
+	err := handler.Handle(context.Background(), UpdateThreadCommand{ThreadID: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing thread")
+	}
+}
+
+func TestDeleteThreadHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	th, _ := workflow.NewThread(nil)
+	repo.Threads[th.ID()] = th
+
+	handler := NewDeleteThreadHandler(repo)
+	err := handler.Handle(context.Background(), DeleteThreadCommand{ThreadID: th.ID()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.Threads) != 0 {
+		t.Error("thread should be deleted")
+	}
+}
+
+func TestAddMessageHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	th, _ := workflow.NewThread(nil)
+	repo.Threads[th.ID()] = th
+
+	handler := NewAddMessageHandler(repo)
+	msg, err := handler.Handle(context.Background(), AddMessageCommand{
+		ThreadID: th.ID(),
+		Role:     "user",
+		Content:  "hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Role != "user" {
+		t.Error("wrong role")
+	}
+	if msg.Content != "hello" {
+		t.Error("wrong content")
+	}
+}
+
+func TestAddMessageHandler_ThreadNotFound(t *testing.T) {
+	handler := NewAddMessageHandler(mocks.NewThreadRepository())
+	_, err := handler.Handle(context.Background(), AddMessageCommand{
+		ThreadID: "nonexistent",
+		Role:     "user",
+		Content:  "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing thread")
+	}
+}
+
+func TestAddMessageHandler_InvalidRole(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	th, _ := workflow.NewThread(nil)
+	repo.Threads[th.ID()] = th
+
+	handler := NewAddMessageHandler(repo)
+	_, err := handler.Handle(context.Background(), AddMessageCommand{
+		ThreadID: th.ID(),
+		Role:     "invalid",
+		Content:  "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid role")
+	}
+}
+
+func TestSubmitToolOutputsHandler_Success(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	intRepo := mocks.NewInterruptRepository()
+
+	r, _ := run.NewRun("t1", "a1", nil)
+	_ = r.Start()
+	_ = r.RequiresAction("int-1", "tool_call", nil)
+	runRepo.Runs[r.ID()] = r
+
+	interrupt, _ := humanloop.NewInterrupt(r.ID(), "node-1", humanloop.ReasonToolCall, nil, nil)
+	intRepo.Interrupts[interrupt.ID()] = interrupt
+
+	handler := NewSubmitToolOutputsHandler(runRepo, intRepo)
+	err := handler.Handle(context.Background(), SubmitToolOutputs{
+		RunID:       r.ID(),
+		ToolOutputs: []map[string]interface{}{{"tool_call_id": "c1", "output": "result"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runRepo.Runs[r.ID()].Status() != run.StatusInProgress {
+		t.Errorf("expected status in_progress, got %s", runRepo.Runs[r.ID()].Status())
+	}
+}
+
+func TestSubmitToolOutputsHandler_NotRequiresAction(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	intRepo := mocks.NewInterruptRepository()
+
+	r, _ := run.NewRun("t1", "a1", nil)
+	runRepo.Runs[r.ID()] = r
+
+	handler := NewSubmitToolOutputsHandler(runRepo, intRepo)
+	err := handler.Handle(context.Background(), SubmitToolOutputs{RunID: r.ID()})
+	if err == nil {
+		t.Fatal("expected error when run is not in requires_action state")
+	}
+}
+
+func TestSubmitToolOutputsHandler_NoInterrupts(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	intRepo := mocks.NewInterruptRepository()
+
+	r, _ := run.NewRun("t1", "a1", nil)
+	_ = r.Start()
+	_ = r.RequiresAction("int-1", "reason", nil)
+	runRepo.Runs[r.ID()] = r
+
+	handler := NewSubmitToolOutputsHandler(runRepo, intRepo)
+	err := handler.Handle(context.Background(), SubmitToolOutputs{RunID: r.ID()})
+	if err == nil {
+		t.Fatal("expected error when no unresolved interrupts")
+	}
+}
+
+func TestSubmitToolOutputsHandler_RunNotFound(t *testing.T) {
+	handler := NewSubmitToolOutputsHandler(mocks.NewRunRepository(), mocks.NewInterruptRepository())
+	err := handler.Handle(context.Background(), SubmitToolOutputs{RunID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for missing run")
+	}
+}
+
+func TestUpdateThreadStateHandler_FirstCheckpoint(t *testing.T) {
+	cpRepo := mocks.NewCheckpointRepository()
+	handler := NewUpdateThreadStateHandler(cpRepo)
+
+	cp, err := handler.Handle(context.Background(), UpdateThreadStateCommand{
+		ThreadID: "thread-1",
+		Values:   map[string]interface{}{"messages": []string{"hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cp.ThreadID() != "thread-1" {
+		t.Error("wrong thread ID")
+	}
+	if len(cpRepo.Checkpoints) != 1 {
+		t.Error("expected 1 checkpoint saved")
+	}
+}
+
+func TestUpdateThreadStateHandler_MergesExisting(t *testing.T) {
+	cpRepo := mocks.NewCheckpointRepository()
+	handler := NewUpdateThreadStateHandler(cpRepo)
+
+	_, _ = handler.Handle(context.Background(), UpdateThreadStateCommand{
+		ThreadID: "thread-1",
+		Values:   map[string]interface{}{"a": 1, "b": 2},
+	})
+
+	cp, err := handler.Handle(context.Background(), UpdateThreadStateCommand{
+		ThreadID: "thread-1",
+		Values:   map[string]interface{}{"b": 3, "c": 4},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	vals := cp.ChannelValues()
+	if vals["a"] != 1 {
+		t.Error("existing value 'a' should be merged")
+	}
+	if vals["b"] != 3 {
+		t.Error("new value 'b' should override")
+	}
+	if vals["c"] != 4 {
+		t.Error("new value 'c' should be present")
+	}
+}
+
+func TestCreateCheckpointHandler_NoExisting(t *testing.T) {
+	cpRepo := mocks.NewCheckpointRepository()
+	handler := NewCreateCheckpointHandler(cpRepo)
+
+	cp, err := handler.Handle(context.Background(), CreateCheckpointCommand{
+		ThreadID:     "thread-1",
+		CheckpointNS: "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cp.ThreadID() != "thread-1" {
+		t.Error("wrong thread ID")
+	}
+	if cp.ParentCheckpointID() != "" {
+		t.Error("first checkpoint should have no parent")
+	}
+}
+
+func TestCreateCheckpointHandler_WithExisting(t *testing.T) {
+	cpRepo := mocks.NewCheckpointRepository()
+	handler := NewCreateCheckpointHandler(cpRepo)
+
+	first, _ := handler.Handle(context.Background(), CreateCheckpointCommand{
+		ThreadID:     "thread-1",
+		CheckpointNS: "default",
+	})
+
+	second, err := handler.Handle(context.Background(), CreateCheckpointCommand{
+		ThreadID:     "thread-1",
+		CheckpointNS: "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if second.ParentCheckpointID() != first.CheckpointID() {
+		t.Error("second checkpoint should reference first as parent")
+	}
+}
+
+func TestCreateAssistantVersionHandler_FirstVersion(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	handler := NewCreateAssistantVersionHandler(repo)
+
+	v, err := handler.Handle(context.Background(), CreateAssistantVersionCommand{
+		AssistantID: "asst-1",
+		GraphID:     "graph-1",
+		Config:      map[string]interface{}{"model": "gpt-4"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Version != 1 {
+		t.Errorf("expected version=1, got %d", v.Version)
+	}
+	if v.GraphID != "graph-1" {
+		t.Error("wrong graph ID")
+	}
+}
+
+func TestCreateAssistantVersionHandler_IncrementVersion(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	handler := NewCreateAssistantVersionHandler(repo)
+
+	_, _ = handler.Handle(context.Background(), CreateAssistantVersionCommand{
+		AssistantID: "asst-1",
+		GraphID:     "g1",
+	})
+	v2, err := handler.Handle(context.Background(), CreateAssistantVersionCommand{
+		AssistantID: "asst-1",
+		GraphID:     "g2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v2.Version != 2 {
+		t.Errorf("expected version=2, got %d", v2.Version)
+	}
+}
+
+func TestSetLatestVersionHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	handler := NewSetLatestVersionHandler(repo)
+
+	err := handler.Handle(context.Background(), SetLatestVersionCommand{
+		AssistantID: "asst-1",
+		Version:     3,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCopyThreadHandler_Success(t *testing.T) {
+	threadRepo := mocks.NewThreadRepository()
+	cpRepo := mocks.NewCheckpointRepository()
+
+	th, _ := workflow.NewThread(map[string]interface{}{"key": "val"})
+	th.AddMessage("user", "hello", nil)
+	threadRepo.Threads[th.ID()] = th
+
+	handler := NewCopyThreadHandler(threadRepo, cpRepo)
+	newID, err := handler.Handle(context.Background(), CopyThreadCommand{ThreadID: th.ID()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newID == th.ID() {
+		t.Error("copied thread should have different ID")
+	}
+	if len(threadRepo.Threads) != 2 {
+		t.Error("should have 2 threads now")
+	}
+	newThread := threadRepo.Threads[newID]
+	if len(newThread.Messages()) != 1 {
+		t.Error("messages should be copied")
+	}
+}
+
+func TestCopyThreadHandler_NotFound(t *testing.T) {
+	handler := NewCopyThreadHandler(mocks.NewThreadRepository(), mocks.NewCheckpointRepository())
+	_, err := handler.Handle(context.Background(), CopyThreadCommand{ThreadID: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing thread")
+	}
+}

--- a/internal/application/query/query_test.go
+++ b/internal/application/query/query_test.go
@@ -1,0 +1,992 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/domain/checkpoint"
+	"github.com/duragraph/duragraph/internal/domain/run"
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/mocks"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// ---------------------------------------------------------------------------
+// GetRunHandler
+// ---------------------------------------------------------------------------
+
+func TestGetRunHandler_Success(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", map[string]interface{}{"msg": "hello"})
+	repo.Runs[r.ID()] = r
+
+	handler := NewGetRunHandler(repo)
+	dto, err := handler.Handle(context.Background(), GetRun{RunID: r.ID()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dto.ID != r.ID() {
+		t.Errorf("expected ID %s, got %s", r.ID(), dto.ID)
+	}
+	if dto.ThreadID != "thread-1" {
+		t.Errorf("expected thread-1, got %s", dto.ThreadID)
+	}
+	if dto.AssistantID != "asst-1" {
+		t.Errorf("expected asst-1, got %s", dto.AssistantID)
+	}
+	if dto.Status != r.Status().String() {
+		t.Errorf("expected status %s, got %s", r.Status().String(), dto.Status)
+	}
+}
+
+func TestGetRunHandler_NotFound(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	handler := NewGetRunHandler(repo)
+
+	_, err := handler.Handle(context.Background(), GetRun{RunID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListRunsHandler
+// ---------------------------------------------------------------------------
+
+func TestListRunsHandler_DefaultLimit(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	for i := 0; i < 3; i++ {
+		r, _ := run.NewRun("thread-1", "asst-1", nil)
+		repo.Runs[r.ID()] = r
+	}
+
+	handler := NewListRunsHandler(repo)
+	dtos, err := handler.Handle(context.Background(), ListRuns{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dtos) != 3 {
+		t.Errorf("expected 3 runs, got %d", len(dtos))
+	}
+}
+
+func TestListRunsHandler_WithThreadFilter(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	r1, _ := run.NewRun("thread-1", "asst-1", nil)
+	r2, _ := run.NewRun("thread-2", "asst-1", nil)
+	repo.Runs[r1.ID()] = r1
+	repo.Runs[r2.ID()] = r2
+
+	handler := NewListRunsHandler(repo)
+	dtos, err := handler.Handle(context.Background(), ListRuns{ThreadID: "thread-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dtos) != 1 {
+		t.Errorf("expected 1 run, got %d", len(dtos))
+	}
+	if len(dtos) > 0 && dtos[0].ThreadID != "thread-1" {
+		t.Errorf("expected thread-1, got %s", dtos[0].ThreadID)
+	}
+}
+
+func TestListRunsHandler_Empty(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	handler := NewListRunsHandler(repo)
+
+	dtos, err := handler.Handle(context.Background(), ListRuns{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dtos) != 0 {
+		t.Errorf("expected 0 runs, got %d", len(dtos))
+	}
+}
+
+func TestListRunsHandler_RepoError(t *testing.T) {
+	repo := mocks.NewRunRepository()
+	repo.FindAllFunc = func(ctx context.Context, limit, offset int) ([]*run.Run, error) {
+		return nil, errors.Internal("db error", nil)
+	}
+
+	handler := NewListRunsHandler(repo)
+	_, err := handler.Handle(context.Background(), ListRuns{})
+	if err == nil {
+		t.Fatal("expected error from repo")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetAssistantHandler
+// ---------------------------------------------------------------------------
+
+func TestGetAssistantHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	a, _ := workflow.NewAssistant("test-assistant", "desc", "gpt-4", "instr", nil, nil)
+	repo.Assistants[a.ID()] = a
+
+	handler := NewGetAssistantHandler(repo)
+	result, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name() != "test-assistant" {
+		t.Errorf("expected test-assistant, got %s", result.Name())
+	}
+}
+
+func TestGetAssistantHandler_NotFound(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	handler := NewGetAssistantHandler(repo)
+
+	_, err := handler.Handle(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent assistant")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListAssistantsHandler
+// ---------------------------------------------------------------------------
+
+func TestListAssistantsHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	a1, _ := workflow.NewAssistant("a1", "", "", "", nil, nil)
+	a2, _ := workflow.NewAssistant("a2", "", "", "", nil, nil)
+	repo.Assistants[a1.ID()] = a1
+	repo.Assistants[a2.ID()] = a2
+
+	handler := NewListAssistantsHandler(repo)
+	result, err := handler.Handle(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 assistants, got %d", len(result))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SearchAssistantsHandler
+// ---------------------------------------------------------------------------
+
+func TestSearchAssistantsHandler_DefaultLimit(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	repo.Assistants[a.ID()] = a
+
+	handler := NewSearchAssistantsHandler(repo)
+	result, err := handler.Handle(context.Background(), SearchAssistants{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("expected 1 assistant, got %d", len(result))
+	}
+}
+
+func TestSearchAssistantsHandler_WithFilters(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	repo.SearchFunc = func(ctx context.Context, filters workflow.AssistantSearchFilters) ([]*workflow.Assistant, error) {
+		if filters.GraphID != "graph-1" {
+			t.Errorf("expected graph_id filter graph-1, got %s", filters.GraphID)
+		}
+		return []*workflow.Assistant{}, nil
+	}
+
+	handler := NewSearchAssistantsHandler(repo)
+	_, err := handler.Handle(context.Background(), SearchAssistants{
+		GraphID: "graph-1",
+		Limit:   5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CountAssistantsHandler
+// ---------------------------------------------------------------------------
+
+func TestCountAssistantsHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	a1, _ := workflow.NewAssistant("a1", "", "", "", nil, nil)
+	a2, _ := workflow.NewAssistant("a2", "", "", "", nil, nil)
+	repo.Assistants[a1.ID()] = a1
+	repo.Assistants[a2.ID()] = a2
+
+	handler := NewCountAssistantsHandler(repo)
+	count, err := handler.Handle(context.Background(), CountAssistants{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestCountAssistantsHandler_WithFilters(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	repo.CountFunc = func(ctx context.Context, filters workflow.AssistantSearchFilters) (int, error) {
+		if filters.GraphID != "g-1" {
+			t.Errorf("expected graph_id g-1, got %s", filters.GraphID)
+		}
+		return 42, nil
+	}
+
+	handler := NewCountAssistantsHandler(repo)
+	count, err := handler.Handle(context.Background(), CountAssistants{GraphID: "g-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 42 {
+		t.Errorf("expected 42, got %d", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetThreadHandler
+// ---------------------------------------------------------------------------
+
+func TestGetThreadHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	thread, _ := workflow.NewThread(map[string]interface{}{"key": "value"})
+	repo.Threads[thread.ID()] = thread
+
+	handler := NewGetThreadHandler(repo)
+	result, err := handler.Handle(context.Background(), thread.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID() != thread.ID() {
+		t.Errorf("expected ID %s, got %s", thread.ID(), result.ID())
+	}
+}
+
+func TestGetThreadHandler_NotFound(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	handler := NewGetThreadHandler(repo)
+
+	_, err := handler.Handle(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent thread")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListThreadsHandler
+// ---------------------------------------------------------------------------
+
+func TestListThreadsHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	t1, _ := workflow.NewThread(nil)
+	t2, _ := workflow.NewThread(nil)
+	repo.Threads[t1.ID()] = t1
+	repo.Threads[t2.ID()] = t2
+
+	handler := NewListThreadsHandler(repo)
+	result, err := handler.Handle(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 threads, got %d", len(result))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SearchThreadsHandler
+// ---------------------------------------------------------------------------
+
+func TestSearchThreadsHandler_DefaultLimit(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	thread, _ := workflow.NewThread(nil)
+	repo.Threads[thread.ID()] = thread
+
+	handler := NewSearchThreadsHandler(repo)
+	result, err := handler.Handle(context.Background(), SearchThreads{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("expected 1 thread, got %d", len(result))
+	}
+}
+
+func TestSearchThreadsHandler_WithFilters(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	repo.SearchFunc = func(ctx context.Context, filters workflow.ThreadSearchFilters) ([]*workflow.Thread, error) {
+		if filters.Status != "active" {
+			t.Errorf("expected status filter active, got %s", filters.Status)
+		}
+		if filters.Limit != 5 {
+			t.Errorf("expected limit 5, got %d", filters.Limit)
+		}
+		return []*workflow.Thread{}, nil
+	}
+
+	handler := NewSearchThreadsHandler(repo)
+	_, err := handler.Handle(context.Background(), SearchThreads{
+		Status: "active",
+		Limit:  5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CountThreadsHandler
+// ---------------------------------------------------------------------------
+
+func TestCountThreadsHandler_Success(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	t1, _ := workflow.NewThread(nil)
+	repo.Threads[t1.ID()] = t1
+
+	handler := NewCountThreadsHandler(repo)
+	count, err := handler.Handle(context.Background(), CountThreads{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+}
+
+func TestCountThreadsHandler_WithFilters(t *testing.T) {
+	repo := mocks.NewThreadRepository()
+	repo.CountFunc = func(ctx context.Context, filters workflow.ThreadSearchFilters) (int, error) {
+		if filters.Status != "idle" {
+			t.Errorf("expected status idle, got %s", filters.Status)
+		}
+		return 7, nil
+	}
+
+	handler := NewCountThreadsHandler(repo)
+	count, err := handler.Handle(context.Background(), CountThreads{Status: "idle"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 7 {
+		t.Errorf("expected 7, got %d", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetThreadStateHandler
+// ---------------------------------------------------------------------------
+
+func TestGetThreadStateHandler_WithCheckpoint(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	cp, _ := checkpoint.NewCheckpoint("thread-1", "", "cp-1", "", map[string]interface{}{
+		"messages":     []interface{}{"hello"},
+		"__next__":     []interface{}{"node-a", "node-b"},
+		"__tasks__":    []interface{}{map[string]interface{}{"id": "t1", "name": "process"}},
+		"__metadata__": map[string]interface{}{"source": "api"},
+	})
+	repo.Checkpoints = append(repo.Checkpoints, cp)
+
+	handler := NewGetThreadStateHandler(repo)
+	state, err := handler.Handle(context.Background(), "thread-1", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.CheckpointID != "cp-1" {
+		t.Errorf("expected checkpoint ID cp-1, got %s", state.CheckpointID)
+	}
+	if len(state.Next) != 2 {
+		t.Errorf("expected 2 next nodes, got %d", len(state.Next))
+	}
+	if len(state.Tasks) != 1 {
+		t.Errorf("expected 1 task, got %d", len(state.Tasks))
+	}
+	if state.Metadata["source"] != "api" {
+		t.Errorf("expected metadata source=api, got %v", state.Metadata["source"])
+	}
+}
+
+func TestGetThreadStateHandler_NoCheckpoint(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+
+	handler := NewGetThreadStateHandler(repo)
+	state, err := handler.Handle(context.Background(), "thread-1", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(state.Values) != 0 {
+		t.Errorf("expected empty values, got %v", state.Values)
+	}
+	if len(state.Next) != 0 {
+		t.Errorf("expected empty next, got %v", state.Next)
+	}
+	if len(state.Tasks) != 0 {
+		t.Errorf("expected empty tasks, got %v", state.Tasks)
+	}
+}
+
+func TestGetThreadStateHandler_HandleWithCheckpoint(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	cp, _ := checkpoint.NewCheckpoint("thread-1", "ns-1", "cp-specific", "", map[string]interface{}{
+		"key": "value",
+	})
+	repo.Checkpoints = append(repo.Checkpoints, cp)
+
+	handler := NewGetThreadStateHandler(repo)
+	state, err := handler.HandleWithCheckpoint(context.Background(), "thread-1", "ns-1", "cp-specific")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.CheckpointID != "cp-specific" {
+		t.Errorf("expected checkpoint cp-specific, got %s", state.CheckpointID)
+	}
+	if state.Values["key"] != "value" {
+		t.Errorf("expected key=value, got %v", state.Values["key"])
+	}
+}
+
+func TestGetThreadStateHandler_HandleWithCheckpoint_NotFound(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+
+	handler := NewGetThreadStateHandler(repo)
+	_, err := handler.HandleWithCheckpoint(context.Background(), "thread-1", "", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent checkpoint")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetThreadHistoryHandler
+// ---------------------------------------------------------------------------
+
+func TestGetThreadHistoryHandler_Success(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	cp1, _ := checkpoint.NewCheckpoint("thread-1", "", "cp-1", "", map[string]interface{}{"step": 1})
+	cp2, _ := checkpoint.NewCheckpoint("thread-1", "", "cp-2", "cp-1", map[string]interface{}{"step": 2})
+	repo.Checkpoints = append(repo.Checkpoints, cp1, cp2)
+
+	handler := NewGetThreadHistoryHandler(repo)
+	entries, err := handler.Handle(context.Background(), GetThreadHistory{
+		ThreadID: "thread-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+}
+
+func TestGetThreadHistoryHandler_DefaultLimit(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	repo.FindHistoryFunc = func(ctx context.Context, threadID, checkpointNS string, limit int, before string) ([]*checkpoint.Checkpoint, error) {
+		if limit != 10 {
+			t.Errorf("expected default limit 10, got %d", limit)
+		}
+		return []*checkpoint.Checkpoint{}, nil
+	}
+
+	handler := NewGetThreadHistoryHandler(repo)
+	_, err := handler.Handle(context.Background(), GetThreadHistory{ThreadID: "thread-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetThreadHistoryHandler_WithLimit(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	for i := 0; i < 5; i++ {
+		cp, _ := checkpoint.NewCheckpoint("thread-1", "", "", "", map[string]interface{}{})
+		repo.Checkpoints = append(repo.Checkpoints, cp)
+	}
+
+	handler := NewGetThreadHistoryHandler(repo)
+	entries, err := handler.Handle(context.Background(), GetThreadHistory{
+		ThreadID: "thread-1",
+		Limit:    2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries (limited), got %d", len(entries))
+	}
+}
+
+func TestGetThreadHistoryHandler_ParentChain(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	cp1, _ := checkpoint.NewCheckpoint("thread-1", "", "cp-1", "", map[string]interface{}{})
+	cp2, _ := checkpoint.NewCheckpoint("thread-1", "", "cp-2", "cp-1", map[string]interface{}{})
+	repo.Checkpoints = append(repo.Checkpoints, cp1, cp2)
+
+	handler := NewGetThreadHistoryHandler(repo)
+	entries, err := handler.Handle(context.Background(), GetThreadHistory{ThreadID: "thread-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range entries {
+		if e.CheckpointID == "cp-2" && e.ParentCheckpointID == "cp-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected cp-2 to reference parent cp-1")
+	}
+}
+
+func TestGetThreadHistoryHandler_Empty(t *testing.T) {
+	repo := mocks.NewCheckpointRepository()
+	repo.FindHistoryFunc = func(ctx context.Context, threadID, checkpointNS string, limit int, before string) ([]*checkpoint.Checkpoint, error) {
+		return []*checkpoint.Checkpoint{}, nil
+	}
+
+	handler := NewGetThreadHistoryHandler(repo)
+	entries, err := handler.Handle(context.Background(), GetThreadHistory{ThreadID: "thread-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetAssistantGraphHandler
+// ---------------------------------------------------------------------------
+
+func TestGetAssistantGraphHandler_WithGraph(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "llm", Type: workflow.NodeTypeLLM, Config: map[string]interface{}{"model": "gpt-4"}},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{ID: "e1", Source: "start", Target: "llm"},
+		{ID: "e2", Source: "llm", Target: "end"},
+	}
+	g, _ := workflow.NewGraph(a.ID(), "main", "1.0.0", "test graph", nodes, edges, map[string]interface{}{"key": "val"})
+	graphRepo.Graphs[g.ID()] = g
+
+	handler := NewGetAssistantGraphHandler(assistantRepo, graphRepo)
+	result, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Nodes) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(result.Nodes))
+	}
+	if len(result.Edges) != 2 {
+		t.Errorf("expected 2 edges, got %d", len(result.Edges))
+	}
+	if result.Config["key"] != "val" {
+		t.Errorf("expected config key=val, got %v", result.Config["key"])
+	}
+}
+
+func TestGetAssistantGraphHandler_NoGraphs(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	handler := NewGetAssistantGraphHandler(assistantRepo, graphRepo)
+	result, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Nodes) != 0 {
+		t.Errorf("expected 0 nodes, got %d", len(result.Nodes))
+	}
+	if len(result.Edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(result.Edges))
+	}
+}
+
+func TestGetAssistantGraphHandler_AssistantNotFound(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	handler := NewGetAssistantGraphHandler(assistantRepo, graphRepo)
+	_, err := handler.Handle(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent assistant")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetAssistantVersionsHandler
+// ---------------------------------------------------------------------------
+
+func TestGetAssistantVersionsHandler_Success(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	now := time.Now()
+	repo.Versions["asst-1"] = []workflow.AssistantVersionInfo{
+		{ID: "v1", AssistantID: "asst-1", Version: 1, GraphID: "g1", Config: map[string]interface{}{"model": "gpt-4"}, CreatedAt: now},
+		{ID: "v2", AssistantID: "asst-1", Version: 2, GraphID: "g2", Config: map[string]interface{}{"model": "gpt-4o"}, CreatedAt: now},
+	}
+
+	handler := NewGetAssistantVersionsHandler(repo)
+	versions, err := handler.Handle(context.Background(), "asst-1", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Errorf("expected 2 versions, got %d", len(versions))
+	}
+	if versions[0].Version != 1 {
+		t.Errorf("expected version 1, got %d", versions[0].Version)
+	}
+	if versions[1].Config["model"] != "gpt-4o" {
+		t.Errorf("expected model gpt-4o, got %v", versions[1].Config["model"])
+	}
+}
+
+func TestGetAssistantVersionsHandler_DefaultLimit(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+	repo.FindVersionsFunc = func(ctx context.Context, assistantID string, limit int) ([]workflow.AssistantVersionInfo, error) {
+		if limit != 10 {
+			t.Errorf("expected default limit 10, got %d", limit)
+		}
+		return []workflow.AssistantVersionInfo{}, nil
+	}
+
+	handler := NewGetAssistantVersionsHandler(repo)
+	_, err := handler.Handle(context.Background(), "asst-1", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAssistantVersionsHandler_Empty(t *testing.T) {
+	repo := mocks.NewAssistantRepository()
+
+	handler := NewGetAssistantVersionsHandler(repo)
+	versions, err := handler.Handle(context.Background(), "asst-1", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Errorf("expected 0 versions, got %d", len(versions))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetAssistantSchemaHandler
+// ---------------------------------------------------------------------------
+
+func TestGetAssistantSchemaHandler_WithSchemas(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{{ID: "e1", Source: "start", Target: "end"}}
+	config := map[string]interface{}{
+		"graph_id":      "g-1",
+		"input_schema":  map[string]interface{}{"type": "object"},
+		"output_schema": map[string]interface{}{"type": "string"},
+		"state_schema":  map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+		"config_schema": map[string]interface{}{"type": "object"},
+	}
+	g, _ := workflow.NewGraph(a.ID(), "main", "1.0.0", "", nodes, edges, config)
+	graphRepo.Graphs[g.ID()] = g
+
+	handler := NewGetAssistantSchemaHandler(assistantRepo, graphRepo)
+	schema, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema.GraphID != "g-1" {
+		t.Errorf("expected graph_id g-1, got %s", schema.GraphID)
+	}
+	if schema.InputSchema["type"] != "object" {
+		t.Errorf("expected input schema type=object, got %v", schema.InputSchema["type"])
+	}
+	if schema.OutputSchema["type"] != "string" {
+		t.Errorf("expected output schema type=string, got %v", schema.OutputSchema["type"])
+	}
+}
+
+func TestGetAssistantSchemaHandler_NoGraphs(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	handler := NewGetAssistantSchemaHandler(assistantRepo, graphRepo)
+	schema, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema.GraphID != "" {
+		t.Errorf("expected empty graph_id, got %s", schema.GraphID)
+	}
+	if len(schema.InputSchema) != 0 {
+		t.Errorf("expected empty input schema, got %v", schema.InputSchema)
+	}
+}
+
+func TestGetAssistantSchemaHandler_AssistantNotFound(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	handler := NewGetAssistantSchemaHandler(assistantRepo, graphRepo)
+	_, err := handler.Handle(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent assistant")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetSubgraphsHandler
+// ---------------------------------------------------------------------------
+
+func TestGetSubgraphsHandler_WithSubgraphs(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "sub1", Type: workflow.NodeTypeSubgraph, Config: map[string]interface{}{
+			"namespace": "rag-pipeline",
+			"graph_id":  "rag-graph-1",
+		}},
+		{ID: "sub2", Type: workflow.NodeTypeSubgraph, Config: map[string]interface{}{
+			"graph_id": "tool-graph",
+		}},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{ID: "e1", Source: "start", Target: "sub1"},
+		{ID: "e2", Source: "sub1", Target: "sub2"},
+		{ID: "e3", Source: "sub2", Target: "end"},
+	}
+	g, _ := workflow.NewGraph(a.ID(), "main", "1.0.0", "", nodes, edges, nil)
+	graphRepo.Graphs[g.ID()] = g
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	subgraphs, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(subgraphs) != 2 {
+		t.Fatalf("expected 2 subgraphs, got %d", len(subgraphs))
+	}
+
+	found := map[string]bool{}
+	for _, sg := range subgraphs {
+		found[sg.Namespace] = true
+	}
+	if !found["rag-pipeline"] {
+		t.Error("expected subgraph with namespace rag-pipeline")
+	}
+	if !found["sub2"] {
+		t.Error("expected subgraph with namespace sub2 (defaults to node ID)")
+	}
+}
+
+func TestGetSubgraphsHandler_NoGraphs(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	subgraphs, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(subgraphs) != 0 {
+		t.Errorf("expected 0 subgraphs, got %d", len(subgraphs))
+	}
+}
+
+func TestGetSubgraphsHandler_NoSubgraphNodes(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "llm", Type: workflow.NodeTypeLLM},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{ID: "e1", Source: "start", Target: "llm"},
+		{ID: "e2", Source: "llm", Target: "end"},
+	}
+	g, _ := workflow.NewGraph(a.ID(), "main", "1.0.0", "", nodes, edges, nil)
+	graphRepo.Graphs[g.ID()] = g
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	subgraphs, err := handler.Handle(context.Background(), a.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(subgraphs) != 0 {
+		t.Errorf("expected 0 subgraphs, got %d", len(subgraphs))
+	}
+}
+
+func TestGetSubgraphsHandler_AssistantNotFound(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	_, err := handler.Handle(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent assistant")
+	}
+}
+
+func TestGetSubgraphsHandler_HandleByNamespace(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "sub1", Type: workflow.NodeTypeSubgraph, Config: map[string]interface{}{
+			"namespace": "rag",
+			"graph_id":  "rag-graph",
+			"nodes": []interface{}{
+				map[string]interface{}{"id": "inner-start", "type": "start"},
+				map[string]interface{}{"id": "inner-end", "type": "end"},
+			},
+			"edges": []interface{}{
+				map[string]interface{}{"id": "ie1", "source": "inner-start", "target": "inner-end"},
+			},
+			"config": map[string]interface{}{"retriever": "dense"},
+		}},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{ID: "e1", Source: "start", Target: "sub1"},
+		{ID: "e2", Source: "sub1", Target: "end"},
+	}
+	g, _ := workflow.NewGraph(a.ID(), "main", "1.0.0", "", nodes, edges, nil)
+	graphRepo.Graphs[g.ID()] = g
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	result, err := handler.HandleByNamespace(context.Background(), a.ID(), "rag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Nodes) != 2 {
+		t.Errorf("expected 2 inner nodes, got %d", len(result.Nodes))
+	}
+	if len(result.Edges) != 1 {
+		t.Errorf("expected 1 inner edge, got %d", len(result.Edges))
+	}
+	if result.Config["retriever"] != "dense" {
+		t.Errorf("expected config retriever=dense, got %v", result.Config["retriever"])
+	}
+}
+
+func TestGetSubgraphsHandler_HandleByNamespace_NotFound(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{{ID: "e1", Source: "start", Target: "end"}}
+	g, _ := workflow.NewGraph(a.ID(), "main", "1.0.0", "", nodes, edges, nil)
+	graphRepo.Graphs[g.ID()] = g
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	_, err := handler.HandleByNamespace(context.Background(), a.ID(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent subgraph namespace")
+	}
+}
+
+func TestGetSubgraphsHandler_HandleByNamespace_NoGraphs(t *testing.T) {
+	assistantRepo := mocks.NewAssistantRepository()
+	graphRepo := mocks.NewGraphRepository()
+
+	a, _ := workflow.NewAssistant("test", "", "", "", nil, nil)
+	assistantRepo.Assistants[a.ID()] = a
+
+	handler := NewGetSubgraphsHandler(assistantRepo, graphRepo)
+	_, err := handler.HandleByNamespace(context.Background(), a.ID(), "something")
+	if err == nil {
+		t.Fatal("expected error when no graphs exist")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: verify extractNext / extractTasks / extractMetadata edge cases
+// ---------------------------------------------------------------------------
+
+func TestExtractNext_NonStringValues(t *testing.T) {
+	cp, _ := checkpoint.NewCheckpoint("t1", "", "", "", map[string]interface{}{
+		"__next__": []interface{}{42, "valid", true},
+	})
+	next := extractNext(cp)
+	if len(next) != 1 {
+		t.Errorf("expected 1 string value, got %d", len(next))
+	}
+	if next[0] != "valid" {
+		t.Errorf("expected 'valid', got %s", next[0])
+	}
+}
+
+func TestExtractTasks_NonMapValues(t *testing.T) {
+	cp, _ := checkpoint.NewCheckpoint("t1", "", "", "", map[string]interface{}{
+		"__tasks__": []interface{}{"not-a-map", map[string]interface{}{"id": "t1"}},
+	})
+	tasks := extractTasks(cp)
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestExtractMetadata_NotAMap(t *testing.T) {
+	cp, _ := checkpoint.NewCheckpoint("t1", "", "", "", map[string]interface{}{
+		"__metadata__": "not-a-map",
+	})
+	metadata := extractMetadata(cp)
+	if len(metadata) != 0 {
+		t.Errorf("expected empty metadata, got %v", metadata)
+	}
+}
+
+func TestExtractNext_Missing(t *testing.T) {
+	cp, _ := checkpoint.NewCheckpoint("t1", "", "", "", map[string]interface{}{})
+	next := extractNext(cp)
+	if len(next) != 0 {
+		t.Errorf("expected empty next, got %v", next)
+	}
+}
+
+// Ensure errors import is used
+var _ = errors.NotFound

--- a/internal/application/service/run_service_test.go
+++ b/internal/application/service/run_service_test.go
@@ -1,0 +1,1143 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/domain/humanloop"
+	"github.com/duragraph/duragraph/internal/domain/run"
+	"github.com/duragraph/duragraph/internal/domain/worker"
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/mocks"
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
+)
+
+// ---------------------------------------------------------------------------
+// RunService: CheckMultitaskStrategy
+// ---------------------------------------------------------------------------
+
+func TestCheckMultitaskStrategy_NoActiveRuns(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, existingID, err := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "reject")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if action != "proceed" {
+		t.Errorf("expected proceed, got %s", action)
+	}
+	if existingID != "" {
+		t.Errorf("expected empty existing run ID, got %s", existingID)
+	}
+}
+
+func TestCheckMultitaskStrategy_Reject(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, existingID, err := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "reject")
+	if action != "reject" {
+		t.Errorf("expected reject, got %s", action)
+	}
+	if existingID == "" {
+		t.Error("expected existing run ID")
+	}
+	if err == nil {
+		t.Error("expected error for reject strategy")
+	}
+}
+
+func TestCheckMultitaskStrategy_DefaultIsReject(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, _, _ := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "")
+	if action != "reject" {
+		t.Errorf("expected reject as default, got %s", action)
+	}
+}
+
+func TestCheckMultitaskStrategy_Interrupt(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, existingID, err := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "interrupt")
+	if action != "interrupt" {
+		t.Errorf("expected interrupt, got %s", action)
+	}
+	if existingID == "" {
+		t.Error("expected existing run ID")
+	}
+	if err != nil {
+		t.Errorf("unexpected error for interrupt: %v", err)
+	}
+}
+
+func TestCheckMultitaskStrategy_Rollback(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, _, err := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "rollback")
+	if action != "rollback" {
+		t.Errorf("expected rollback, got %s", action)
+	}
+	if err != nil {
+		t.Errorf("unexpected error for rollback: %v", err)
+	}
+}
+
+func TestCheckMultitaskStrategy_Enqueue(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, existingID, err := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "enqueue")
+	if action != "proceed" {
+		t.Errorf("expected proceed for enqueue, got %s", action)
+	}
+	if existingID != "" {
+		t.Errorf("expected empty existing run ID for enqueue, got %s", existingID)
+	}
+	if err != nil {
+		t.Errorf("unexpected error for enqueue: %v", err)
+	}
+}
+
+func TestCheckMultitaskStrategy_UnknownDefaultsToReject(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	action, _, err := svc.CheckMultitaskStrategy(context.Background(), "thread-1", "unknown-strategy")
+	if action != "reject" {
+		t.Errorf("expected reject for unknown, got %s", action)
+	}
+	if err == nil {
+		t.Error("expected error for unknown strategy")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: ApplyMultitaskStrategy
+// ---------------------------------------------------------------------------
+
+func TestApplyMultitaskStrategy_Proceed(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	canProceed, err := svc.ApplyMultitaskStrategy(context.Background(), "thread-1", "reject")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !canProceed {
+		t.Error("expected proceed when no active runs")
+	}
+}
+
+func TestApplyMultitaskStrategy_RejectWithActiveRun(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	canProceed, err := svc.ApplyMultitaskStrategy(context.Background(), "thread-1", "reject")
+	if canProceed {
+		t.Error("expected reject to prevent proceeding")
+	}
+	if err == nil {
+		t.Error("expected error from reject")
+	}
+}
+
+func TestApplyMultitaskStrategy_InterruptCancelsExisting(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	canProceed, err := svc.ApplyMultitaskStrategy(context.Background(), "thread-1", "interrupt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !canProceed {
+		t.Error("expected proceed after interrupt cancels existing")
+	}
+	if !runRepo.Runs[r.ID()].Status().IsTerminal() {
+		t.Errorf("expected existing run to be cancelled, got status %s", runRepo.Runs[r.ID()].Status())
+	}
+}
+
+func TestApplyMultitaskStrategy_RollbackCancelsExisting(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	canProceed, err := svc.ApplyMultitaskStrategy(context.Background(), "thread-1", "rollback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !canProceed {
+		t.Error("expected proceed after rollback cancels existing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: CancelRun
+// ---------------------------------------------------------------------------
+
+func TestCancelRun_Success(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.CancelRun(context.Background(), r.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusCancelled {
+		t.Errorf("expected cancelled status, got %s", updated.Status())
+	}
+}
+
+func TestCancelRun_AlreadyTerminal(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	_ = r.Complete(map[string]interface{}{"result": "ok"})
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.CancelRun(context.Background(), r.ID())
+	if err == nil {
+		t.Error("expected error when cancelling completed run")
+	}
+}
+
+func TestCancelRun_NotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.CancelRun(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: UpdateStateBeforeResume
+// ---------------------------------------------------------------------------
+
+func TestUpdateStateBeforeResume_Success(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", map[string]interface{}{"key": "val"})
+	_ = r.Start()
+	_ = r.RequiresAction("int-1", "need input", nil)
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.UpdateStateBeforeResume(context.Background(), r.ID(), "thread-1", map[string]interface{}{
+		"new_key": "new_val",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	input := runRepo.Runs[r.ID()].Input()
+	updates, ok := input["state_updates"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected state_updates in input")
+	}
+	if updates["new_key"] != "new_val" {
+		t.Errorf("expected new_key=new_val, got %v", updates["new_key"])
+	}
+}
+
+func TestUpdateStateBeforeResume_WrongStatus(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", map[string]interface{}{"key": "val"})
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.UpdateStateBeforeResume(context.Background(), r.ID(), "thread-1", map[string]interface{}{
+		"new_key": "new_val",
+	})
+	if err == nil {
+		t.Error("expected error when run is not in requires_action state")
+	}
+}
+
+func TestUpdateStateBeforeResume_MergesExisting(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	input := map[string]interface{}{
+		"key": "val",
+		"state_updates": map[string]interface{}{
+			"existing": "value",
+		},
+	}
+	r, _ := run.NewRun("thread-1", "asst-1", input)
+	_ = r.Start()
+	_ = r.RequiresAction("int-1", "need input", nil)
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.UpdateStateBeforeResume(context.Background(), r.ID(), "thread-1", map[string]interface{}{
+		"new_key": "new_val",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updates := runRepo.Runs[r.ID()].Input()["state_updates"].(map[string]interface{})
+	if updates["existing"] != "value" {
+		t.Errorf("expected existing key preserved, got %v", updates["existing"])
+	}
+	if updates["new_key"] != "new_val" {
+		t.Errorf("expected new_key=new_val, got %v", updates["new_key"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: ResumeRun (only status check; ExecuteRun requires graph engine)
+// ---------------------------------------------------------------------------
+
+func TestResumeRun_WrongStatus(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.ResumeRun(context.Background(), r.ID())
+	if err == nil {
+		t.Error("expected error when run is not in requires_action state")
+	}
+}
+
+func TestResumeRun_NotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, nil)
+
+	err := svc.ResumeRun(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: WaitForRun (already terminal)
+// ---------------------------------------------------------------------------
+
+func TestWaitForRun_AlreadyTerminal(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	_ = r.Complete(map[string]interface{}{"result": "done"})
+	runRepo.Runs[r.ID()] = r
+
+	bus := eventbus.New()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, bus)
+
+	result, err := svc.WaitForRun(context.Background(), r.ID(), 1*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID() != r.ID() {
+		t.Errorf("expected run ID %s, got %s", r.ID(), result.ID())
+	}
+}
+
+func TestWaitForRun_AlreadyRequiresAction(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	_ = r.RequiresAction("int-1", "need input", nil)
+	runRepo.Runs[r.ID()] = r
+
+	bus := eventbus.New()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, bus)
+
+	result, err := svc.WaitForRun(context.Background(), r.ID(), 1*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status() != run.StatusRequiresAction {
+		t.Errorf("expected requires_action, got %s", result.Status())
+	}
+}
+
+func TestWaitForRun_NotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	bus := eventbus.New()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, bus)
+
+	_, err := svc.WaitForRun(context.Background(), "nonexistent", 1*time.Second)
+	if err == nil {
+		t.Error("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: ResumeRunWithInput (status check and interrupt handling)
+// ---------------------------------------------------------------------------
+
+func TestResumeRunWithInput_WrongStatus(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	interruptRepo := mocks.NewInterruptRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewRunService(runRepo, nil, nil, interruptRepo, nil, nil)
+
+	err := svc.ResumeRunWithInput(context.Background(), r.ID(), map[string]interface{}{"input": "val"})
+	if err == nil {
+		t.Error("expected error when run is not in requires_action state")
+	}
+}
+
+func TestResumeRunWithInput_NotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	interruptRepo := mocks.NewInterruptRepository()
+	svc := NewRunService(runRepo, nil, nil, interruptRepo, nil, nil)
+
+	err := svc.ResumeRunWithInput(context.Background(), "nonexistent", nil)
+	if err == nil {
+		t.Error("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: SetWorkerService / SetTaskQueue
+// ---------------------------------------------------------------------------
+
+func TestRunService_SetWorkerService(t *testing.T) {
+	svc := NewRunService(nil, nil, nil, nil, nil, nil)
+	ws := &WorkerService{}
+	svc.SetWorkerService(ws)
+	if svc.workerService != ws {
+		t.Error("expected workerService to be set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: HasWorkers
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_HasWorkers_True(t *testing.T) {
+	workerRepo := mocks.NewWorkerRepository()
+	workerRepo.Workers["w1"] = &worker.Worker{
+		ID:     "w1",
+		Name:   "test-worker",
+		Status: worker.StatusReady,
+	}
+
+	svc := NewWorkerService(workerRepo, nil, nil, nil, nil, 30*time.Second)
+
+	if !svc.HasWorkers(context.Background()) {
+		t.Error("expected HasWorkers to return true")
+	}
+}
+
+func TestWorkerService_HasWorkers_False(t *testing.T) {
+	workerRepo := mocks.NewWorkerRepository()
+	svc := NewWorkerService(workerRepo, nil, nil, nil, nil, 30*time.Second)
+
+	if svc.HasWorkers(context.Background()) {
+		t.Error("expected HasWorkers to return false")
+	}
+}
+
+func TestWorkerService_HasWorkers_Error(t *testing.T) {
+	workerRepo := mocks.NewWorkerRepository()
+	workerRepo.FindAllFunc = func(ctx context.Context) ([]*worker.Worker, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	svc := NewWorkerService(workerRepo, nil, nil, nil, nil, 30*time.Second)
+
+	if svc.HasWorkers(context.Background()) {
+		t.Error("expected HasWorkers to return false on error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: HasHealthyWorkerForGraph
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_HasHealthyWorkerForGraph_True(t *testing.T) {
+	workerRepo := mocks.NewWorkerRepository()
+	workerRepo.FindForGraphFunc = func(ctx context.Context, graphID string, threshold time.Duration) (*worker.Worker, error) {
+		return &worker.Worker{ID: "w1"}, nil
+	}
+
+	svc := NewWorkerService(workerRepo, nil, nil, nil, nil, 30*time.Second)
+
+	if !svc.HasHealthyWorkerForGraph(context.Background(), "graph-1") {
+		t.Error("expected true when worker found")
+	}
+}
+
+func TestWorkerService_HasHealthyWorkerForGraph_False(t *testing.T) {
+	workerRepo := mocks.NewWorkerRepository()
+
+	svc := NewWorkerService(workerRepo, nil, nil, nil, nil, 30*time.Second)
+
+	if svc.HasHealthyWorkerForGraph(context.Background(), "graph-1") {
+		t.Error("expected false when no worker found")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: WorkerRepo / TaskRepo accessors
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_Accessors(t *testing.T) {
+	workerRepo := mocks.NewWorkerRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	svc := NewWorkerService(workerRepo, taskRepo, nil, nil, nil, 30*time.Second)
+
+	if svc.WorkerRepo() != workerRepo {
+		t.Error("WorkerRepo() should return the injected repo")
+	}
+	if svc.TaskRepo() != taskRepo {
+		t.Error("TaskRepo() should return the injected repo")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: UpdateRunStatus
+// ---------------------------------------------------------------------------
+
+func TestUpdateRunStatus_Completed(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	taskRepo.Tasks[1] = &worker.TaskAssignment{
+		ID:    1,
+		RunID: r.ID(),
+	}
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "completed", map[string]interface{}{"result": "ok"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusCompleted {
+		t.Errorf("expected completed status, got %s", updated.Status())
+	}
+	if taskRepo.Tasks[1].Status != worker.TaskStatusCompleted {
+		t.Errorf("expected task completed, got %s", taskRepo.Tasks[1].Status)
+	}
+}
+
+func TestUpdateRunStatus_Failed(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	taskRepo.Tasks[1] = &worker.TaskAssignment{
+		ID:    1,
+		RunID: r.ID(),
+	}
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "failed", nil, "something broke")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusFailed {
+		t.Errorf("expected failed status, got %s", updated.Status())
+	}
+}
+
+func TestUpdateRunStatus_RequiresAction(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "requires_action", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusRequiresAction {
+		t.Errorf("expected requires_action status, got %s", updated.Status())
+	}
+}
+
+func TestUpdateRunStatus_Cancelled(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "cancelled", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusCancelled {
+		t.Errorf("expected cancelled status, got %s", updated.Status())
+	}
+}
+
+func TestUpdateRunStatus_InProgress(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "in_progress", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusInProgress {
+		t.Errorf("expected in_progress status, got %s", updated.Status())
+	}
+}
+
+func TestUpdateRunStatus_NotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), "nonexistent", "completed", nil, "")
+	if err == nil {
+		t.Error("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: PollTasks
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_PollTasks(t *testing.T) {
+	taskRepo := mocks.NewTaskRepository()
+	taskRepo.ClaimFunc = func(ctx context.Context, workerID string, graphIDs []string, leaseDuration time.Duration, maxTasks int) ([]*worker.TaskAssignment, error) {
+		if workerID != "w1" {
+			t.Errorf("expected workerID w1, got %s", workerID)
+		}
+		if maxTasks != 5 {
+			t.Errorf("expected maxTasks 5, got %d", maxTasks)
+		}
+		return []*worker.TaskAssignment{{ID: 1, RunID: "run-1"}}, nil
+	}
+
+	svc := NewWorkerService(nil, taskRepo, nil, nil, nil, 30*time.Second)
+
+	tasks, err := svc.PollTasks(context.Background(), "w1", []string{"graph-1"}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: MonitorExpiredLeases
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_MonitorExpiredLeases_NoExpired(t *testing.T) {
+	taskRepo := mocks.NewTaskRepository()
+	svc := NewWorkerService(nil, taskRepo, nil, nil, nil, 30*time.Second)
+
+	err := svc.MonitorExpiredLeases(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkerService_MonitorExpiredLeases_WithExpired(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	taskRepo.FindExpiredLeasesFunc = func(ctx context.Context) ([]*worker.TaskAssignment, error) {
+		return []*worker.TaskAssignment{
+			{ID: 1, RunID: r.ID(), GraphID: "g1", ThreadID: "thread-1", AssistantID: "asst-1"},
+		}, nil
+	}
+
+	retried := false
+	taskRepo.RetryOrFailFunc = func(ctx context.Context, id int64) error {
+		retried = true
+		return nil
+	}
+
+	taskRepo.FindByRunIDFunc = func(ctx context.Context, runID string) (*worker.TaskAssignment, error) {
+		return &worker.TaskAssignment{ID: 1, RunID: runID, Status: worker.TaskStatusFailed}, nil
+	}
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.MonitorExpiredLeases(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !retried {
+		t.Error("expected RetryOrFail to be called")
+	}
+
+	updated := runRepo.Runs[r.ID()]
+	if updated.Status() != run.StatusFailed {
+		t.Errorf("expected run to be failed after max retries, got %s", updated.Status())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: DispatchRun
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_DispatchRun_NoWorker(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	workerRepo := mocks.NewWorkerRepository()
+	assistantRepo := mocks.NewAssistantRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	a, _ := newTestAssistant("test-asst")
+
+	r, _ := run.NewRun("thread-1", a.ID(), nil)
+	runRepo.Runs[r.ID()] = r
+
+	assistantRepo.Assistants[a.ID()] = a
+
+	workerRepo.FindForGraphFunc = func(ctx context.Context, graphID string, threshold time.Duration) (*worker.Worker, error) {
+		return nil, nil
+	}
+
+	svc := NewWorkerService(workerRepo, taskRepo, runRepo, assistantRepo, nil, 30*time.Second)
+
+	workerID, err := svc.DispatchRun(context.Background(), r.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if workerID != "" {
+		t.Errorf("expected empty worker ID, got %s", workerID)
+	}
+}
+
+func TestWorkerService_DispatchRun_RunNotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	svc := NewWorkerService(nil, nil, runRepo, nil, nil, 30*time.Second)
+
+	_, err := svc.DispatchRun(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("expected error for non-existent run")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CronScheduler: extended edge cases for ComputeNextRun
+// ---------------------------------------------------------------------------
+
+func TestComputeNextRun_EmptyTimezone(t *testing.T) {
+	from := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	next, err := ComputeNextRun("0 18 * * *", "", from)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Date(2025, 6, 1, 18, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestComputeNextRun_EndOfMonth(t *testing.T) {
+	from := time.Date(2025, 1, 31, 23, 59, 0, 0, time.UTC)
+	next, err := ComputeNextRun("0 0 1 * *", "UTC", from)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next.Day() != 1 {
+		t.Errorf("expected day 1, got %d", next.Day())
+	}
+	if next.Month() != 2 {
+		t.Errorf("expected February, got %s", next.Month())
+	}
+}
+
+func TestComputeNextRun_EveryMinute(t *testing.T) {
+	from := time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
+	next, err := ComputeNextRun("* * * * *", "UTC", from)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Date(2025, 3, 15, 10, 31, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestComputeNextRun_WeekdayOnly(t *testing.T) {
+	from := time.Date(2025, 6, 6, 18, 0, 0, 0, time.UTC) // Friday
+	next, err := ComputeNextRun("0 9 * * 1-5", "UTC", from)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next.Weekday() == time.Saturday || next.Weekday() == time.Sunday {
+		t.Errorf("expected weekday, got %s", next.Weekday())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: DispatchRun with available worker
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_DispatchRun_WithWorker(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	workerRepo := mocks.NewWorkerRepository()
+	assistantRepo := mocks.NewAssistantRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	a, _ := newTestAssistant("test-asst")
+	assistantRepo.Assistants[a.ID()] = a
+
+	r, _ := run.NewRun("thread-1", a.ID(), map[string]interface{}{"msg": "hi"})
+	runRepo.Runs[r.ID()] = r
+
+	workerRepo.FindForGraphFunc = func(ctx context.Context, graphID string, threshold time.Duration) (*worker.Worker, error) {
+		return &worker.Worker{ID: "worker-1"}, nil
+	}
+
+	svc := NewWorkerService(workerRepo, taskRepo, runRepo, assistantRepo, nil, 30*time.Second)
+
+	workerID, err := svc.DispatchRun(context.Background(), r.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if workerID != "worker-1" {
+		t.Errorf("expected worker-1, got %s", workerID)
+	}
+	if len(taskRepo.Tasks) != 1 {
+		t.Errorf("expected 1 task created, got %d", len(taskRepo.Tasks))
+	}
+}
+
+func TestWorkerService_DispatchRun_WithGraphIDFromMetadata(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	workerRepo := mocks.NewWorkerRepository()
+	assistantRepo := mocks.NewAssistantRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	a, _ := workflow.ReconstructAssistant(
+		"asst-1", "test", "", "", "",
+		nil,
+		map[string]interface{}{"graph_id": "custom-graph"},
+		time.Now(), time.Now(),
+	)
+	assistantRepo.Assistants[a.ID()] = a
+
+	r, _ := run.NewRun("thread-1", a.ID(), nil)
+	runRepo.Runs[r.ID()] = r
+
+	var capturedGraphID string
+	workerRepo.FindForGraphFunc = func(ctx context.Context, graphID string, threshold time.Duration) (*worker.Worker, error) {
+		capturedGraphID = graphID
+		return &worker.Worker{ID: "w1"}, nil
+	}
+
+	svc := NewWorkerService(workerRepo, taskRepo, runRepo, assistantRepo, nil, 30*time.Second)
+	_, err := svc.DispatchRun(context.Background(), r.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedGraphID != "custom-graph" {
+		t.Errorf("expected graph_id from metadata, got %s", capturedGraphID)
+	}
+}
+
+func TestWorkerService_DispatchRun_AssistantNotFound(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	workerRepo := mocks.NewWorkerRepository()
+	assistantRepo := mocks.NewAssistantRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	r, _ := run.NewRun("thread-1", "nonexistent-asst", nil)
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(workerRepo, taskRepo, runRepo, assistantRepo, nil, 30*time.Second)
+
+	_, err := svc.DispatchRun(context.Background(), r.ID())
+	if err == nil {
+		t.Error("expected error for non-existent assistant")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: MonitorExpiredLeases — pending retry path
+// ---------------------------------------------------------------------------
+
+func TestWorkerService_MonitorExpiredLeases_PendingRetry(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	taskRepo.FindExpiredLeasesFunc = func(ctx context.Context) ([]*worker.TaskAssignment, error) {
+		return []*worker.TaskAssignment{
+			{ID: 1, RunID: r.ID(), GraphID: "g1"},
+		}, nil
+	}
+	taskRepo.RetryOrFailFunc = func(ctx context.Context, id int64) error {
+		return nil
+	}
+	taskRepo.FindByRunIDFunc = func(ctx context.Context, runID string) (*worker.TaskAssignment, error) {
+		return &worker.TaskAssignment{ID: 1, RunID: runID, Status: worker.TaskStatusPending}, nil
+	}
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+	err := svc.MonitorExpiredLeases(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runRepo.Runs[r.ID()].Status() == run.StatusFailed {
+		t.Error("run should not be failed on pending retry")
+	}
+}
+
+func TestWorkerService_MonitorExpiredLeases_RetryError(t *testing.T) {
+	taskRepo := mocks.NewTaskRepository()
+	taskRepo.FindExpiredLeasesFunc = func(ctx context.Context) ([]*worker.TaskAssignment, error) {
+		return []*worker.TaskAssignment{
+			{ID: 1, RunID: "run-1"},
+		}, nil
+	}
+	taskRepo.RetryOrFailFunc = func(ctx context.Context, id int64) error {
+		return context.DeadlineExceeded
+	}
+
+	svc := NewWorkerService(nil, taskRepo, nil, nil, nil, 30*time.Second)
+	err := svc.MonitorExpiredLeases(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: WaitForRun with polling (run transitions to terminal async)
+// ---------------------------------------------------------------------------
+
+func TestWaitForRun_PollUntilComplete(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	bus := eventbus.New()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, bus)
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		runRepo.Runs[r.ID()].Complete(map[string]interface{}{"done": true})
+	}()
+
+	result, err := svc.WaitForRun(context.Background(), r.ID(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Status().IsTerminal() {
+		t.Errorf("expected terminal status, got %s", result.Status())
+	}
+}
+
+func TestWaitForRun_Timeout(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	bus := eventbus.New()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, bus)
+
+	_, err := svc.WaitForRun(context.Background(), r.ID(), 600*time.Millisecond)
+	if err == nil {
+		t.Error("expected timeout error")
+	}
+}
+
+func TestWaitForRun_DefaultTimeout(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	_ = r.Complete(map[string]interface{}{})
+	runRepo.Runs[r.ID()] = r
+
+	bus := eventbus.New()
+	svc := NewRunService(runRepo, nil, nil, nil, nil, bus)
+
+	result, err := svc.WaitForRun(context.Background(), r.ID(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID() != r.ID() {
+		t.Errorf("expected run ID %s, got %s", r.ID(), result.ID())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunService: SetTaskQueue
+// ---------------------------------------------------------------------------
+
+func TestRunService_SetTaskQueue(t *testing.T) {
+	svc := NewRunService(nil, nil, nil, nil, nil, nil)
+	if svc.taskQueue != nil {
+		t.Error("expected nil taskQueue initially")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkerService: UpdateRunStatus — success alias
+// ---------------------------------------------------------------------------
+
+func TestUpdateRunStatus_SuccessAlias(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "success", map[string]interface{}{"ok": true}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runRepo.Runs[r.ID()].Status().IsTerminal() != true {
+		t.Error("expected terminal status after success")
+	}
+}
+
+func TestUpdateRunStatus_ErrorAlias(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "error", nil, "oops")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !runRepo.Runs[r.ID()].Status().IsTerminal() {
+		t.Error("expected terminal status after error")
+	}
+}
+
+func TestUpdateRunStatus_RunningAlias(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "running", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateRunStatus_Interrupted(t *testing.T) {
+	runRepo := mocks.NewRunRepository()
+	taskRepo := mocks.NewTaskRepository()
+	r, _ := run.NewRun("thread-1", "asst-1", nil)
+	_ = r.Start()
+	runRepo.Runs[r.ID()] = r
+
+	svc := NewWorkerService(nil, taskRepo, runRepo, nil, nil, 30*time.Second)
+
+	err := svc.UpdateRunStatus(context.Background(), r.ID(), "interrupted", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runRepo.Runs[r.ID()].Status() != run.StatusRequiresAction {
+		t.Errorf("expected requires_action, got %s", runRepo.Runs[r.ID()].Status())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newTestAssistant(name string) (*workflow.Assistant, error) {
+	return workflow.NewAssistant(name, "", "", "", nil, nil)
+}
+
+// Ensure imports are used
+var _ = humanloop.ReasonToolCall

--- a/internal/mocks/assistant_repo.go
+++ b/internal/mocks/assistant_repo.go
@@ -1,0 +1,135 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type AssistantRepository struct {
+	mu         sync.RWMutex
+	Assistants map[string]*workflow.Assistant
+	Versions   map[string][]workflow.AssistantVersionInfo
+
+	SaveFunc             func(ctx context.Context, a *workflow.Assistant) error
+	FindByIDFunc         func(ctx context.Context, id string) (*workflow.Assistant, error)
+	ListFunc             func(ctx context.Context, limit, offset int) ([]*workflow.Assistant, error)
+	SearchFunc           func(ctx context.Context, filters workflow.AssistantSearchFilters) ([]*workflow.Assistant, error)
+	CountFunc            func(ctx context.Context, filters workflow.AssistantSearchFilters) (int, error)
+	UpdateFunc           func(ctx context.Context, a *workflow.Assistant) error
+	DeleteFunc           func(ctx context.Context, id string) error
+	FindVersionsFunc     func(ctx context.Context, assistantID string, limit int) ([]workflow.AssistantVersionInfo, error)
+	SaveVersionFunc      func(ctx context.Context, version workflow.AssistantVersionInfo) error
+	SetLatestVersionFunc func(ctx context.Context, assistantID string, version int) error
+}
+
+func NewAssistantRepository() *AssistantRepository {
+	return &AssistantRepository{
+		Assistants: make(map[string]*workflow.Assistant),
+		Versions:   make(map[string][]workflow.AssistantVersionInfo),
+	}
+}
+
+func (m *AssistantRepository) Save(ctx context.Context, a *workflow.Assistant) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, a)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Assistants[a.ID()] = a
+	return nil
+}
+
+func (m *AssistantRepository) FindByID(ctx context.Context, id string) (*workflow.Assistant, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	a, ok := m.Assistants[id]
+	if !ok {
+		return nil, errors.NotFound("assistant", id)
+	}
+	return a, nil
+}
+
+func (m *AssistantRepository) List(ctx context.Context, limit, offset int) ([]*workflow.Assistant, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx, limit, offset)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*workflow.Assistant, 0, len(m.Assistants))
+	for _, a := range m.Assistants {
+		result = append(result, a)
+	}
+	return result, nil
+}
+
+func (m *AssistantRepository) Search(ctx context.Context, filters workflow.AssistantSearchFilters) ([]*workflow.Assistant, error) {
+	if m.SearchFunc != nil {
+		return m.SearchFunc(ctx, filters)
+	}
+	return m.List(ctx, filters.Limit, filters.Offset)
+}
+
+func (m *AssistantRepository) Count(ctx context.Context, filters workflow.AssistantSearchFilters) (int, error) {
+	if m.CountFunc != nil {
+		return m.CountFunc(ctx, filters)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.Assistants), nil
+}
+
+func (m *AssistantRepository) Update(ctx context.Context, a *workflow.Assistant) error {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, a)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Assistants[a.ID()] = a
+	return nil
+}
+
+func (m *AssistantRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Assistants, id)
+	return nil
+}
+
+func (m *AssistantRepository) FindVersions(ctx context.Context, assistantID string, limit int) ([]workflow.AssistantVersionInfo, error) {
+	if m.FindVersionsFunc != nil {
+		return m.FindVersionsFunc(ctx, assistantID, limit)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	versions := m.Versions[assistantID]
+	if limit > 0 && limit < len(versions) {
+		versions = versions[:limit]
+	}
+	return versions, nil
+}
+
+func (m *AssistantRepository) SaveVersion(ctx context.Context, version workflow.AssistantVersionInfo) error {
+	if m.SaveVersionFunc != nil {
+		return m.SaveVersionFunc(ctx, version)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Versions[version.AssistantID] = append(m.Versions[version.AssistantID], version)
+	return nil
+}
+
+func (m *AssistantRepository) SetLatestVersion(ctx context.Context, assistantID string, version int) error {
+	if m.SetLatestVersionFunc != nil {
+		return m.SetLatestVersionFunc(ctx, assistantID, version)
+	}
+	return nil
+}

--- a/internal/mocks/checkpoint_repo.go
+++ b/internal/mocks/checkpoint_repo.go
@@ -1,0 +1,126 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/checkpoint"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type CheckpointRepository struct {
+	mu          sync.RWMutex
+	Checkpoints []*checkpoint.Checkpoint
+	Writes      []*checkpoint.CheckpointWrite
+
+	SaveFunc                   func(ctx context.Context, cp *checkpoint.Checkpoint) error
+	FindByIDFunc               func(ctx context.Context, id string) (*checkpoint.Checkpoint, error)
+	FindByCheckpointIDFunc     func(ctx context.Context, threadID, checkpointNS, checkpointID string) (*checkpoint.Checkpoint, error)
+	FindLatestFunc             func(ctx context.Context, threadID, checkpointNS string) (*checkpoint.Checkpoint, error)
+	FindHistoryFunc            func(ctx context.Context, threadID, checkpointNS string, limit int, before string) ([]*checkpoint.Checkpoint, error)
+	DeleteFunc                 func(ctx context.Context, id string) error
+	SaveWriteFunc              func(ctx context.Context, write *checkpoint.CheckpointWrite) error
+	FindWritesByCheckpointFunc func(ctx context.Context, threadID, checkpointNS, checkpointID string) ([]*checkpoint.CheckpointWrite, error)
+}
+
+func NewCheckpointRepository() *CheckpointRepository {
+	return &CheckpointRepository{}
+}
+
+func (m *CheckpointRepository) Save(ctx context.Context, cp *checkpoint.Checkpoint) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, cp)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Checkpoints = append(m.Checkpoints, cp)
+	return nil
+}
+
+func (m *CheckpointRepository) FindByID(ctx context.Context, id string) (*checkpoint.Checkpoint, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, cp := range m.Checkpoints {
+		if cp.ID() == id {
+			return cp, nil
+		}
+	}
+	return nil, errors.NotFound("checkpoint", id)
+}
+
+func (m *CheckpointRepository) FindByCheckpointID(ctx context.Context, threadID, checkpointNS, checkpointID string) (*checkpoint.Checkpoint, error) {
+	if m.FindByCheckpointIDFunc != nil {
+		return m.FindByCheckpointIDFunc(ctx, threadID, checkpointNS, checkpointID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, cp := range m.Checkpoints {
+		if cp.ThreadID() == threadID && cp.CheckpointID() == checkpointID {
+			return cp, nil
+		}
+	}
+	return nil, errors.NotFound("checkpoint", checkpointID)
+}
+
+func (m *CheckpointRepository) FindLatest(ctx context.Context, threadID, checkpointNS string) (*checkpoint.Checkpoint, error) {
+	if m.FindLatestFunc != nil {
+		return m.FindLatestFunc(ctx, threadID, checkpointNS)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var latest *checkpoint.Checkpoint
+	for _, cp := range m.Checkpoints {
+		if cp.ThreadID() == threadID {
+			latest = cp
+		}
+	}
+	if latest == nil {
+		return nil, errors.NotFound("checkpoint", threadID)
+	}
+	return latest, nil
+}
+
+func (m *CheckpointRepository) FindHistory(ctx context.Context, threadID, checkpointNS string, limit int, before string) ([]*checkpoint.Checkpoint, error) {
+	if m.FindHistoryFunc != nil {
+		return m.FindHistoryFunc(ctx, threadID, checkpointNS, limit, before)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*checkpoint.Checkpoint
+	for _, cp := range m.Checkpoints {
+		if cp.ThreadID() == threadID {
+			result = append(result, cp)
+		}
+	}
+	if limit > 0 && limit < len(result) {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+func (m *CheckpointRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *CheckpointRepository) SaveWrite(ctx context.Context, write *checkpoint.CheckpointWrite) error {
+	if m.SaveWriteFunc != nil {
+		return m.SaveWriteFunc(ctx, write)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Writes = append(m.Writes, write)
+	return nil
+}
+
+func (m *CheckpointRepository) FindWritesByCheckpoint(ctx context.Context, threadID, checkpointNS, checkpointID string) ([]*checkpoint.CheckpointWrite, error) {
+	if m.FindWritesByCheckpointFunc != nil {
+		return m.FindWritesByCheckpointFunc(ctx, threadID, checkpointNS, checkpointID)
+	}
+	return m.Writes, nil
+}

--- a/internal/mocks/graph_repo.go
+++ b/internal/mocks/graph_repo.go
@@ -1,0 +1,97 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type GraphRepository struct {
+	mu     sync.RWMutex
+	Graphs map[string]*workflow.Graph
+
+	SaveFunc                        func(ctx context.Context, g *workflow.Graph) error
+	FindByIDFunc                    func(ctx context.Context, id string) (*workflow.Graph, error)
+	FindByAssistantIDFunc           func(ctx context.Context, assistantID string) ([]*workflow.Graph, error)
+	FindByAssistantIDAndVersionFunc func(ctx context.Context, assistantID, version string) (*workflow.Graph, error)
+	UpdateFunc                      func(ctx context.Context, g *workflow.Graph) error
+	DeleteFunc                      func(ctx context.Context, id string) error
+}
+
+func NewGraphRepository() *GraphRepository {
+	return &GraphRepository{Graphs: make(map[string]*workflow.Graph)}
+}
+
+func (m *GraphRepository) Save(ctx context.Context, g *workflow.Graph) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, g)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Graphs[g.ID()] = g
+	return nil
+}
+
+func (m *GraphRepository) FindByID(ctx context.Context, id string) (*workflow.Graph, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	g, ok := m.Graphs[id]
+	if !ok {
+		return nil, errors.NotFound("graph", id)
+	}
+	return g, nil
+}
+
+func (m *GraphRepository) FindByAssistantID(ctx context.Context, assistantID string) ([]*workflow.Graph, error) {
+	if m.FindByAssistantIDFunc != nil {
+		return m.FindByAssistantIDFunc(ctx, assistantID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*workflow.Graph
+	for _, g := range m.Graphs {
+		if g.AssistantID() == assistantID {
+			result = append(result, g)
+		}
+	}
+	return result, nil
+}
+
+func (m *GraphRepository) FindByAssistantIDAndVersion(ctx context.Context, assistantID, version string) (*workflow.Graph, error) {
+	if m.FindByAssistantIDAndVersionFunc != nil {
+		return m.FindByAssistantIDAndVersionFunc(ctx, assistantID, version)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, g := range m.Graphs {
+		if g.AssistantID() == assistantID && g.Version() == version {
+			return g, nil
+		}
+	}
+	return nil, errors.NotFound("graph", assistantID+"/"+version)
+}
+
+func (m *GraphRepository) Update(ctx context.Context, g *workflow.Graph) error {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, g)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Graphs[g.ID()] = g
+	return nil
+}
+
+func (m *GraphRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Graphs, id)
+	return nil
+}

--- a/internal/mocks/interrupt_repo.go
+++ b/internal/mocks/interrupt_repo.go
@@ -1,0 +1,98 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/humanloop"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type InterruptRepository struct {
+	mu         sync.RWMutex
+	Interrupts map[string]*humanloop.Interrupt
+
+	SaveFunc                func(ctx context.Context, i *humanloop.Interrupt) error
+	FindByIDFunc            func(ctx context.Context, id string) (*humanloop.Interrupt, error)
+	FindByRunIDFunc         func(ctx context.Context, runID string) ([]*humanloop.Interrupt, error)
+	FindUnresolvedByRunFunc func(ctx context.Context, runID string) ([]*humanloop.Interrupt, error)
+	UpdateFunc              func(ctx context.Context, i *humanloop.Interrupt) error
+	DeleteFunc              func(ctx context.Context, id string) error
+}
+
+func NewInterruptRepository() *InterruptRepository {
+	return &InterruptRepository{Interrupts: make(map[string]*humanloop.Interrupt)}
+}
+
+func (m *InterruptRepository) Save(ctx context.Context, i *humanloop.Interrupt) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, i)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Interrupts[i.ID()] = i
+	return nil
+}
+
+func (m *InterruptRepository) FindByID(ctx context.Context, id string) (*humanloop.Interrupt, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	i, ok := m.Interrupts[id]
+	if !ok {
+		return nil, errors.NotFound("interrupt", id)
+	}
+	return i, nil
+}
+
+func (m *InterruptRepository) FindByRunID(ctx context.Context, runID string) ([]*humanloop.Interrupt, error) {
+	if m.FindByRunIDFunc != nil {
+		return m.FindByRunIDFunc(ctx, runID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*humanloop.Interrupt
+	for _, i := range m.Interrupts {
+		if i.RunID() == runID {
+			result = append(result, i)
+		}
+	}
+	return result, nil
+}
+
+func (m *InterruptRepository) FindUnresolvedByRunID(ctx context.Context, runID string) ([]*humanloop.Interrupt, error) {
+	if m.FindUnresolvedByRunFunc != nil {
+		return m.FindUnresolvedByRunFunc(ctx, runID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*humanloop.Interrupt
+	for _, i := range m.Interrupts {
+		if i.RunID() == runID && !i.IsResolved() {
+			result = append(result, i)
+		}
+	}
+	return result, nil
+}
+
+func (m *InterruptRepository) Update(ctx context.Context, i *humanloop.Interrupt) error {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, i)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Interrupts[i.ID()] = i
+	return nil
+}
+
+func (m *InterruptRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Interrupts, id)
+	return nil
+}

--- a/internal/mocks/run_repo.go
+++ b/internal/mocks/run_repo.go
@@ -1,0 +1,147 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/run"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type RunRepository struct {
+	mu   sync.RWMutex
+	Runs map[string]*run.Run
+
+	SaveFunc               func(ctx context.Context, r *run.Run) error
+	FindByIDFunc           func(ctx context.Context, id string) (*run.Run, error)
+	FindAllFunc            func(ctx context.Context, limit, offset int) ([]*run.Run, error)
+	FindByThreadIDFunc     func(ctx context.Context, threadID string, limit, offset int) ([]*run.Run, error)
+	FindByAssistantIDFunc  func(ctx context.Context, assistantID string, limit, offset int) ([]*run.Run, error)
+	FindByStatusFunc       func(ctx context.Context, status run.Status, limit, offset int) ([]*run.Run, error)
+	FindActiveByThreadFunc func(ctx context.Context, threadID string) ([]*run.Run, error)
+	UpdateFunc             func(ctx context.Context, r *run.Run) error
+	DeleteFunc             func(ctx context.Context, id string) error
+	LoadFromEventsFunc     func(ctx context.Context, id string) (*run.Run, error)
+}
+
+func NewRunRepository() *RunRepository {
+	return &RunRepository{Runs: make(map[string]*run.Run)}
+}
+
+func (m *RunRepository) Save(ctx context.Context, r *run.Run) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, r)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Runs[r.ID()] = r
+	return nil
+}
+
+func (m *RunRepository) FindByID(ctx context.Context, id string) (*run.Run, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	r, ok := m.Runs[id]
+	if !ok {
+		return nil, errors.NotFound("run", id)
+	}
+	return r, nil
+}
+
+func (m *RunRepository) FindAll(ctx context.Context, limit, offset int) ([]*run.Run, error) {
+	if m.FindAllFunc != nil {
+		return m.FindAllFunc(ctx, limit, offset)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*run.Run, 0, len(m.Runs))
+	for _, r := range m.Runs {
+		result = append(result, r)
+	}
+	return applyPagination(result, limit, offset), nil
+}
+
+func (m *RunRepository) FindByThreadID(ctx context.Context, threadID string, limit, offset int) ([]*run.Run, error) {
+	if m.FindByThreadIDFunc != nil {
+		return m.FindByThreadIDFunc(ctx, threadID, limit, offset)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*run.Run
+	for _, r := range m.Runs {
+		if r.ThreadID() == threadID {
+			result = append(result, r)
+		}
+	}
+	return applyPagination(result, limit, offset), nil
+}
+
+func (m *RunRepository) FindByAssistantID(ctx context.Context, assistantID string, limit, offset int) ([]*run.Run, error) {
+	if m.FindByAssistantIDFunc != nil {
+		return m.FindByAssistantIDFunc(ctx, assistantID, limit, offset)
+	}
+	return []*run.Run{}, nil
+}
+
+func (m *RunRepository) FindByStatus(ctx context.Context, status run.Status, limit, offset int) ([]*run.Run, error) {
+	if m.FindByStatusFunc != nil {
+		return m.FindByStatusFunc(ctx, status, limit, offset)
+	}
+	return []*run.Run{}, nil
+}
+
+func (m *RunRepository) FindActiveByThreadID(ctx context.Context, threadID string) ([]*run.Run, error) {
+	if m.FindActiveByThreadFunc != nil {
+		return m.FindActiveByThreadFunc(ctx, threadID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*run.Run
+	for _, r := range m.Runs {
+		if r.ThreadID() == threadID && !r.Status().IsTerminal() {
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+func (m *RunRepository) Update(ctx context.Context, r *run.Run) error {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, r)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Runs[r.ID()] = r
+	return nil
+}
+
+func (m *RunRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Runs, id)
+	return nil
+}
+
+func (m *RunRepository) LoadFromEvents(ctx context.Context, id string) (*run.Run, error) {
+	if m.LoadFromEventsFunc != nil {
+		return m.LoadFromEventsFunc(ctx, id)
+	}
+	return m.FindByID(ctx, id)
+}
+
+func applyPagination(runs []*run.Run, limit, offset int) []*run.Run {
+	if offset >= len(runs) {
+		return []*run.Run{}
+	}
+	runs = runs[offset:]
+	if limit > 0 && limit < len(runs) {
+		runs = runs[:limit]
+	}
+	return runs
+}

--- a/internal/mocks/task_repo.go
+++ b/internal/mocks/task_repo.go
@@ -1,0 +1,104 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/domain/worker"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type TaskRepository struct {
+	mu     sync.RWMutex
+	Tasks  map[int64]*worker.TaskAssignment
+	NextID int64
+
+	CreateFunc            func(ctx context.Context, task *worker.TaskAssignment) error
+	ClaimFunc             func(ctx context.Context, workerID string, graphIDs []string, leaseDuration time.Duration, maxTasks int) ([]*worker.TaskAssignment, error)
+	CompleteFunc          func(ctx context.Context, id int64) error
+	FailFunc              func(ctx context.Context, id int64, errMsg string) error
+	FindByRunIDFunc       func(ctx context.Context, runID string) (*worker.TaskAssignment, error)
+	FindExpiredLeasesFunc func(ctx context.Context) ([]*worker.TaskAssignment, error)
+	RetryOrFailFunc       func(ctx context.Context, id int64) error
+}
+
+func NewTaskRepository() *TaskRepository {
+	return &TaskRepository{Tasks: make(map[int64]*worker.TaskAssignment)}
+}
+
+func (m *TaskRepository) Create(ctx context.Context, task *worker.TaskAssignment) error {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(ctx, task)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.NextID++
+	task.ID = m.NextID
+	m.Tasks[task.ID] = task
+	return nil
+}
+
+func (m *TaskRepository) Claim(ctx context.Context, workerID string, graphIDs []string, leaseDuration time.Duration, maxTasks int) ([]*worker.TaskAssignment, error) {
+	if m.ClaimFunc != nil {
+		return m.ClaimFunc(ctx, workerID, graphIDs, leaseDuration, maxTasks)
+	}
+	return []*worker.TaskAssignment{}, nil
+}
+
+func (m *TaskRepository) Complete(ctx context.Context, id int64) error {
+	if m.CompleteFunc != nil {
+		return m.CompleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	task, ok := m.Tasks[id]
+	if !ok {
+		return errors.NotFound("task", "")
+	}
+	task.Status = worker.TaskStatusCompleted
+	return nil
+}
+
+func (m *TaskRepository) Fail(ctx context.Context, id int64, errMsg string) error {
+	if m.FailFunc != nil {
+		return m.FailFunc(ctx, id, errMsg)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	task, ok := m.Tasks[id]
+	if !ok {
+		return errors.NotFound("task", "")
+	}
+	task.Status = worker.TaskStatusFailed
+	task.ErrorMessage = errMsg
+	return nil
+}
+
+func (m *TaskRepository) FindByRunID(ctx context.Context, runID string) (*worker.TaskAssignment, error) {
+	if m.FindByRunIDFunc != nil {
+		return m.FindByRunIDFunc(ctx, runID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, t := range m.Tasks {
+		if t.RunID == runID {
+			return t, nil
+		}
+	}
+	return nil, errors.NotFound("task", runID)
+}
+
+func (m *TaskRepository) FindExpiredLeases(ctx context.Context) ([]*worker.TaskAssignment, error) {
+	if m.FindExpiredLeasesFunc != nil {
+		return m.FindExpiredLeasesFunc(ctx)
+	}
+	return []*worker.TaskAssignment{}, nil
+}
+
+func (m *TaskRepository) RetryOrFail(ctx context.Context, id int64) error {
+	if m.RetryOrFailFunc != nil {
+		return m.RetryOrFailFunc(ctx, id)
+	}
+	return nil
+}

--- a/internal/mocks/thread_repo.go
+++ b/internal/mocks/thread_repo.go
@@ -1,0 +1,98 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type ThreadRepository struct {
+	mu      sync.RWMutex
+	Threads map[string]*workflow.Thread
+
+	SaveFunc     func(ctx context.Context, t *workflow.Thread) error
+	FindByIDFunc func(ctx context.Context, id string) (*workflow.Thread, error)
+	ListFunc     func(ctx context.Context, limit, offset int) ([]*workflow.Thread, error)
+	SearchFunc   func(ctx context.Context, filters workflow.ThreadSearchFilters) ([]*workflow.Thread, error)
+	CountFunc    func(ctx context.Context, filters workflow.ThreadSearchFilters) (int, error)
+	UpdateFunc   func(ctx context.Context, t *workflow.Thread) error
+	DeleteFunc   func(ctx context.Context, id string) error
+}
+
+func NewThreadRepository() *ThreadRepository {
+	return &ThreadRepository{Threads: make(map[string]*workflow.Thread)}
+}
+
+func (m *ThreadRepository) Save(ctx context.Context, t *workflow.Thread) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, t)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Threads[t.ID()] = t
+	return nil
+}
+
+func (m *ThreadRepository) FindByID(ctx context.Context, id string) (*workflow.Thread, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, ok := m.Threads[id]
+	if !ok {
+		return nil, errors.NotFound("thread", id)
+	}
+	return t, nil
+}
+
+func (m *ThreadRepository) List(ctx context.Context, limit, offset int) ([]*workflow.Thread, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx, limit, offset)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*workflow.Thread, 0, len(m.Threads))
+	for _, t := range m.Threads {
+		result = append(result, t)
+	}
+	return result, nil
+}
+
+func (m *ThreadRepository) Search(ctx context.Context, filters workflow.ThreadSearchFilters) ([]*workflow.Thread, error) {
+	if m.SearchFunc != nil {
+		return m.SearchFunc(ctx, filters)
+	}
+	return m.List(ctx, filters.Limit, filters.Offset)
+}
+
+func (m *ThreadRepository) Count(ctx context.Context, filters workflow.ThreadSearchFilters) (int, error) {
+	if m.CountFunc != nil {
+		return m.CountFunc(ctx, filters)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.Threads), nil
+}
+
+func (m *ThreadRepository) Update(ctx context.Context, t *workflow.Thread) error {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, t)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Threads[t.ID()] = t
+	return nil
+}
+
+func (m *ThreadRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Threads, id)
+	return nil
+}

--- a/internal/mocks/worker_repo.go
+++ b/internal/mocks/worker_repo.go
@@ -1,0 +1,110 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/domain/worker"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+type WorkerRepository struct {
+	mu      sync.RWMutex
+	Workers map[string]*worker.Worker
+
+	SaveFunc                func(ctx context.Context, w *worker.Worker) error
+	FindByIDFunc            func(ctx context.Context, id string) (*worker.Worker, error)
+	FindAllFunc             func(ctx context.Context) ([]*worker.Worker, error)
+	FindHealthyFunc         func(ctx context.Context, threshold time.Duration) ([]*worker.Worker, error)
+	FindForGraphFunc        func(ctx context.Context, graphID string, threshold time.Duration) (*worker.Worker, error)
+	HeartbeatFunc           func(ctx context.Context, id string, status worker.Status, activeRuns, totalRuns, failedRuns int) error
+	DeleteFunc              func(ctx context.Context, id string) error
+	CleanupStaleFunc        func(ctx context.Context, threshold time.Duration) (int, error)
+	FindGraphDefinitionFunc func(ctx context.Context, graphID string) (*worker.GraphDefinition, error)
+}
+
+func NewWorkerRepository() *WorkerRepository {
+	return &WorkerRepository{Workers: make(map[string]*worker.Worker)}
+}
+
+func (m *WorkerRepository) Save(ctx context.Context, w *worker.Worker) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, w)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Workers[w.ID] = w
+	return nil
+}
+
+func (m *WorkerRepository) FindByID(ctx context.Context, id string) (*worker.Worker, error) {
+	if m.FindByIDFunc != nil {
+		return m.FindByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	w, ok := m.Workers[id]
+	if !ok {
+		return nil, errors.NotFound("worker", id)
+	}
+	return w, nil
+}
+
+func (m *WorkerRepository) FindAll(ctx context.Context) ([]*worker.Worker, error) {
+	if m.FindAllFunc != nil {
+		return m.FindAllFunc(ctx)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*worker.Worker, 0, len(m.Workers))
+	for _, w := range m.Workers {
+		result = append(result, w)
+	}
+	return result, nil
+}
+
+func (m *WorkerRepository) FindHealthy(ctx context.Context, threshold time.Duration) ([]*worker.Worker, error) {
+	if m.FindHealthyFunc != nil {
+		return m.FindHealthyFunc(ctx, threshold)
+	}
+	return m.FindAll(ctx)
+}
+
+func (m *WorkerRepository) FindForGraph(ctx context.Context, graphID string, threshold time.Duration) (*worker.Worker, error) {
+	if m.FindForGraphFunc != nil {
+		return m.FindForGraphFunc(ctx, graphID, threshold)
+	}
+	return nil, errors.NotFound("worker", graphID)
+}
+
+func (m *WorkerRepository) Heartbeat(ctx context.Context, id string, status worker.Status, activeRuns, totalRuns, failedRuns int) error {
+	if m.HeartbeatFunc != nil {
+		return m.HeartbeatFunc(ctx, id, status, activeRuns, totalRuns, failedRuns)
+	}
+	return nil
+}
+
+func (m *WorkerRepository) Delete(ctx context.Context, id string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Workers, id)
+	return nil
+}
+
+func (m *WorkerRepository) CleanupStale(ctx context.Context, threshold time.Duration) (int, error) {
+	if m.CleanupStaleFunc != nil {
+		return m.CleanupStaleFunc(ctx, threshold)
+	}
+	return 0, nil
+}
+
+func (m *WorkerRepository) FindGraphDefinition(ctx context.Context, graphID string) (*worker.GraphDefinition, error) {
+	if m.FindGraphDefinitionFunc != nil {
+		return m.FindGraphDefinitionFunc(ctx, graphID)
+	}
+	return nil, errors.NotFound("graph_definition", graphID)
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [test coverage plan](TEST_COVERAGE_PLAN.md): application layer unit tests with hand-written mock repositories.

- **Mocks**: 8 mock implementations in `internal/mocks/` (run, assistant, thread, graph, checkpoint, interrupt, worker, task repos). Each uses in-memory storage + optional function overrides for custom behavior.
- **Command handlers**: 34 tests across all 15 handlers. Coverage: **0% → 82.9%**
- **Query handlers**: 40 tests across all 17+ handlers. Coverage: **0% → 96.0%**
- **Service layer**: 72 tests covering RunService (multitask strategies, cancel, wait, resume, state updates) and WorkerService (dispatch, status updates, polling, lease monitoring). Coverage: **5.2% → 50.3%**

### Coverage Impact

| Package | Before | After |
|---------|--------|-------|
| `application/command` | 0% | 82.9% |
| `application/query` | 0% | 96.0% |
| `application/service` | 5.2% | 50.3% |
| **Overall** | ~38% | ~47.2% |

### Service layer notes

The remaining uncovered service code (`ExecuteRun`, `waitForRunNATS`, `CronScheduler.Start`) depends on concrete infrastructure types (`*graph.Engine`, `*nats.TaskQueue`, `*postgres.CronRepository`) that cannot be mocked without interface extraction. These will be covered in Phase 4 (integration tests).

## Test plan

- [x] All 146 new tests pass (`go test -short ./...`)
- [x] Pre-commit hooks pass (go-fmt, go-vet, go-imports, commitizen)
- [x] No regressions in existing tests