### PR TITLE
fix: resolve 5 worker dispatch bugs found in real-world usage

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -170,13 +170,19 @@ func main() {
 	fmt.Println("✅ Streaming bridge started")
 
 	// Initialize worker service (persistent PostgreSQL + NATS)
+	healthThreshold := 90 * time.Second
+	if v := os.Getenv("WORKER_HEALTH_THRESHOLD_SECONDS"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			healthThreshold = time.Duration(secs) * time.Second
+		}
+	}
 	workerService := service.NewWorkerService(
 		workerRepo,
 		taskRepo,
 		runRepo,
 		assistantRepo,
 		taskQueue,
-		30*time.Second, // Health threshold
+		healthThreshold,
 	)
 
 	fmt.Println("✅ Worker service initialized (PostgreSQL + NATS)")

--- a/internal/application/command/create_assistant.go
+++ b/internal/application/command/create_assistant.go
@@ -9,6 +9,7 @@ import (
 
 // CreateAssistant command
 type CreateAssistant struct {
+	GraphID      string
 	Name         string
 	Description  string
 	Model        string
@@ -32,6 +33,11 @@ func NewCreateAssistantHandler(assistantRepo workflow.AssistantRepository) *Crea
 // Handle handles the CreateAssistant command
 func (h *CreateAssistantHandler) Handle(ctx context.Context, cmd CreateAssistant) (string, error) {
 	// Create assistant aggregate
+	var opts []workflow.AssistantOption
+	if cmd.GraphID != "" {
+		opts = append(opts, workflow.WithGraphID(cmd.GraphID))
+	}
+
 	assistant, err := workflow.NewAssistant(
 		cmd.Name,
 		cmd.Description,
@@ -39,6 +45,7 @@ func (h *CreateAssistantHandler) Handle(ctx context.Context, cmd CreateAssistant
 		cmd.Instructions,
 		cmd.Tools,
 		cmd.Metadata,
+		opts...,
 	)
 	if err != nil {
 		return "", err

--- a/internal/application/service/run_service.go
+++ b/internal/application/service/run_service.go
@@ -135,6 +135,9 @@ func (s *RunService) ExecuteRun(ctx context.Context, runID string) error {
 		if dispatchErr != nil {
 			fmt.Printf("Worker dispatch failed for run %s: %v, falling back to local execution\n", runID, dispatchErr)
 		}
+		if workerID == "" && dispatchErr == nil {
+			fmt.Printf("No healthy worker found for run %s (assistant=%s), falling back to local execution\n", runID, runAgg.AssistantID())
+		}
 	}
 
 	if err := runAgg.Start(); err != nil {

--- a/internal/application/service/worker_service.go
+++ b/internal/application/service/worker_service.go
@@ -66,10 +66,13 @@ func (s *WorkerService) DispatchRun(ctx context.Context, runID string) (string, 
 		return "", fmt.Errorf("load assistant: %w", err)
 	}
 
-	graphID := assistant.ID()
-	if metadata := assistant.Metadata(); metadata != nil {
-		if gid, ok := metadata["graph_id"].(string); ok && gid != "" {
-			graphID = gid
+	graphID := assistant.GraphID()
+	if graphID == "" {
+		graphID = assistant.ID()
+		if metadata := assistant.Metadata(); metadata != nil {
+			if gid, ok := metadata["graph_id"].(string); ok && gid != "" {
+				graphID = gid
+			}
 		}
 	}
 

--- a/internal/domain/workflow/assistant.go
+++ b/internal/domain/workflow/assistant.go
@@ -8,9 +8,20 @@ import (
 	pkguuid "github.com/duragraph/duragraph/internal/pkg/uuid"
 )
 
+// AssistantOption configures optional Assistant fields
+type AssistantOption func(*Assistant)
+
+// WithGraphID sets the graph ID on an assistant
+func WithGraphID(graphID string) AssistantOption {
+	return func(a *Assistant) {
+		a.graphID = graphID
+	}
+}
+
 // Assistant represents an AI assistant aggregate
 type Assistant struct {
 	id           string
+	graphID      string
 	name         string
 	description  string
 	model        string
@@ -25,7 +36,7 @@ type Assistant struct {
 }
 
 // NewAssistant creates a new Assistant aggregate
-func NewAssistant(name, description, model, instructions string, tools []map[string]interface{}, metadata map[string]interface{}) (*Assistant, error) {
+func NewAssistant(name, description, model, instructions string, tools []map[string]interface{}, metadata map[string]interface{}, opts ...AssistantOption) (*Assistant, error) {
 	if name == "" {
 		return nil, errors.InvalidInput("name", "name is required")
 	}
@@ -53,6 +64,10 @@ func NewAssistant(name, description, model, instructions string, tools []map[str
 		events:       make([]eventbus.Event, 0),
 	}
 
+	for _, opt := range opts {
+		opt(assistant)
+	}
+
 	assistant.recordEvent(AssistantCreated{
 		AssistantID:  assistantID,
 		Name:         name,
@@ -72,6 +87,7 @@ func ReconstructAssistant(
 	tools []map[string]interface{},
 	metadata map[string]interface{},
 	createdAt, updatedAt time.Time,
+	opts ...AssistantOption,
 ) (*Assistant, error) {
 	if tools == nil {
 		tools = make([]map[string]interface{}, 0)
@@ -80,7 +96,7 @@ func ReconstructAssistant(
 		metadata = make(map[string]interface{})
 	}
 
-	return &Assistant{
+	a := &Assistant{
 		id:           id,
 		name:         name,
 		description:  description,
@@ -91,7 +107,11 @@ func ReconstructAssistant(
 		createdAt:    createdAt,
 		updatedAt:    updatedAt,
 		events:       make([]eventbus.Event, 0),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a, nil
 }
 
 // ID returns the assistant ID
@@ -185,6 +205,16 @@ func (a *Assistant) Delete() error {
 	})
 
 	return nil
+}
+
+// GraphID returns the graph ID
+func (a *Assistant) GraphID() string {
+	return a.graphID
+}
+
+// SetGraphID sets the graph ID
+func (a *Assistant) SetGraphID(graphID string) {
+	a.graphID = graphID
 }
 
 // Events returns the uncommitted events

--- a/internal/infrastructure/http/handlers/assistant.go
+++ b/internal/infrastructure/http/handlers/assistant.go
@@ -81,6 +81,7 @@ func (h *AssistantHandler) Create(c echo.Context) error {
 
 	// Create assistant
 	assistantID, err := h.createHandler.Handle(c.Request().Context(), command.CreateAssistant{
+		GraphID:      req.GraphID,
 		Name:         req.Name,
 		Description:  req.Description,
 		Model:        req.Model,

--- a/internal/infrastructure/persistence/postgres/assistant_repository.go
+++ b/internal/infrastructure/persistence/postgres/assistant_repository.go
@@ -44,10 +44,11 @@ func (r *AssistantRepository) Save(ctx context.Context, assistant *workflow.Assi
 	metadataJSON, _ := json.Marshal(assistant.Metadata())
 
 	_, err := r.writePool.Exec(ctx, `
-		INSERT INTO assistants (id, name, description, model, instructions, tools, metadata, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO assistants (id, graph_id, name, description, model, instructions, tools, metadata, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 	`,
 		assistant.ID(),
+		assistant.GraphID(),
 		assistant.Name(),
 		assistant.Description(),
 		assistant.Model(),
@@ -79,15 +80,16 @@ func (r *AssistantRepository) Save(ctx context.Context, assistant *workflow.Assi
 // FindByID retrieves an assistant by ID
 func (r *AssistantRepository) FindByID(ctx context.Context, id string) (*workflow.Assistant, error) {
 	var assistantID, name, description, model, instructions string
+	var graphID *string
 	var toolsJSON, metadataJSON []byte
 	var createdAt, updatedAt time.Time
 
 	err := r.writePool.QueryRow(ctx, `
-		SELECT id, name, description, model, instructions, tools, metadata, created_at, updated_at
+		SELECT id, graph_id, name, description, model, instructions, tools, metadata, created_at, updated_at
 		FROM assistants
 		WHERE id = $1
 	`, id).Scan(
-		&assistantID, &name, &description, &model, &instructions,
+		&assistantID, &graphID, &name, &description, &model, &instructions,
 		&toolsJSON, &metadataJSON, &createdAt, &updatedAt,
 	)
 
@@ -95,16 +97,21 @@ func (r *AssistantRepository) FindByID(ctx context.Context, id string) (*workflo
 		return nil, errors.NotFound("assistant", id)
 	}
 
-	// Reconstruct assistant
 	var tools []map[string]interface{}
 	json.Unmarshal(toolsJSON, &tools)
 
 	var metadata map[string]interface{}
 	json.Unmarshal(metadataJSON, &metadata)
 
+	var opts []workflow.AssistantOption
+	if graphID != nil {
+		opts = append(opts, workflow.WithGraphID(*graphID))
+	}
+
 	assistant, err := workflow.ReconstructAssistant(
 		assistantID, name, description, model, instructions,
 		tools, metadata, createdAt, updatedAt,
+		opts...,
 	)
 	if err != nil {
 		return nil, err
@@ -116,7 +123,7 @@ func (r *AssistantRepository) FindByID(ctx context.Context, id string) (*workflo
 // List retrieves assistants with pagination
 func (r *AssistantRepository) List(ctx context.Context, limit, offset int) ([]*workflow.Assistant, error) {
 	rows, err := r.writePool.Query(ctx, `
-		SELECT id, name, description, model, instructions, tools, metadata, created_at, updated_at
+		SELECT id, graph_id, name, description, model, instructions, tools, metadata, created_at, updated_at
 		FROM assistants
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2
@@ -131,10 +138,11 @@ func (r *AssistantRepository) List(ctx context.Context, limit, offset int) ([]*w
 
 	for rows.Next() {
 		var assistantID, name, description, model, instructions string
+		var graphID *string
 		var toolsJSON, metadataJSON []byte
 		var createdAt, updatedAt time.Time
 
-		err := rows.Scan(&assistantID, &name, &description, &model, &instructions,
+		err := rows.Scan(&assistantID, &graphID, &name, &description, &model, &instructions,
 			&toolsJSON, &metadataJSON, &createdAt, &updatedAt)
 		if err != nil {
 			return nil, errors.Internal("failed to scan assistant", err)
@@ -146,9 +154,15 @@ func (r *AssistantRepository) List(ctx context.Context, limit, offset int) ([]*w
 		var metadata map[string]interface{}
 		json.Unmarshal(metadataJSON, &metadata)
 
+		var opts []workflow.AssistantOption
+		if graphID != nil {
+			opts = append(opts, workflow.WithGraphID(*graphID))
+		}
+
 		assistant, _ := workflow.ReconstructAssistant(
 			assistantID, name, description, model, instructions,
 			tools, metadata, createdAt, updatedAt,
+			opts...,
 		)
 		assistants = append(assistants, assistant)
 	}

--- a/internal/infrastructure/persistence/postgres/worker_repository.go
+++ b/internal/infrastructure/persistence/postgres/worker_repository.go
@@ -3,10 +3,12 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/duragraph/duragraph/internal/domain/worker"
 	"github.com/duragraph/duragraph/internal/pkg/errors"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -116,7 +118,7 @@ func (r *WorkerRepository) FindForGraph(ctx context.Context, graphID string, thr
 		WHERE last_heartbeat_at > $1
 		  AND status != 'offline'
 		  AND capabilities->'graphs' ? $2
-		  AND active_runs < COALESCE((capabilities->>'max_concurrent_runs')::int, 1)
+		  AND active_runs < GREATEST(COALESCE((capabilities->>'max_concurrent_runs')::int, 10), 1)
 		ORDER BY active_runs ASC
 		LIMIT 1
 	`, cutoff, graphID).Scan(
@@ -124,7 +126,11 @@ func (r *WorkerRepository) FindForGraph(ctx context.Context, graphID string, thr
 		&w.ActiveRuns, &w.TotalRuns, &w.FailedRuns, &w.LastHeartbeat, &w.RegisteredAt,
 	)
 	if err != nil {
-		return nil, nil
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		fmt.Printf("FindForGraph query error (graphID=%s): %v\n", graphID, err)
+		return nil, errors.Internal("failed to find worker for graph", err)
 	}
 
 	w.Status = worker.Status(statusStr)


### PR DESCRIPTION
## Summary

Fixes 5 interconnected bugs in the worker dispatch pipeline discovered during real-world usage. These bugs form a chain: graph_id never saved → worker lookup silently fails → dispatch silently falls through → heartbeat timing causes false negatives → capacity check broken for zero values.

## Changes

1. **CreateAssistant persists graph_id** — Added `GraphID` field to command struct, handler mapping, domain model (via functional options), and repository INSERT/SELECT
2. **FindForGraph error handling** — Check `pgx.ErrNoRows` specifically; propagate all other errors instead of returning `(nil, nil)`
3. **Worker dispatch logging** — Log when no healthy worker found instead of silent fallthrough to local execution
4. **Health threshold** — Increased default from 30s to 90s (3x heartbeat interval), configurable via `WORKER_HEALTH_THRESHOLD_SECONDS` env var
5. **max_concurrent_runs SQL** — `GREATEST(COALESCE(..., 10), 1)` handles both NULL (missing field) and 0 (Go zero-value)

## Files changed

- `internal/domain/workflow/assistant.go` — `AssistantOption` functional options, `graphID` field
- `internal/application/command/create_assistant.go` — `GraphID` in command struct
- `internal/infrastructure/http/handlers/assistant.go` — DTO→command mapping
- `internal/infrastructure/persistence/postgres/assistant_repository.go` — INSERT/SELECT with `graph_id`
- `internal/application/service/worker_service.go` — Use `assistant.GraphID()` in dispatch
- `internal/infrastructure/persistence/postgres/worker_repository.go` — Error handling + SQL fix
- `internal/application/service/run_service.go` — Dispatch fallback logging
- `cmd/server/main.go` — Configurable health threshold

## Test plan

- [x] `go build ./cmd/server/` compiles
- [x] `go test -short ./...` all pass
- [ ] CI checks pass