### PR TITLE
test: phase 3 — infrastructure layer unit tests

### DIFF
--- a/cmd/server/config/config_test.go
+++ b/cmd/server/config/config_test.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoad_Defaults(t *testing.T) {
+	os.Unsetenv("PORT")
+	os.Unsetenv("HOST")
+	os.Unsetenv("DB_HOST")
+	os.Unsetenv("DB_PORT")
+	os.Unsetenv("DB_USER")
+	os.Unsetenv("DB_PASSWORD")
+	os.Unsetenv("DB_NAME")
+	os.Unsetenv("DB_SSLMODE")
+	os.Unsetenv("NATS_URL")
+	os.Unsetenv("DB_READ_HOST")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Port != 8080 {
+		t.Errorf("default port: got %d, want 8080", cfg.Server.Port)
+	}
+	if cfg.Server.Host != "0.0.0.0" {
+		t.Errorf("default host: got %q", cfg.Server.Host)
+	}
+	if cfg.Database.Host != "localhost" {
+		t.Errorf("default db host: got %q", cfg.Database.Host)
+	}
+	if cfg.Database.Port != 5432 {
+		t.Errorf("default db port: got %d", cfg.Database.Port)
+	}
+	if cfg.Database.User != "appuser" {
+		t.Errorf("default db user: got %q", cfg.Database.User)
+	}
+	if cfg.Database.Password != "apppass" {
+		t.Errorf("default db password: got %q", cfg.Database.Password)
+	}
+	if cfg.Database.Database != "appdb" {
+		t.Errorf("default db name: got %q", cfg.Database.Database)
+	}
+	if cfg.Database.SSLMode != "disable" {
+		t.Errorf("default sslmode: got %q", cfg.Database.SSLMode)
+	}
+	if cfg.NATS.URL != "nats://localhost:4222" {
+		t.Errorf("default nats url: got %q", cfg.NATS.URL)
+	}
+	if cfg.ReadDatabase != nil {
+		t.Error("read database should be nil when DB_READ_HOST not set")
+	}
+}
+
+func TestLoad_CustomValues(t *testing.T) {
+	t.Setenv("PORT", "9090")
+	t.Setenv("HOST", "127.0.0.1")
+	t.Setenv("DB_HOST", "db.example.com")
+	t.Setenv("DB_PORT", "5433")
+	t.Setenv("DB_USER", "myuser")
+	t.Setenv("DB_PASSWORD", "mypass")
+	t.Setenv("DB_NAME", "mydb")
+	t.Setenv("DB_SSLMODE", "require")
+	t.Setenv("NATS_URL", "nats://nats.example.com:4222")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Port != 9090 {
+		t.Errorf("port: got %d, want 9090", cfg.Server.Port)
+	}
+	if cfg.Server.Host != "127.0.0.1" {
+		t.Errorf("host: got %q", cfg.Server.Host)
+	}
+	if cfg.Database.Host != "db.example.com" {
+		t.Errorf("db host: got %q", cfg.Database.Host)
+	}
+	if cfg.Database.Port != 5433 {
+		t.Errorf("db port: got %d", cfg.Database.Port)
+	}
+	if cfg.Database.SSLMode != "require" {
+		t.Errorf("sslmode: got %q", cfg.Database.SSLMode)
+	}
+}
+
+func TestLoad_ReadReplica(t *testing.T) {
+	t.Setenv("DB_HOST", "primary.db")
+	t.Setenv("DB_PORT", "5432")
+	t.Setenv("DB_USER", "writer")
+	t.Setenv("DB_PASSWORD", "writerpass")
+	t.Setenv("DB_NAME", "maindb")
+	t.Setenv("DB_SSLMODE", "require")
+	t.Setenv("DB_READ_HOST", "replica.db")
+	t.Setenv("DB_READ_PORT", "5433")
+	t.Setenv("DB_READ_USER", "reader")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ReadDatabase == nil {
+		t.Fatal("read database should not be nil")
+	}
+	if cfg.ReadDatabase.Host != "replica.db" {
+		t.Errorf("read host: got %q", cfg.ReadDatabase.Host)
+	}
+	if cfg.ReadDatabase.Port != 5433 {
+		t.Errorf("read port: got %d", cfg.ReadDatabase.Port)
+	}
+	if cfg.ReadDatabase.User != "reader" {
+		t.Errorf("read user: got %q", cfg.ReadDatabase.User)
+	}
+	if cfg.ReadDatabase.Password != "writerpass" {
+		t.Errorf("read password should inherit from primary: got %q", cfg.ReadDatabase.Password)
+	}
+	if cfg.ReadDatabase.Database != "maindb" {
+		t.Errorf("read database should inherit from primary: got %q", cfg.ReadDatabase.Database)
+	}
+}
+
+func TestLoad_InvalidPort(t *testing.T) {
+	t.Setenv("PORT", "not-a-number")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Port != 8080 {
+		t.Errorf("invalid PORT should fall back to default: got %d", cfg.Server.Port)
+	}
+}
+
+func TestServerAddr(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{
+			Host: "0.0.0.0",
+			Port: 8080,
+		},
+	}
+
+	addr := cfg.ServerAddr()
+	if addr != "0.0.0.0:8080" {
+		t.Errorf("expected 0.0.0.0:8080, got %q", addr)
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	t.Setenv("TEST_VAR", "custom")
+	if v := getEnv("TEST_VAR", "default"); v != "custom" {
+		t.Errorf("expected custom, got %q", v)
+	}
+
+	os.Unsetenv("TEST_VAR_MISSING")
+	if v := getEnv("TEST_VAR_MISSING", "fallback"); v != "fallback" {
+		t.Errorf("expected fallback, got %q", v)
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	t.Setenv("TEST_INT", "42")
+	if v := getEnvInt("TEST_INT", 0); v != 42 {
+		t.Errorf("expected 42, got %d", v)
+	}
+
+	t.Setenv("TEST_INT_BAD", "abc")
+	if v := getEnvInt("TEST_INT_BAD", 99); v != 99 {
+		t.Errorf("expected 99 for invalid int, got %d", v)
+	}
+
+	os.Unsetenv("TEST_INT_MISSING")
+	if v := getEnvInt("TEST_INT_MISSING", 7); v != 7 {
+		t.Errorf("expected 7 for missing var, got %d", v)
+	}
+}

--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -1,0 +1,172 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewOAuthManager_Google(t *testing.T) {
+	m := NewOAuthManager(OAuthConfig{
+		GoogleClientID:     "google-id",
+		GoogleClientSecret: "google-secret",
+		RedirectURL:        "http://localhost:8080/auth",
+		JWTSecret:          "secret",
+	})
+
+	if _, ok := m.configs[ProviderGoogle]; !ok {
+		t.Error("Google provider should be configured")
+	}
+	if _, ok := m.configs[ProviderGitHub]; ok {
+		t.Error("GitHub provider should not be configured")
+	}
+}
+
+func TestNewOAuthManager_GitHub(t *testing.T) {
+	m := NewOAuthManager(OAuthConfig{
+		GitHubClientID:     "github-id",
+		GitHubClientSecret: "github-secret",
+		RedirectURL:        "http://localhost:8080/auth",
+		JWTSecret:          "secret",
+	})
+
+	if _, ok := m.configs[ProviderGitHub]; !ok {
+		t.Error("GitHub provider should be configured")
+	}
+	if _, ok := m.configs[ProviderGoogle]; ok {
+		t.Error("Google provider should not be configured")
+	}
+}
+
+func TestNewOAuthManager_Both(t *testing.T) {
+	m := NewOAuthManager(OAuthConfig{
+		GoogleClientID:     "g-id",
+		GoogleClientSecret: "g-secret",
+		GitHubClientID:     "gh-id",
+		GitHubClientSecret: "gh-secret",
+		RedirectURL:        "http://localhost:8080/auth",
+		JWTSecret:          "secret",
+	})
+
+	if len(m.configs) != 2 {
+		t.Errorf("expected 2 providers, got %d", len(m.configs))
+	}
+}
+
+func TestNewOAuthManager_NoProviders(t *testing.T) {
+	m := NewOAuthManager(OAuthConfig{
+		JWTSecret: "secret",
+	})
+
+	if len(m.configs) != 0 {
+		t.Errorf("expected 0 providers, got %d", len(m.configs))
+	}
+}
+
+func TestNewOAuthManager_RedirectURLs(t *testing.T) {
+	m := NewOAuthManager(OAuthConfig{
+		GoogleClientID:     "g-id",
+		GoogleClientSecret: "g-secret",
+		GitHubClientID:     "gh-id",
+		GitHubClientSecret: "gh-secret",
+		RedirectURL:        "http://localhost:8080/auth",
+		JWTSecret:          "secret",
+	})
+
+	googleConfig := m.configs[ProviderGoogle]
+	if googleConfig.RedirectURL != "http://localhost:8080/auth/google/callback" {
+		t.Errorf("Google redirect: got %q", googleConfig.RedirectURL)
+	}
+
+	githubConfig := m.configs[ProviderGitHub]
+	if githubConfig.RedirectURL != "http://localhost:8080/auth/github/callback" {
+		t.Errorf("GitHub redirect: got %q", githubConfig.RedirectURL)
+	}
+}
+
+func TestGenerateJWT(t *testing.T) {
+	m := NewOAuthManager(OAuthConfig{
+		JWTSecret: "test-secret-key",
+	})
+
+	userInfo := &UserInfo{
+		ID:       "user-123",
+		Email:    "test@example.com",
+		Name:     "Test User",
+		Provider: "google",
+	}
+
+	token, err := m.generateJWT(userInfo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Error("token should not be empty")
+	}
+}
+
+func TestGenerateStateToken(t *testing.T) {
+	token1, err := generateStateToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(token1) == 0 {
+		t.Error("token should not be empty")
+	}
+
+	token2, err := generateStateToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if token1 == token2 {
+		t.Error("tokens should be unique")
+	}
+}
+
+func TestProviderConstants(t *testing.T) {
+	if ProviderGoogle != "google" {
+		t.Errorf("expected 'google', got %q", ProviderGoogle)
+	}
+	if ProviderGitHub != "github" {
+		t.Errorf("expected 'github', got %q", ProviderGitHub)
+	}
+}
+
+func TestUserInfo_Fields(t *testing.T) {
+	u := UserInfo{
+		ID:       "123",
+		Email:    "test@test.com",
+		Name:     "Test",
+		Picture:  "http://pic.url",
+		Provider: "google",
+	}
+
+	if u.ID != "123" || u.Email != "test@test.com" || u.Provider != "google" {
+		t.Errorf("unexpected: %+v", u)
+	}
+}
+
+func TestOAuthConfig_StateStore(t *testing.T) {
+	config := OAuthConfig{
+		JWTSecret:  "secret",
+		StateStore: &mockStateStore{},
+	}
+
+	m := NewOAuthManager(config)
+	if m.stateStore == nil {
+		t.Error("state store should be set")
+	}
+}
+
+type mockStateStore struct{}
+
+func (s *mockStateStore) Set(_ context.Context, _ string, _ interface{}, _ time.Duration) error {
+	return nil
+}
+func (s *mockStateStore) Get(_ context.Context, _ string) (interface{}, error) {
+	return nil, nil
+}
+func (s *mockStateStore) Delete(_ context.Context, _ string) error {
+	return nil
+}

--- a/internal/infrastructure/execution/execution_test.go
+++ b/internal/infrastructure/execution/execution_test.go
@@ -1,0 +1,374 @@
+package execution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/domain/execution"
+	"github.com/duragraph/duragraph/internal/infrastructure/llm"
+)
+
+func TestLLMExecutor_GetProviderFromModel(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+
+	tests := []struct {
+		model    string
+		expected string
+	}{
+		{"gpt-4", "openai"},
+		{"gpt-3.5-turbo", "openai"},
+		{"o1-preview", "openai"},
+		{"chatgpt-4o", "openai"},
+		{"claude-3-opus", "anthropic"},
+		{"claude-3-sonnet", "anthropic"},
+		{"unknown-model", "openai"},
+		{"llama-2", "openai"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := exec.getProviderFromModel(tt.model)
+			if got != tt.expected {
+				t.Errorf("model %q: got %q, want %q", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLLMExecutor_ExtractMessages_SystemPrompt(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"system_prompt": "You are helpful",
+	}
+
+	msgs := exec.extractMessages(config, state)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" || msgs[0].Content != "You are helpful" {
+		t.Errorf("unexpected message: %+v", msgs[0])
+	}
+}
+
+func TestLLMExecutor_ExtractMessages_ConfigMessages(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "Hello"},
+			map[string]interface{}{"role": "assistant", "content": "Hi there"},
+		},
+	}
+
+	msgs := exec.extractMessages(config, state)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" || msgs[0].Content != "Hello" {
+		t.Errorf("msg 0: %+v", msgs[0])
+	}
+}
+
+func TestLLMExecutor_ExtractMessages_Prompt(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"prompt": "Tell me a joke",
+	}
+
+	msgs := exec.extractMessages(config, state)
+	if len(msgs) != 1 || msgs[0].Role != "user" {
+		t.Errorf("unexpected: %+v", msgs)
+	}
+}
+
+func TestLLMExecutor_ExtractMessages_FromState(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+	state.GlobalState["input"] = "state input"
+
+	config := map[string]interface{}{}
+
+	msgs := exec.extractMessages(config, state)
+	if len(msgs) != 1 || msgs[0].Content != "state input" {
+		t.Errorf("expected state input, got %+v", msgs)
+	}
+}
+
+func TestLLMExecutor_ExtractMessages_Combined(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"system_prompt": "Be helpful",
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "Hi"},
+		},
+		"prompt": "Also this",
+	}
+
+	msgs := exec.extractMessages(config, state)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" {
+		t.Errorf("first should be system, got %q", msgs[0].Role)
+	}
+}
+
+func TestLLMExecutor_ExtractMessages_SkipEmpty(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{"role": "", "content": "no role"},
+			map[string]interface{}{"role": "user", "content": ""},
+		},
+	}
+
+	msgs := exec.extractMessages(config, state)
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages (empty role/content skipped), got %d", len(msgs))
+	}
+}
+
+func TestLLMExecutor_ExtractTools(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+
+	config := map[string]interface{}{
+		"tools": []interface{}{
+			map[string]interface{}{
+				"name":        "search",
+				"description": "Search the web",
+				"parameters":  map[string]interface{}{"type": "object"},
+			},
+			map[string]interface{}{
+				"name":        "calculator",
+				"description": "Do math",
+			},
+		},
+	}
+
+	tools := exec.extractTools(config)
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+	if tools[0].Name != "search" || tools[0].Description != "Search the web" {
+		t.Errorf("tool 0: %+v", tools[0])
+	}
+}
+
+func TestLLMExecutor_ExtractTools_Empty(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+
+	tools := exec.extractTools(map[string]interface{}{})
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(tools))
+	}
+}
+
+func TestLLMExecutor_ExtractTools_SkipNoName(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+
+	config := map[string]interface{}{
+		"tools": []interface{}{
+			map[string]interface{}{"description": "no name tool"},
+		},
+	}
+
+	tools := exec.extractTools(config)
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools (no name skipped), got %d", len(tools))
+	}
+}
+
+func TestLLMExecutor_Execute_MissingModel(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+
+	_, err := exec.Execute(context.Background(), "node-1", "llm_call", map[string]interface{}{}, state)
+	if err == nil {
+		t.Error("expected error for missing model")
+	}
+}
+
+func TestLLMExecutor_Execute_NoProvider(t *testing.T) {
+	exec := NewLLMExecutor("", "")
+	state := execution.NewExecutionState("run-1")
+	state.GlobalState["input"] = "test"
+
+	config := map[string]interface{}{
+		"model": "gpt-4",
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "llm_call", config, state)
+	if err == nil {
+		t.Error("expected error for no configured provider")
+	}
+}
+
+func TestLLMExecutor_Execute_NoMessages(t *testing.T) {
+	exec := &LLMExecutor{
+		clients: map[string]llm.Client{
+			"openai": &mockLLMClient{},
+		},
+	}
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"model": "gpt-4",
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "llm_call", config, state)
+	if err == nil {
+		t.Error("expected error for no messages")
+	}
+}
+
+func TestLLMExecutor_Execute_Success(t *testing.T) {
+	exec := &LLMExecutor{
+		clients: map[string]llm.Client{
+			"openai": &mockLLMClient{
+				response: &llm.CompletionResponse{
+					Content: "Hello! How can I help?",
+					Model:   "gpt-4",
+					Usage:   llm.Usage{PromptTokens: 10, CompletionTokens: 8, TotalTokens: 18},
+				},
+			},
+		},
+	}
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"model":  "gpt-4",
+		"prompt": "Hello",
+	}
+
+	output, err := exec.Execute(context.Background(), "node-1", "llm_call", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output["content"] != "Hello! How can I help?" {
+		t.Errorf("content: got %v", output["content"])
+	}
+	if output["provider"] != "openai" {
+		t.Errorf("provider: got %v", output["provider"])
+	}
+	if state.GlobalState["last_llm_response"] != "Hello! How can I help?" {
+		t.Error("last_llm_response not set in state")
+	}
+}
+
+func TestLLMExecutor_Execute_WithToolCalls(t *testing.T) {
+	exec := &LLMExecutor{
+		clients: map[string]llm.Client{
+			"openai": &mockLLMClient{
+				response: &llm.CompletionResponse{
+					Content: "",
+					Model:   "gpt-4",
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc-1", Name: "search", Arguments: map[string]interface{}{"q": "test"}},
+					},
+				},
+			},
+		},
+	}
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"model":  "gpt-4",
+		"prompt": "Search for test",
+	}
+
+	output, err := exec.Execute(context.Background(), "node-1", "llm_call", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	toolCalls, ok := output["tool_calls"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tool_calls, got %T", output["tool_calls"])
+	}
+	if len(toolCalls) != 1 || toolCalls[0]["name"] != "search" {
+		t.Errorf("tool_calls: %v", toolCalls)
+	}
+}
+
+func TestLLMExecutor_Execute_CustomTemperature(t *testing.T) {
+	var capturedReq llm.CompletionRequest
+	exec := &LLMExecutor{
+		clients: map[string]llm.Client{
+			"openai": &mockLLMClient{
+				completeFn: func(ctx context.Context, req llm.CompletionRequest) (*llm.CompletionResponse, error) {
+					capturedReq = req
+					return &llm.CompletionResponse{Content: "ok"}, nil
+				},
+			},
+		},
+	}
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"model":       "gpt-4",
+		"prompt":      "Hi",
+		"temperature": 0.2,
+		"max_tokens":  500.0,
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "llm_call", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedReq.Temperature != 0.2 {
+		t.Errorf("temperature: got %f, want 0.2", capturedReq.Temperature)
+	}
+	if capturedReq.MaxTokens != 500 {
+		t.Errorf("max_tokens: got %d, want 500", capturedReq.MaxTokens)
+	}
+}
+
+func TestNewLLMExecutor_Clients(t *testing.T) {
+	exec := NewLLMExecutor("sk-openai", "sk-anthropic")
+	if len(exec.clients) != 2 {
+		t.Errorf("expected 2 clients, got %d", len(exec.clients))
+	}
+
+	exec2 := NewLLMExecutor("sk-openai", "")
+	if len(exec2.clients) != 1 {
+		t.Errorf("expected 1 client, got %d", len(exec2.clients))
+	}
+
+	exec3 := NewLLMExecutor("", "")
+	if len(exec3.clients) != 0 {
+		t.Errorf("expected 0 clients, got %d", len(exec3.clients))
+	}
+}
+
+type mockLLMClient struct {
+	response   *llm.CompletionResponse
+	err        error
+	completeFn func(ctx context.Context, req llm.CompletionRequest) (*llm.CompletionResponse, error)
+}
+
+func (m *mockLLMClient) Complete(ctx context.Context, req llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	if m.completeFn != nil {
+		return m.completeFn(ctx, req)
+	}
+	return m.response, m.err
+}
+
+func (m *mockLLMClient) CompleteStream(ctx context.Context, req llm.CompletionRequest, callback llm.StreamCallback) (*llm.CompletionResponse, error) {
+	if m.completeFn != nil {
+		return m.completeFn(ctx, req)
+	}
+	return m.response, m.err
+}
+
+func (m *mockLLMClient) Name() string { return "mock" }

--- a/internal/infrastructure/execution/tool_executor_test.go
+++ b/internal/infrastructure/execution/tool_executor_test.go
@@ -1,0 +1,203 @@
+package execution
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/domain/execution"
+	"github.com/duragraph/duragraph/internal/infrastructure/tools"
+)
+
+func TestToolExecutor_Execute_Success(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&simpleTool{
+		name: "echo",
+		fn: func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+			return map[string]interface{}{"echoed": args["input"]}, nil
+		},
+	})
+
+	exec := NewToolExecutor(registry)
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"tool":      "echo",
+		"arguments": map[string]interface{}{"input": "hello"},
+	}
+
+	output, err := exec.Execute(context.Background(), "node-1", "tool", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output["tool"] != "echo" {
+		t.Errorf("tool: got %v", output["tool"])
+	}
+	result, ok := output["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("result type: %T", output["result"])
+	}
+	if result["echoed"] != "hello" {
+		t.Errorf("echoed: got %v", result["echoed"])
+	}
+
+	if state.GlobalState["last_tool_result"] == nil {
+		t.Error("last_tool_result not set in state")
+	}
+}
+
+func TestToolExecutor_Execute_MissingToolName(t *testing.T) {
+	exec := NewToolExecutor(tools.NewRegistry())
+	state := execution.NewExecutionState("run-1")
+
+	_, err := exec.Execute(context.Background(), "node-1", "tool", map[string]interface{}{}, state)
+	if err == nil {
+		t.Error("expected error for missing tool name")
+	}
+}
+
+func TestToolExecutor_Execute_ToolNotFound(t *testing.T) {
+	exec := NewToolExecutor(tools.NewRegistry())
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"tool": "nonexistent",
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "tool", config, state)
+	if err == nil {
+		t.Error("expected error for non-existent tool")
+	}
+}
+
+func TestToolExecutor_Execute_SaveToState(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&simpleTool{
+		name: "calc",
+		fn: func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+			return map[string]interface{}{"answer": 42}, nil
+		},
+	})
+
+	exec := NewToolExecutor(registry)
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"tool":          "calc",
+		"save_to_state": "calc_result",
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "tool", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if state.GlobalState["calc_result"] == nil {
+		t.Error("calc_result not set in state")
+	}
+	if state.GlobalState["last_tool_result"] != nil {
+		t.Error("last_tool_result should not be set when save_to_state is specified")
+	}
+}
+
+func TestToolExecutor_Execute_UseState(t *testing.T) {
+	var capturedArgs map[string]interface{}
+	registry := tools.NewRegistry()
+	registry.Register(&simpleTool{
+		name: "inspect",
+		fn: func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+			capturedArgs = args
+			return map[string]interface{}{}, nil
+		},
+	})
+
+	exec := NewToolExecutor(registry)
+	state := execution.NewExecutionState("run-1")
+	state.GlobalState["context_key"] = "context_value"
+
+	config := map[string]interface{}{
+		"tool":      "inspect",
+		"use_state": true,
+		"arguments": map[string]interface{}{"explicit": "arg"},
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "tool", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedArgs["explicit"] != "arg" {
+		t.Error("explicit arg should be preserved")
+	}
+	if capturedArgs["context_key"] != "context_value" {
+		t.Error("state should be merged into args")
+	}
+}
+
+func TestToolExecutor_Execute_UseState_ExplicitOverridesState(t *testing.T) {
+	var capturedArgs map[string]interface{}
+	registry := tools.NewRegistry()
+	registry.Register(&simpleTool{
+		name: "inspect",
+		fn: func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+			capturedArgs = args
+			return map[string]interface{}{}, nil
+		},
+	})
+
+	exec := NewToolExecutor(registry)
+	state := execution.NewExecutionState("run-1")
+	state.GlobalState["key"] = "from_state"
+
+	config := map[string]interface{}{
+		"tool":      "inspect",
+		"use_state": true,
+		"arguments": map[string]interface{}{"key": "from_args"},
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "tool", config, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedArgs["key"] != "from_args" {
+		t.Errorf("explicit args should override state, got %v", capturedArgs["key"])
+	}
+}
+
+func TestToolExecutor_Execute_ToolError(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&simpleTool{
+		name: "failing",
+		fn: func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+			return nil, fmt.Errorf("tool broke")
+		},
+	})
+
+	exec := NewToolExecutor(registry)
+	state := execution.NewExecutionState("run-1")
+
+	config := map[string]interface{}{
+		"tool": "failing",
+	}
+
+	_, err := exec.Execute(context.Background(), "node-1", "tool", config, state)
+	if err == nil {
+		t.Error("expected error from failing tool")
+	}
+}
+
+type simpleTool struct {
+	name string
+	fn   func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error)
+}
+
+func (t *simpleTool) Name() string        { return t.name }
+func (t *simpleTool) Description() string { return "test tool" }
+func (t *simpleTool) Schema() map[string]interface{} {
+	return map[string]interface{}{}
+}
+func (t *simpleTool) Execute(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+	return t.fn(ctx, args)
+}

--- a/internal/infrastructure/graph/engine_test.go
+++ b/internal/infrastructure/graph/engine_test.go
@@ -1,0 +1,375 @@
+package graph
+
+import (
+	"context"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/domain/execution"
+	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
+)
+
+func TestNewEngine(t *testing.T) {
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+	if engine == nil {
+		t.Fatal("engine should not be nil")
+	}
+	if engine.eventBus != eb {
+		t.Error("eventBus not set correctly")
+	}
+}
+
+func TestNewEngineWithGraphRepo(t *testing.T) {
+	eb := eventbus.New()
+	engine := NewEngineWithGraphRepo(eb, nil)
+	if engine == nil {
+		t.Fatal("engine should not be nil")
+	}
+}
+
+func TestSetGraphRepository(t *testing.T) {
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+	engine.SetGraphRepository(nil)
+}
+
+func TestBuildEdgeMap(t *testing.T) {
+	edges := []workflow.Edge{
+		{Source: "a", Target: "b"},
+		{Source: "b", Target: "c"},
+	}
+
+	em := buildEdgeMap(edges)
+	if len(em) != 2 {
+		t.Fatalf("expected 2 edges, got %d", len(em))
+	}
+	if _, ok := em["a:b"]; !ok {
+		t.Error("missing edge a:b")
+	}
+	if _, ok := em["b:c"]; !ok {
+		t.Error("missing edge b:c")
+	}
+}
+
+func TestHasCycle_NoCycle(t *testing.T) {
+	nodes := []workflow.Node{
+		{ID: "a"}, {ID: "b"}, {ID: "c"},
+	}
+	adj := map[string][]string{
+		"a": {"b"},
+		"b": {"c"},
+		"c": {},
+	}
+
+	if hasCycle(adj, nodes) {
+		t.Error("should not detect cycle in DAG")
+	}
+}
+
+func TestHasCycle_WithCycle(t *testing.T) {
+	nodes := []workflow.Node{
+		{ID: "a"}, {ID: "b"}, {ID: "c"},
+	}
+	adj := map[string][]string{
+		"a": {"b"},
+		"b": {"c"},
+		"c": {"a"},
+	}
+
+	if !hasCycle(adj, nodes) {
+		t.Error("should detect cycle")
+	}
+}
+
+func TestHasCycle_SelfLoop(t *testing.T) {
+	nodes := []workflow.Node{{ID: "a"}}
+	adj := map[string][]string{"a": {"a"}}
+
+	if !hasCycle(adj, nodes) {
+		t.Error("should detect self-loop")
+	}
+}
+
+func TestEvaluateCondition_Match(t *testing.T) {
+	condition := map[string]interface{}{"status": "done"}
+	output := map[string]interface{}{"status": "done"}
+	state := execution.NewExecutionState("run-1")
+
+	if !evaluateCondition(condition, output, state) {
+		t.Error("condition should match")
+	}
+}
+
+func TestEvaluateCondition_NoMatch(t *testing.T) {
+	condition := map[string]interface{}{"status": "done"}
+	output := map[string]interface{}{"status": "pending"}
+	state := execution.NewExecutionState("run-1")
+
+	if evaluateCondition(condition, output, state) {
+		t.Error("condition should not match")
+	}
+}
+
+func TestExtractStringList_StringSlice(t *testing.T) {
+	m := map[string]interface{}{
+		"nodes": []string{"a", "b", "c"},
+	}
+
+	result := extractStringList(m, "nodes")
+	if len(result) != 3 || result[0] != "a" {
+		t.Errorf("expected [a b c], got %v", result)
+	}
+}
+
+func TestExtractStringList_InterfaceSlice(t *testing.T) {
+	m := map[string]interface{}{
+		"nodes": []interface{}{"a", "b"},
+	}
+
+	result := extractStringList(m, "nodes")
+	if len(result) != 2 || result[0] != "a" {
+		t.Errorf("expected [a b], got %v", result)
+	}
+}
+
+func TestExtractStringList_Missing(t *testing.T) {
+	m := map[string]interface{}{}
+
+	result := extractStringList(m, "nodes")
+	if len(result) != 0 {
+		t.Errorf("expected empty, got %v", result)
+	}
+}
+
+func TestContainsString(t *testing.T) {
+	slice := []string{"a", "b", "c"}
+
+	if !containsString(slice, "b") {
+		t.Error("should contain 'b'")
+	}
+	if containsString(slice, "d") {
+		t.Error("should not contain 'd'")
+	}
+	if containsString(nil, "a") {
+		t.Error("nil slice should not contain anything")
+	}
+}
+
+func TestGetString(t *testing.T) {
+	m := map[string]interface{}{
+		"name": "test",
+		"num":  42,
+	}
+
+	if v := getString(m, "name"); v != "test" {
+		t.Errorf("expected 'test', got %q", v)
+	}
+	if v := getString(m, "num"); v != "" {
+		t.Errorf("non-string should return empty, got %q", v)
+	}
+	if v := getString(m, "missing"); v != "" {
+		t.Errorf("missing key should return empty, got %q", v)
+	}
+}
+
+func TestGetMapKeys(t *testing.T) {
+	m := map[string]interface{}{"a": 1, "b": 2, "c": 3}
+	keys := getMapKeys(m)
+	if len(keys) != 3 {
+		t.Errorf("expected 3 keys, got %d", len(keys))
+	}
+}
+
+func TestBuildExecutionPlan_Simple(t *testing.T) {
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{Source: "start", Target: "end"},
+	}
+
+	graph, err := workflow.NewGraph("asst-1", "test", "1.0", "test graph", nodes, edges, nil)
+	if err != nil {
+		t.Fatalf("NewGraph error: %v", err)
+	}
+
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+
+	plan, err := engine.buildExecutionPlan(graph)
+	if err != nil {
+		t.Fatalf("buildExecutionPlan error: %v", err)
+	}
+
+	if len(plan.StartNodes) == 0 {
+		t.Error("should have at least one start node")
+	}
+	if len(plan.NodeMap) != 2 {
+		t.Errorf("expected 2 nodes in plan, got %d", len(plan.NodeMap))
+	}
+}
+
+func TestBuildExecutionPlan_NoStartNode(t *testing.T) {
+	// NewGraph validates start/end nodes, so we test that validation rejects
+	// graphs without start nodes.
+	nodes := []workflow.Node{
+		{ID: "a", Type: workflow.NodeTypeLLM},
+		{ID: "b", Type: workflow.NodeTypeLLM},
+	}
+	edges := []workflow.Edge{
+		{Source: "a", Target: "b"},
+		{Source: "b", Target: "a"},
+	}
+
+	_, err := workflow.NewGraph("asst-1", "test", "1.0", "test", nodes, edges, nil)
+	if err == nil {
+		t.Error("expected validation error for graph without start node")
+	}
+}
+
+func TestEngine_Execute_SimpleGraph(t *testing.T) {
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{Source: "start", Target: "end"},
+	}
+
+	graph, err := workflow.NewGraph("asst-1", "test", "1.0", "test", nodes, edges, nil)
+	if err != nil {
+		t.Fatalf("NewGraph error: %v", err)
+	}
+
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+
+	output, err := engine.Execute(context.Background(), "run-1", graph, map[string]interface{}{"message": "hello"}, eb)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if output == nil {
+		t.Error("output should not be nil")
+	}
+}
+
+func TestEngine_Execute_CancelledContext(t *testing.T) {
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "process", Type: workflow.NodeTypeLLM, Config: map[string]interface{}{}},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{Source: "start", Target: "process"},
+		{Source: "process", Target: "end"},
+	}
+
+	graph, err := workflow.NewGraph("asst-1", "test", "1.0", "test", nodes, edges, nil)
+	if err != nil {
+		t.Fatalf("NewGraph error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+
+	_, err = engine.Execute(ctx, "run-1", graph, map[string]interface{}{}, eb)
+	if err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestEngine_Execute_InterruptBefore(t *testing.T) {
+	nodes := []workflow.Node{
+		{ID: "start", Type: workflow.NodeTypeStart},
+		{ID: "approval", Type: workflow.NodeTypeLLM},
+		{ID: "end", Type: workflow.NodeTypeEnd},
+	}
+	edges := []workflow.Edge{
+		{Source: "start", Target: "approval"},
+		{Source: "approval", Target: "end"},
+	}
+
+	graph, err := workflow.NewGraph("asst-1", "test", "1.0", "test", nodes, edges, nil)
+	if err != nil {
+		t.Fatalf("NewGraph error: %v", err)
+	}
+
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+
+	input := map[string]interface{}{
+		"interrupt_before": []interface{}{"approval"},
+	}
+
+	output, err := engine.Execute(context.Background(), "run-1", graph, input, eb)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if output["requires_action"] != true {
+		t.Error("expected requires_action=true for interrupt_before")
+	}
+	if output["node_id"] != "approval" {
+		t.Errorf("expected node_id=approval, got %v", output["node_id"])
+	}
+}
+
+func TestBuildGraphFromInline(t *testing.T) {
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+
+	inline := map[string]interface{}{
+		"name": "test-subgraph",
+		"nodes": []interface{}{
+			map[string]interface{}{"id": "s1", "type": "start"},
+			map[string]interface{}{"id": "s2", "type": "end"},
+		},
+		"edges": []interface{}{
+			map[string]interface{}{"source": "s1", "target": "s2"},
+		},
+	}
+
+	graph, err := engine.buildGraphFromInline(inline)
+	if err != nil {
+		t.Fatalf("buildGraphFromInline error: %v", err)
+	}
+
+	if graph.Name() != "test-subgraph" {
+		t.Errorf("expected name 'test-subgraph', got %q", graph.Name())
+	}
+	if len(graph.Nodes()) != 2 {
+		t.Errorf("expected 2 nodes, got %d", len(graph.Nodes()))
+	}
+	if len(graph.Edges()) != 1 {
+		t.Errorf("expected 1 edge, got %d", len(graph.Edges()))
+	}
+}
+
+func TestBuildGraphFromInline_DefaultName(t *testing.T) {
+	eb := eventbus.New()
+	engine := NewEngine(eb)
+
+	inline := map[string]interface{}{
+		"nodes": []interface{}{
+			map[string]interface{}{"id": "s1", "type": "start"},
+			map[string]interface{}{"id": "s2", "type": "end"},
+		},
+		"edges": []interface{}{
+			map[string]interface{}{"source": "s1", "target": "s2"},
+		},
+	}
+
+	graph, err := engine.buildGraphFromInline(inline)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if graph.Name() != "inline-subgraph" {
+		t.Errorf("expected 'inline-subgraph', got %q", graph.Name())
+	}
+}

--- a/internal/infrastructure/http/dto/dto_test.go
+++ b/internal/infrastructure/http/dto/dto_test.go
@@ -1,0 +1,588 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestStringOrSlice_UnmarshalJSON_String(t *testing.T) {
+	input := `"values"`
+	var s StringOrSlice
+	if err := json.Unmarshal([]byte(input), &s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s) != 1 || s[0] != "values" {
+		t.Errorf("expected [values], got %v", s)
+	}
+}
+
+func TestStringOrSlice_UnmarshalJSON_Slice(t *testing.T) {
+	input := `["values","messages"]`
+	var s StringOrSlice
+	if err := json.Unmarshal([]byte(input), &s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s) != 2 || s[0] != "values" || s[1] != "messages" {
+		t.Errorf("expected [values messages], got %v", s)
+	}
+}
+
+func TestStringOrSlice_UnmarshalJSON_Invalid(t *testing.T) {
+	input := `123`
+	var s StringOrSlice
+	if err := json.Unmarshal([]byte(input), &s); err == nil {
+		t.Error("expected error for invalid input")
+	}
+}
+
+func TestStringOrSlice_InStruct(t *testing.T) {
+	jsonStr := `{"assistant_id":"a1","stream_mode":"events"}`
+	var req CreateRunRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(req.StreamMode) != 1 || req.StreamMode[0] != "events" {
+		t.Errorf("expected [events], got %v", req.StreamMode)
+	}
+}
+
+func TestStringOrSlice_InStruct_Array(t *testing.T) {
+	jsonStr := `{"assistant_id":"a1","stream_mode":["values","updates"]}`
+	var req CreateRunRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(req.StreamMode) != 2 {
+		t.Errorf("expected 2 modes, got %d", len(req.StreamMode))
+	}
+}
+
+func TestCreateRunRequest_Roundtrip(t *testing.T) {
+	boolTrue := true
+	req := CreateRunRequest{
+		AssistantID:       "asst-1",
+		ThreadID:          "thread-1",
+		Input:             map[string]interface{}{"message": "hello"},
+		StreamMode:        StringOrSlice{"values", "messages"},
+		StreamSubgraphs:   &boolTrue,
+		MultitaskStrategy: "reject",
+		InterruptBefore:   []string{"node1"},
+		InterruptAfter:    []string{"node2"},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded CreateRunRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.AssistantID != req.AssistantID {
+		t.Errorf("assistant_id: got %q, want %q", decoded.AssistantID, req.AssistantID)
+	}
+	if decoded.MultitaskStrategy != "reject" {
+		t.Errorf("multitask_strategy: got %q", decoded.MultitaskStrategy)
+	}
+	if len(decoded.InterruptBefore) != 1 || decoded.InterruptBefore[0] != "node1" {
+		t.Errorf("interrupt_before: got %v", decoded.InterruptBefore)
+	}
+}
+
+func TestCreateRunResponse_JSON(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	resp := CreateRunResponse{
+		RunID:       "run-1",
+		ThreadID:    "thread-1",
+		AssistantID: "asst-1",
+		Status:      "pending",
+		CreatedAt:   now,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded CreateRunResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.RunID != "run-1" || decoded.Status != "pending" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestGetRunResponse_OptionalFields(t *testing.T) {
+	resp := GetRunResponse{
+		RunID:  "run-1",
+		Status: "success",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	if _, ok := m["output"]; ok {
+		t.Error("empty output should be omitted")
+	}
+	if _, ok := m["error"]; ok {
+		t.Error("empty error should be omitted")
+	}
+	if _, ok := m["started_at"]; ok {
+		t.Error("nil started_at should be omitted")
+	}
+}
+
+func TestSubmitToolOutputsRequest_Roundtrip(t *testing.T) {
+	req := SubmitToolOutputsRequest{
+		ToolOutputs: []ToolOutput{
+			{ToolCallID: "tc-1", Output: "result1"},
+			{ToolCallID: "tc-2", Output: "result2"},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded SubmitToolOutputsRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if len(decoded.ToolOutputs) != 2 {
+		t.Fatalf("expected 2 tool outputs, got %d", len(decoded.ToolOutputs))
+	}
+	if decoded.ToolOutputs[0].ToolCallID != "tc-1" {
+		t.Errorf("unexpected tool_call_id: %q", decoded.ToolOutputs[0].ToolCallID)
+	}
+}
+
+func TestCreateAssistantRequest_Roundtrip(t *testing.T) {
+	req := CreateAssistantRequest{
+		GraphID:      "graph-1",
+		Name:         "My Assistant",
+		Description:  "A test assistant",
+		Model:        "gpt-4",
+		Instructions: "Be helpful",
+		Tools: []map[string]interface{}{
+			{"type": "function", "name": "search"},
+		},
+		Metadata: map[string]interface{}{"team": "platform"},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded CreateAssistantRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.Name != "My Assistant" || decoded.Model != "gpt-4" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+	if len(decoded.Tools) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(decoded.Tools))
+	}
+}
+
+func TestUpdateAssistantRequest_PartialUpdate(t *testing.T) {
+	jsonStr := `{"name":"Updated Name"}`
+	var req UpdateAssistantRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if req.Name == nil || *req.Name != "Updated Name" {
+		t.Errorf("expected name to be set")
+	}
+	if req.Description != nil {
+		t.Error("description should be nil when not provided")
+	}
+	if req.Model != nil {
+		t.Error("model should be nil when not provided")
+	}
+}
+
+func TestAssistantResponse_JSON(t *testing.T) {
+	resp := AssistantResponse{
+		ID:        "asst-1",
+		GraphID:   "graph-1",
+		Name:      "Test",
+		Version:   3,
+		CreatedAt: "2026-01-01T00:00:00Z",
+		UpdatedAt: "2026-01-02T00:00:00Z",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	json.Unmarshal(data, &decoded)
+
+	if decoded["assistant_id"] != "asst-1" {
+		t.Errorf("expected assistant_id, got %v", decoded)
+	}
+	if int(decoded["version"].(float64)) != 3 {
+		t.Errorf("expected version 3")
+	}
+}
+
+func TestThreadResponse_JSON(t *testing.T) {
+	resp := ThreadResponse{
+		ThreadID:  "t-1",
+		Status:    "idle",
+		Values:    map[string]interface{}{"key": "val"},
+		CreatedAt: "2026-01-01T00:00:00Z",
+		UpdatedAt: "2026-01-01T00:00:00Z",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded ThreadResponse
+	json.Unmarshal(data, &decoded)
+
+	if decoded.ThreadID != "t-1" || decoded.Status != "idle" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestErrorResponse_JSON(t *testing.T) {
+	resp := ErrorResponse{
+		Error:     "NOT_FOUND",
+		Message:   "resource not found",
+		Code:      "NOT_FOUND",
+		RequestID: "req-123",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded ErrorResponse
+	json.Unmarshal(data, &decoded)
+
+	if decoded.Error != "NOT_FOUND" || decoded.RequestID != "req-123" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestSearchAssistantsRequest_DefaultValues(t *testing.T) {
+	jsonStr := `{}`
+	var req SearchAssistantsRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if req.Limit != 0 {
+		t.Errorf("default limit should be 0 (zero value), got %d", req.Limit)
+	}
+	if req.GraphID != "" {
+		t.Errorf("graph_id should be empty, got %q", req.GraphID)
+	}
+}
+
+func TestSearchThreadsRequest_Roundtrip(t *testing.T) {
+	req := SearchThreadsRequest{
+		Status: "idle",
+		Limit:  25,
+		Offset: 10,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded SearchThreadsRequest
+	json.Unmarshal(data, &decoded)
+
+	if decoded.Status != "idle" || decoded.Limit != 25 || decoded.Offset != 10 {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestThreadStateResponse_JSON(t *testing.T) {
+	resp := ThreadStateResponse{
+		Values:       map[string]interface{}{"msg": "hello"},
+		Next:         []string{"node1", "node2"},
+		CheckpointID: "cp-1",
+		CreatedAt:    time.Now().Unix(),
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded ThreadStateResponse
+	json.Unmarshal(data, &decoded)
+
+	if decoded.CheckpointID != "cp-1" || len(decoded.Next) != 2 {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestResumeRunRequest_WithCommand(t *testing.T) {
+	jsonStr := `{
+		"command": {
+			"resume": "approved",
+			"update": {"status": "active"},
+			"goto": "next_node",
+			"send": [{"node": "n1", "message": "hello"}]
+		}
+	}`
+
+	var req ResumeRunRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if req.Command == nil {
+		t.Fatal("command should not be nil")
+	}
+	if req.Command.Resume != "approved" {
+		t.Errorf("resume: got %v", req.Command.Resume)
+	}
+	if req.Command.Goto != "next_node" {
+		t.Errorf("goto: got %q", req.Command.Goto)
+	}
+	if len(req.Command.Send) != 1 || req.Command.Send[0].Node != "n1" {
+		t.Errorf("send: got %v", req.Command.Send)
+	}
+}
+
+func TestGraphResponse_JSON(t *testing.T) {
+	resp := GraphResponse{
+		Nodes: []GraphNodeResponse{
+			{ID: "start", Type: "start"},
+			{ID: "llm", Type: "llm_call", Config: map[string]interface{}{"model": "gpt-4"}},
+		},
+		Edges: []GraphEdgeResponse{
+			{Source: "start", Target: "llm"},
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded GraphResponse
+	json.Unmarshal(data, &decoded)
+
+	if len(decoded.Nodes) != 2 || len(decoded.Edges) != 1 {
+		t.Errorf("unexpected counts: nodes=%d edges=%d", len(decoded.Nodes), len(decoded.Edges))
+	}
+}
+
+func TestCopyThreadRequest_JSON(t *testing.T) {
+	jsonStr := `{"checkpoint_id":"cp-123"}`
+	var req CopyThreadRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if req.CheckpointID != "cp-123" {
+		t.Errorf("expected cp-123, got %q", req.CheckpointID)
+	}
+}
+
+func TestAssistantVersionResponse_JSON(t *testing.T) {
+	resp := AssistantVersionResponse{
+		ID:          "v-1",
+		AssistantID: "asst-1",
+		Version:     2,
+		GraphID:     "graph-1",
+		Config:      map[string]interface{}{"key": "val"},
+		CreatedAt:   time.Now().Unix(),
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded AssistantVersionResponse
+	json.Unmarshal(data, &decoded)
+
+	if decoded.Version != 2 || decoded.AssistantID != "asst-1" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestWorkerDTOs_Roundtrip(t *testing.T) {
+	req := RegisterWorkerRequest{
+		WorkerID: "w-1",
+		Name:     "test-worker",
+		Capabilities: WorkerCapabilities{
+			Graphs:            []string{"graph-1"},
+			MaxConcurrentRuns: 5,
+		},
+		GraphDefinitions: []GraphDefinition{
+			{
+				GraphID:    "graph-1",
+				Name:       "Test Graph",
+				EntryPoint: "start",
+				Nodes: []NodeDefinition{
+					{ID: "start", Type: "start"},
+				},
+				Edges: []EdgeDefinition{
+					{Source: "start", Target: "end"},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded RegisterWorkerRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.WorkerID != "w-1" || decoded.Capabilities.MaxConcurrentRuns != 5 {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+	if len(decoded.GraphDefinitions) != 1 || decoded.GraphDefinitions[0].EntryPoint != "start" {
+		t.Errorf("graph defs: %+v", decoded.GraphDefinitions)
+	}
+}
+
+func TestCronDTOs_Roundtrip(t *testing.T) {
+	enabled := true
+	endTime := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	req := CreateCronRequest{
+		AssistantID:       "asst-1",
+		Schedule:          "0 * * * *",
+		Timezone:          "America/New_York",
+		Enabled:           &enabled,
+		EndTime:           &endTime,
+		MultitaskStrategy: "enqueue",
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded CreateCronRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.Schedule != "0 * * * *" || decoded.Timezone != "America/New_York" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+	if decoded.Enabled == nil || !*decoded.Enabled {
+		t.Error("enabled should be true")
+	}
+}
+
+func TestStoreDTOs_Roundtrip(t *testing.T) {
+	req := PutStoreItemRequest{
+		Namespace: []string{"users", "profile"},
+		Key:       "user-123",
+		Value:     map[string]interface{}{"name": "Test User"},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded PutStoreItemRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if len(decoded.Namespace) != 2 || decoded.Key != "user-123" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestSearchStoreItemsRequest_JSON(t *testing.T) {
+	req := SearchStoreItemsRequest{
+		NamespacePrefix: []string{"users"},
+		Filter:          map[string]interface{}{"active": true},
+		Limit:           50,
+		Query:           "search term",
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded SearchStoreItemsRequest
+	json.Unmarshal(data, &decoded)
+
+	if decoded.Limit != 50 || decoded.Query != "search term" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+}
+
+func TestInterruptResponse_JSON(t *testing.T) {
+	resp := InterruptResponse{
+		RunID:         "run-1",
+		ThreadID:      "t-1",
+		Status:        "requires_action",
+		InterruptType: "before",
+		NodeID:        "approval_node",
+		Reason:        "needs human approval",
+		ToolCalls: []map[string]interface{}{
+			{"id": "tc-1", "name": "approve"},
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded InterruptResponse
+	json.Unmarshal(data, &decoded)
+
+	if decoded.InterruptType != "before" || decoded.NodeID != "approval_node" {
+		t.Errorf("unexpected: %+v", decoded)
+	}
+	if len(decoded.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call, got %d", len(decoded.ToolCalls))
+	}
+}
+
+func TestCountResponse_JSON(t *testing.T) {
+	resp := CountResponse{Count: 42}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded CountResponse
+	json.Unmarshal(data, &decoded)
+
+	if decoded.Count != 42 {
+		t.Errorf("expected 42, got %d", decoded.Count)
+	}
+}

--- a/internal/infrastructure/http/middleware/auth_test.go
+++ b/internal/infrastructure/http/middleware/auth_test.go
@@ -1,0 +1,566 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+func makeJWT(t *testing.T, secret string, claims JWTClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("failed to sign JWT: %v", err)
+	}
+	return signed
+}
+
+func TestJWT_SkipPaths(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   "secret",
+		RequireAuth: true,
+		SkipPaths:   []string{"/health", "/metrics"},
+	})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/health")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestJWT_APIKey_Valid(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:    "secret",
+		RequireAuth:  true,
+		ValidAPIKeys: map[string]bool{"valid-key": true},
+	})
+
+	handler := mw(func(c echo.Context) error {
+		if c.Get("auth_type") != "api_key" {
+			t.Error("auth_type should be api_key")
+		}
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("X-API-Key", "valid-key")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestJWT_APIKey_Invalid(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:    "secret",
+		RequireAuth:  true,
+		ValidAPIKeys: map[string]bool{"valid-key": true},
+	})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("X-API-Key", "bad-key")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for invalid API key")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+func TestJWT_CustomAPIKeyHeader(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:    "secret",
+		RequireAuth:  true,
+		APIKeyHeader: "Authorization-Key",
+		ValidAPIKeys: map[string]bool{"my-key": true},
+	})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Authorization-Key", "my-key")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/test")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestJWT_MissingAuth_Required(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   "secret",
+		RequireAuth: true,
+	})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for missing auth")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+func TestJWT_MissingAuth_Optional(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   "secret",
+		RequireAuth: false,
+	})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestJWT_ValidToken(t *testing.T) {
+	secret := "test-secret-key"
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   secret,
+		RequireAuth: true,
+	})
+
+	claims := JWTClaims{
+		UserID:   "user-123",
+		Username: "testuser",
+		Email:    "test@example.com",
+		Roles:    []string{"admin"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	tokenStr := makeJWT(t, secret, claims)
+
+	handler := mw(func(c echo.Context) error {
+		if c.Get("user_id") != "user-123" {
+			t.Errorf("user_id: got %v", c.Get("user_id"))
+		}
+		if c.Get("username") != "testuser" {
+			t.Errorf("username: got %v", c.Get("username"))
+		}
+		if c.Get("email") != "test@example.com" {
+			t.Errorf("email: got %v", c.Get("email"))
+		}
+		if c.Get("auth_type") != "jwt" {
+			t.Errorf("auth_type: got %v", c.Get("auth_type"))
+		}
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestJWT_ExpiredToken(t *testing.T) {
+	secret := "test-secret-key"
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   secret,
+		RequireAuth: true,
+	})
+
+	claims := JWTClaims{
+		UserID: "user-123",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+	}
+	tokenStr := makeJWT(t, secret, claims)
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+func TestJWT_WrongSecret(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   "correct-secret",
+		RequireAuth: true,
+	})
+
+	claims := JWTClaims{
+		UserID: "user-123",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tokenStr := makeJWT(t, "wrong-secret", claims)
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for wrong secret")
+	}
+}
+
+func TestJWT_InvalidAuthHeaderFormat(t *testing.T) {
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:   "secret",
+		RequireAuth: true,
+	})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	for _, header := range []string{"Basic abc", "Token xyz", "Bearer"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+		req.Header.Set("Authorization", header)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/api/v1/runs")
+
+		err := handler(c)
+		if err == nil {
+			t.Errorf("expected error for header %q", header)
+		}
+	}
+}
+
+func TestJWT_RoleCheck_Allowed(t *testing.T) {
+	secret := "secret"
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:    secret,
+		RequireAuth:  true,
+		AllowedRoles: []string{"admin", "editor"},
+	})
+
+	claims := JWTClaims{
+		UserID: "user-1",
+		Roles:  []string{"editor"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tokenStr := makeJWT(t, secret, claims)
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestJWT_RoleCheck_Forbidden(t *testing.T) {
+	secret := "secret"
+	e := echo.New()
+	mw := JWT(AuthConfig{
+		JWTSecret:    secret,
+		RequireAuth:  true,
+		AllowedRoles: []string{"admin"},
+	})
+
+	claims := JWTClaims{
+		UserID: "user-1",
+		Roles:  []string{"viewer"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tokenStr := makeJWT(t, secret, claims)
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for insufficient roles")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %v", err)
+	}
+}
+
+func TestRequireAuth(t *testing.T) {
+	mw := RequireAuth("secret")
+	if mw == nil {
+		t.Error("middleware should not be nil")
+	}
+}
+
+func TestOptionalAuth(t *testing.T) {
+	mw := OptionalAuth("secret")
+	if mw == nil {
+		t.Error("middleware should not be nil")
+	}
+}
+
+func TestAPIKeyAuth_Valid(t *testing.T) {
+	e := echo.New()
+	mw := APIKeyAuth([]string{"key-1", "key-2"})
+
+	handler := mw(func(c echo.Context) error {
+		if c.Get("auth_type") != "api_key" {
+			t.Error("auth_type should be api_key")
+		}
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("X-API-Key", "key-1")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAPIKeyAuth_Missing(t *testing.T) {
+	e := echo.New()
+	mw := APIKeyAuth([]string{"key-1"})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+func TestAPIKeyAuth_Invalid(t *testing.T) {
+	e := echo.New()
+	mw := APIKeyAuth([]string{"valid"})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("X-API-Key", "invalid")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v1/runs")
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("expected error for invalid API key")
+	}
+}
+
+func TestAPIKeyAuth_SkipsHealth(t *testing.T) {
+	e := echo.New()
+	mw := APIKeyAuth([]string{"key-1"})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/health")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAPIKeyAuth_SkipsMetrics(t *testing.T) {
+	e := echo.New()
+	mw := APIKeyAuth([]string{"key-1"})
+
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/metrics")
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSanitizeErrorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"safe message", "not found", "not found"},
+		{"password sanitized", "bad password=abc123", "An internal error occurred"},
+		{"secret sanitized", "leaked secret key", "An internal error occurred"},
+		{"token sanitized", "invalid token abc", "An internal error occurred"},
+		{"credential sanitized", "wrong credential", "An internal error occurred"},
+		{"dsn sanitized", "dsn: postgres://...", "An internal error occurred"},
+		{"connection string sanitized", "connection string error", "An internal error occurred"},
+		{"case insensitive", "Bad PASSWORD", "An internal error occurred"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeErrorMessage(tt.input)
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeErrorMessage_LongMessage(t *testing.T) {
+	long := make([]byte, 600)
+	for i := range long {
+		long[i] = 'a'
+	}
+
+	got := sanitizeErrorMessage(string(long))
+	if len(got) != 500 {
+		t.Errorf("expected truncated to 500, got %d", len(got))
+	}
+}
+
+func TestMapDomainErrorToHTTPStatus(t *testing.T) {
+	tests := []struct {
+		code     string
+		expected int
+	}{
+		{"NOT_FOUND", http.StatusNotFound},
+		{"ALREADY_EXISTS", http.StatusConflict},
+		{"INVALID_INPUT", http.StatusBadRequest},
+		{"INVALID_STATE", http.StatusBadRequest},
+		{"UNAUTHORIZED", http.StatusUnauthorized},
+		{"FORBIDDEN", http.StatusForbidden},
+		{"CONCURRENCY", http.StatusConflict},
+		{"TIMEOUT", http.StatusGatewayTimeout},
+		{"RATE_LIMITED", http.StatusTooManyRequests},
+		{"UNKNOWN_CODE", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			err := &errors.DomainError{Code: tt.code, Message: "test"}
+			got := mapDomainErrorToHTTPStatus(err)
+			if got != tt.expected {
+				t.Errorf("code %q: got %d, want %d", tt.code, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/monitoring/metrics_test.go
+++ b/internal/infrastructure/monitoring/metrics_test.go
@@ -1,41 +1,78 @@
-package monitoring_test
+package monitoring
 
 import (
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
+func TestNewMetrics(t *testing.T) {
+	m := NewMetrics("test_monitoring")
+	if m == nil {
+		t.Fatal("metrics should not be nil")
+	}
+	if m.HTTPRequestsTotal == nil {
+		t.Error("HTTPRequestsTotal should not be nil")
+	}
+	if m.RunsTotal == nil {
+		t.Error("RunsTotal should not be nil")
+	}
+	if m.LLMRequestsTotal == nil {
+		t.Error("LLMRequestsTotal should not be nil")
+	}
+	if m.WorkersActive == nil {
+		t.Error("WorkersActive should not be nil")
+	}
+	if m.ErrorsTotal == nil {
+		t.Error("ErrorsTotal should not be nil")
+	}
+}
+
 func TestNewMetrics_DefaultNamespace(t *testing.T) {
-	// Can't use promauto in concurrent tests (global registry conflicts),
-	// so we just verify the struct is built and methods don't panic.
-	// The actual Prometheus metrics are tested via /metrics endpoint in integration tests.
-	t.Skip("Prometheus promauto registers globally; tested via integration")
-}
-
-func TestSanitizeErrorMessage(t *testing.T) {
-	// Test the sanitization function indirectly through the middleware tests.
-	// This test verifies the approach is sound.
-	cases := []struct {
-		name     string
-		msg      string
-		expected string
-	}{
-		{"safe message passes through", "not found", "not found"},
-		{"password is sanitized", "bad password=abc123", "sanitized"},
-		{"secret is sanitized", "leaked secret key", "sanitized"},
-		{"long messages truncated", string(make([]byte, 600)), "truncated"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			_ = tc.expected
-			_ = tc.msg
-		})
+	m := NewMetrics("")
+	if m == nil {
+		t.Fatal("metrics should not be nil")
 	}
 }
 
-func TestRecordError(t *testing.T) {
-	_ = time.Second
-	assert.True(t, true)
+func TestRecordHTTPRequest_NoPanic(t *testing.T) {
+	m := NewMetrics("test_http")
+	m.RecordHTTPRequest("GET", "/api/v1/runs", 200, 50*time.Millisecond, 0, 1024)
+	m.RecordHTTPRequest("POST", "/api/v1/runs", 201, 100*time.Millisecond, 512, 256)
+	m.RecordHTTPRequest("GET", "/api/v1/runs/123", 404, 10*time.Millisecond, 0, 64)
+}
+
+func TestRecordRunCreated_NoPanic(t *testing.T) {
+	m := NewMetrics("test_run")
+	m.RecordRunCreated("asst-1")
+	m.RecordRunCreated("asst-2")
+}
+
+func TestRecordRunCompleted_NoPanic(t *testing.T) {
+	m := NewMetrics("test_run_complete")
+	m.RecordRunCompleted("asst-1", "success", 5*time.Second)
+	m.RecordRunCompleted("asst-1", "error", 2*time.Second)
+}
+
+func TestRecordNodeExecution_NoPanic(t *testing.T) {
+	m := NewMetrics("test_node")
+	m.RecordNodeExecution("llm", "success", 100*time.Millisecond)
+	m.RecordNodeExecution("tool", "error", 50*time.Millisecond)
+}
+
+func TestRecordLLMRequest_NoPanic(t *testing.T) {
+	m := NewMetrics("test_llm")
+	m.RecordLLMRequest("openai", "gpt-4", "success", 2*time.Second, 100, 200)
+	m.RecordLLMRequest("anthropic", "claude-3", "error", time.Second, 50, 0)
+}
+
+func TestRecordToolExecution_NoPanic(t *testing.T) {
+	m := NewMetrics("test_tool")
+	m.RecordToolExecution("http_request", "success", 500*time.Millisecond)
+	m.RecordToolExecution("json_processor", "error", 10*time.Millisecond)
+}
+
+func TestRecordError_NoPanic(t *testing.T) {
+	m := NewMetrics("test_error")
+	m.RecordError("domain", "NOT_FOUND")
+	m.RecordError("infrastructure", "DB_TIMEOUT")
 }

--- a/internal/infrastructure/streaming/streaming_test.go
+++ b/internal/infrastructure/streaming/streaming_test.go
@@ -1,7 +1,12 @@
 package streaming
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
 )
 
 func TestParseStreamModes_Default(t *testing.T) {
@@ -217,5 +222,248 @@ func TestIsValidMode(t *testing.T) {
 	}
 	if isValidMode("invalid") {
 		t.Error("'invalid' should not be valid")
+	}
+}
+
+func TestEventFormatter_FormatStateEvent(t *testing.T) {
+	f := NewEventFormatter([]StreamMode{ModeValues})
+
+	data, err := f.FormatStateEvent(map[string]interface{}{"count": 42})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasPrefix(got, "event: values\n") {
+		t.Errorf("expected values event, got %q", got)
+	}
+	if !strings.Contains(got, `"count":42`) {
+		t.Errorf("expected count in data, got %q", got)
+	}
+}
+
+func TestEventFormatter_FormatMessageChunk(t *testing.T) {
+	f := NewEventFormatter([]StreamMode{ModeMessages})
+
+	data, err := f.FormatMessageChunk("Hello", "assistant", "msg-1")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasPrefix(got, "event: message_chunk\n") {
+		t.Errorf("expected message_chunk event, got %q", got)
+	}
+	if !strings.Contains(got, `"content":"Hello"`) {
+		t.Errorf("expected content in data, got %q", got)
+	}
+}
+
+func TestEventFormatter_FormatNodeStart(t *testing.T) {
+	f := NewEventFormatter([]StreamMode{ModeEvents})
+
+	data, err := f.FormatNodeStart("node-1", "llm", map[string]interface{}{"key": "val"})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasPrefix(got, "event: node_start\n") {
+		t.Errorf("expected node_start, got %q", got)
+	}
+	if !strings.Contains(got, `"node_id":"node-1"`) {
+		t.Errorf("expected node_id, got %q", got)
+	}
+}
+
+func TestEventFormatter_FormatNodeEnd(t *testing.T) {
+	f := NewEventFormatter([]StreamMode{ModeEvents})
+
+	data, err := f.FormatNodeEnd("node-1", "llm", map[string]interface{}{"result": "ok"}, 150)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasPrefix(got, "event: node_end\n") {
+		t.Errorf("expected node_end, got %q", got)
+	}
+	if !strings.Contains(got, `"duration_ms":150`) {
+		t.Errorf("expected duration, got %q", got)
+	}
+}
+
+func TestEventFormatter_FormatDebug(t *testing.T) {
+	f := NewEventFormatter([]StreamMode{ModeDebug})
+
+	data, err := f.FormatDebug("info", "processing node", map[string]interface{}{"node": "n1"})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasPrefix(got, "event: debug\n") {
+		t.Errorf("expected debug, got %q", got)
+	}
+	if !strings.Contains(got, `"level":"info"`) {
+		t.Errorf("expected level, got %q", got)
+	}
+}
+
+func TestEventFormatter_ShouldSend_MultipleModesOR(t *testing.T) {
+	f := NewEventFormatter([]StreamMode{ModeValues, ModeMessages})
+
+	if !f.ShouldSend("values") {
+		t.Error("should send values")
+	}
+	if !f.ShouldSend("message") {
+		t.Error("should send message")
+	}
+	if !f.ShouldSend("end") {
+		t.Error("should send end")
+	}
+}
+
+func TestEventFormatter_ShouldSend_NoModes(t *testing.T) {
+	f := NewEventFormatter(nil)
+
+	if f.ShouldSend("values") {
+		t.Error("no modes should not send values")
+	}
+	if !f.ShouldSend("metadata") {
+		t.Error("metadata should always be sent")
+	}
+}
+
+func TestEmitMetadataEvent(t *testing.T) {
+	eb := eventbus.New()
+	var received bool
+	eb.Subscribe("streaming.metadata", func(ctx context.Context, event eventbus.Event) error {
+		received = true
+		meta, ok := event.(*MetadataStreamEvent)
+		if !ok {
+			t.Errorf("expected MetadataStreamEvent, got %T", event)
+		}
+		if meta.RunID != "run-1" || meta.ThreadID != "t-1" {
+			t.Errorf("unexpected event: %+v", meta)
+		}
+		return nil
+	})
+
+	err := EmitMetadataEvent(eb, context.Background(), "run-1", "t-1", "a-1", "g-1")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !received {
+		t.Error("event not received")
+	}
+}
+
+func TestEmitValuesEvent(t *testing.T) {
+	eb := eventbus.New()
+	var received bool
+	eb.Subscribe("streaming.values", func(ctx context.Context, event eventbus.Event) error {
+		received = true
+		ve, ok := event.(*ValuesStreamEvent)
+		if !ok {
+			t.Errorf("expected ValuesStreamEvent, got %T", event)
+		}
+		if ve.RunID != "run-1" {
+			t.Errorf("run_id: %q", ve.RunID)
+		}
+		if ve.Values["key"] != "val" {
+			t.Errorf("values: %v", ve.Values)
+		}
+		return nil
+	})
+
+	EmitValuesEvent(eb, context.Background(), "run-1", map[string]interface{}{"key": "val"})
+	if !received {
+		t.Error("event not received")
+	}
+}
+
+func TestEmitMessageChunk(t *testing.T) {
+	eb := eventbus.New()
+	var received bool
+	eb.Subscribe("streaming.message_chunk", func(ctx context.Context, event eventbus.Event) error {
+		received = true
+		mc, ok := event.(*MessageChunkStreamEvent)
+		if !ok {
+			t.Errorf("expected MessageChunkStreamEvent, got %T", event)
+		}
+		if mc.Content != "hi" || mc.Role != "assistant" {
+			t.Errorf("unexpected: %+v", mc)
+		}
+		return nil
+	})
+
+	EmitMessageChunk(eb, context.Background(), "run-1", "hi", "assistant", "m-1")
+	if !received {
+		t.Error("event not received")
+	}
+}
+
+func TestEmitUpdatesEvent(t *testing.T) {
+	eb := eventbus.New()
+	var received bool
+	eb.Subscribe("streaming.updates", func(ctx context.Context, event eventbus.Event) error {
+		received = true
+		ue, ok := event.(*UpdatesStreamEvent)
+		if !ok {
+			t.Errorf("expected UpdatesStreamEvent, got %T", event)
+		}
+		if ue.NodeID != "n-1" {
+			t.Errorf("node_id: %q", ue.NodeID)
+		}
+		return nil
+	})
+
+	EmitUpdatesEvent(eb, context.Background(), "run-1", "n-1", map[string]interface{}{"x": 1})
+	if !received {
+		t.Error("event not received")
+	}
+}
+
+func TestEmitDebugEvent(t *testing.T) {
+	eb := eventbus.New()
+	var received bool
+	eb.Subscribe("streaming.debug", func(ctx context.Context, event eventbus.Event) error {
+		received = true
+		de, ok := event.(*DebugStreamEvent)
+		if !ok {
+			t.Errorf("expected DebugStreamEvent, got %T", event)
+		}
+		if de.Level != "error" || de.Message != "failed" {
+			t.Errorf("unexpected: %+v", de)
+		}
+		return nil
+	})
+
+	EmitDebugEvent(eb, context.Background(), "run-1", "error", "failed", nil)
+	if !received {
+		t.Error("event not received")
+	}
+}
+
+func TestSerializeEvent(t *testing.T) {
+	event := &MetadataStreamEvent{
+		RunID:       "r1",
+		ThreadID:    "t1",
+		AssistantID: "a1",
+		GraphID:     "g1",
+	}
+
+	data, err := SerializeEvent(event)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if m["RunID"] != "r1" {
+		t.Errorf("unexpected: %v", m)
 	}
 }

--- a/internal/infrastructure/tools/tools_test.go
+++ b/internal/infrastructure/tools/tools_test.go
@@ -1,0 +1,465 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRegistry_Register(t *testing.T) {
+	r := NewRegistry()
+	tool := &mockTool{name: "test_tool", desc: "A test tool"}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := r.Get("test_tool")
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if got.Name() != "test_tool" {
+		t.Errorf("expected test_tool, got %q", got.Name())
+	}
+}
+
+func TestRegistry_Register_EmptyName(t *testing.T) {
+	r := NewRegistry()
+	tool := &mockTool{name: ""}
+
+	err := r.Register(tool)
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestRegistry_Register_Duplicate(t *testing.T) {
+	r := NewRegistry()
+	tool := &mockTool{name: "dup"}
+
+	r.Register(tool)
+	err := r.Register(tool)
+	if err == nil {
+		t.Error("expected error for duplicate registration")
+	}
+}
+
+func TestRegistry_Unregister(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{name: "removeme"})
+
+	if err := r.Unregister("removeme"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err := r.Get("removeme")
+	if err == nil {
+		t.Error("expected not found after unregister")
+	}
+}
+
+func TestRegistry_Unregister_NotFound(t *testing.T) {
+	r := NewRegistry()
+	err := r.Unregister("nonexistent")
+	if err == nil {
+		t.Error("expected error for non-existent tool")
+	}
+}
+
+func TestRegistry_Get_NotFound(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.Get("missing")
+	if err == nil {
+		t.Error("expected error for missing tool")
+	}
+}
+
+func TestRegistry_List(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{name: "a"})
+	r.Register(&mockTool{name: "b"})
+	r.Register(&mockTool{name: "c"})
+
+	tools := r.List()
+	if len(tools) != 3 {
+		t.Errorf("expected 3 tools, got %d", len(tools))
+	}
+}
+
+func TestRegistry_List_Empty(t *testing.T) {
+	r := NewRegistry()
+	tools := r.List()
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(tools))
+	}
+}
+
+func TestRegistry_Execute(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{
+		name: "echo",
+		execFn: func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+			return map[string]interface{}{"echoed": args["input"]}, nil
+		},
+	})
+
+	result, err := r.Execute(context.Background(), "echo", map[string]interface{}{"input": "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["echoed"] != "hello" {
+		t.Errorf("expected echoed=hello, got %v", result)
+	}
+}
+
+func TestRegistry_Execute_NotFound(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.Execute(context.Background(), "missing", nil)
+	if err == nil {
+		t.Error("expected error for missing tool")
+	}
+}
+
+func TestRegistry_GetSchemas(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{
+		name: "my_tool",
+		desc: "Does something",
+		schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"input": map[string]interface{}{"type": "string"},
+			},
+		},
+	})
+
+	schemas := r.GetSchemas()
+	if len(schemas) != 1 {
+		t.Fatalf("expected 1 schema, got %d", len(schemas))
+	}
+	if schemas[0]["name"] != "my_tool" {
+		t.Errorf("expected my_tool, got %v", schemas[0]["name"])
+	}
+	if schemas[0]["description"] != "Does something" {
+		t.Errorf("expected description, got %v", schemas[0]["description"])
+	}
+}
+
+func TestJSONProcessorTool_Parse(t *testing.T) {
+	tool := &JSONProcessorTool{}
+
+	if tool.Name() != "json_processor" {
+		t.Errorf("name: got %q", tool.Name())
+	}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"data":      map[string]interface{}{"key": "value"},
+		"operation": "parse",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, ok := result["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("result type: %T", result["result"])
+	}
+	if data["key"] != "value" {
+		t.Errorf("expected key=value, got %v", data)
+	}
+}
+
+func TestJSONProcessorTool_Stringify(t *testing.T) {
+	tool := &JSONProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"data":      map[string]interface{}{"key": "value"},
+		"operation": "stringify",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	str, ok := result["result"].(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result["result"])
+	}
+	if str != `{"key":"value"}` {
+		t.Errorf("got %q", str)
+	}
+}
+
+func TestJSONProcessorTool_Extract(t *testing.T) {
+	tool := &JSONProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"data": map[string]interface{}{
+			"user": map[string]interface{}{"name": "Alice"},
+		},
+		"operation": "extract",
+		"path":      "user.name",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["result"] != "Alice" {
+		t.Errorf("expected Alice, got %v", result["result"])
+	}
+}
+
+func TestJSONProcessorTool_Extract_MissingPath(t *testing.T) {
+	tool := &JSONProcessorTool{}
+
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"data":      "hello",
+		"operation": "extract",
+	})
+	if err == nil {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestJSONProcessorTool_MissingData(t *testing.T) {
+	tool := &JSONProcessorTool{}
+
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"operation": "parse",
+	})
+	if err == nil {
+		t.Error("expected error for missing data")
+	}
+}
+
+func TestJSONProcessorTool_UnknownOperation(t *testing.T) {
+	tool := &JSONProcessorTool{}
+
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"data":      "test",
+		"operation": "unknown",
+	})
+	if err == nil {
+		t.Error("expected error for unknown operation")
+	}
+}
+
+func TestStringProcessorTool_Lowercase(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	if tool.Name() != "string_processor" {
+		t.Errorf("name: got %q", tool.Name())
+	}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "HELLO WORLD",
+		"operation": "lowercase",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["result"] != "hello world" {
+		t.Errorf("expected 'hello world', got %v", result["result"])
+	}
+}
+
+func TestStringProcessorTool_Uppercase(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "hello",
+		"operation": "uppercase",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["result"] != "HELLO" {
+		t.Errorf("got %v", result["result"])
+	}
+}
+
+func TestStringProcessorTool_Trim(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "  spaced  ",
+		"operation": "trim",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["result"] != "spaced" {
+		t.Errorf("got %v", result["result"])
+	}
+}
+
+func TestStringProcessorTool_Replace(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "hello world",
+		"operation": "replace",
+		"old":       "world",
+		"new":       "earth",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["result"] != "hello earth" {
+		t.Errorf("got %v", result["result"])
+	}
+}
+
+func TestStringProcessorTool_Split(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "a,b,c",
+		"operation": "split",
+		"delimiter": ",",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	parts, ok := result["result"].([]string)
+	if !ok {
+		t.Fatalf("expected []string, got %T", result["result"])
+	}
+	if len(parts) != 3 || parts[0] != "a" || parts[2] != "c" {
+		t.Errorf("got %v", parts)
+	}
+}
+
+func TestStringProcessorTool_Split_DefaultDelimiter(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	result, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "a,b",
+		"operation": "split",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	parts := result["result"].([]string)
+	if len(parts) != 2 {
+		t.Errorf("expected 2 parts, got %d", len(parts))
+	}
+}
+
+func TestStringProcessorTool_MissingText(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"operation": "lowercase",
+	})
+	if err == nil {
+		t.Error("expected error for missing text")
+	}
+}
+
+func TestStringProcessorTool_UnknownOperation(t *testing.T) {
+	tool := &StringProcessorTool{}
+
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"text":      "test",
+		"operation": "unknown",
+	})
+	if err == nil {
+		t.Error("expected error for unknown operation")
+	}
+}
+
+func TestExtractJSONPath(t *testing.T) {
+	data := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": "deep",
+			},
+		},
+	}
+
+	if v := extractJSONPath(data, "a.b.c"); v != "deep" {
+		t.Errorf("expected 'deep', got %v", v)
+	}
+
+	if v := extractJSONPath(data, "a.x"); v != nil {
+		t.Errorf("expected nil for missing path, got %v", v)
+	}
+
+	if v := extractJSONPath("not a map", "a"); v != nil {
+		t.Errorf("expected nil for non-map, got %v", v)
+	}
+}
+
+func TestRegisterBuiltinTools(t *testing.T) {
+	r := NewRegistry()
+	if err := RegisterBuiltinTools(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tools := r.List()
+	if len(tools) != 3 {
+		t.Errorf("expected 3 builtin tools, got %d", len(tools))
+	}
+
+	names := make(map[string]bool)
+	for _, tool := range tools {
+		names[tool.Name()] = true
+	}
+
+	for _, expected := range []string{"http_request", "json_processor", "string_processor"} {
+		if !names[expected] {
+			t.Errorf("missing builtin tool: %s", expected)
+		}
+	}
+}
+
+func TestRegisterBuiltinTools_DoubleRegister(t *testing.T) {
+	r := NewRegistry()
+	RegisterBuiltinTools(r)
+	err := RegisterBuiltinTools(r)
+	if err == nil {
+		t.Error("expected error on double registration")
+	}
+}
+
+func TestHTTPTool_Schema(t *testing.T) {
+	tool := &HTTPTool{}
+	schema := tool.Schema()
+	if schema["type"] != "object" {
+		t.Errorf("expected object type, got %v", schema["type"])
+	}
+	props := schema["properties"].(map[string]interface{})
+	if _, ok := props["url"]; !ok {
+		t.Error("schema should have url property")
+	}
+}
+
+func TestHTTPTool_MissingURL(t *testing.T) {
+	tool := &HTTPTool{}
+	_, err := tool.Execute(context.Background(), map[string]interface{}{})
+	if err == nil {
+		t.Error("expected error for missing url")
+	}
+}
+
+type mockTool struct {
+	name   string
+	desc   string
+	schema map[string]interface{}
+	execFn func(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error)
+}
+
+func (t *mockTool) Name() string        { return t.name }
+func (t *mockTool) Description() string { return t.desc }
+func (t *mockTool) Schema() map[string]interface{} {
+	if t.schema != nil {
+		return t.schema
+	}
+	return map[string]interface{}{}
+}
+func (t *mockTool) Execute(ctx context.Context, args map[string]interface{}) (map[string]interface{}, error) {
+	if t.execFn != nil {
+		return t.execFn(ctx, args)
+	}
+	return map[string]interface{}{}, nil
+}


### PR DESCRIPTION
## Summary

- Add unit tests for 8 infrastructure packages that previously had 0% coverage
- Extend tests for 2 existing packages (streaming, monitoring)
- Overall coverage: **47.2% → 53.6%**

## New test files (8)

| Package | Coverage | Tests |
|---------|----------|-------|
| `cmd/server/config` | 0% → **100%** | Load defaults, custom env, read replica, invalid port, helpers |
| `http/dto` | 0% → **100%** | JSON serialization roundtrips for all 30+ DTO types |
| `tools` | 0% → **73.8%** | Registry CRUD, builtin tools (JSON/string processors) |
| `graph/engine` | 0% → **75.8%** | Execution plan, cycle detection, conditions, inline subgraphs |
| `execution` | 0% → **95.7%** | LLM executor (provider routing, messages, tools), tool executor |
| `auth` | 0% → **13.3%** | OAuth manager setup, JWT generation, state tokens |
| `middleware/auth` | new file | JWT validation, API key auth, role checks, skip paths, error mapping |
| `tools` | new file | Registry, builtin tools, schema generation |

## Extended test files (2)

| Package | Before | After |
|---------|--------|-------|
| `streaming` | 34.2% | **43.9%** |
| `monitoring` | 0% | **52.5%** |

## Test plan

- [x] All 24 test packages passing (`go test -short ./...`)
- [x] No regressions in existing tests
- [x] Pre-commit hooks pass (go-fmt, go-vet, gitleaks, commitizen)