### PR TITLE
fix(ci): pass canonical image tag from metadata-action to Trivy

### DIFF
--- a/.github/workflows/duragraph.yml
+++ b/.github/workflows/duragraph.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ secrets.INFISICAL_DOCKER_USERNAME }}/duragraph
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -89,7 +91,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          image-ref: ${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.version }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '0'


### PR DESCRIPTION
## Summary

v0.2.2 release succeeded on Docker Hub but the security-scan job failed with \`MANIFEST_UNKNOWN: unknown tag=v0.2.2\`. The metadata-action's \`{{version}}\` pattern strips the \`v\` prefix when publishing (image tag is \`0.2.2\`), but Trivy was using \`\${{ github.ref_name }}\` which is \`v0.2.2\`.

Fix: expose \`steps.meta.outputs.version\` as a job output from \`build-and-push\` and reference it from \`security-scan\`.

## Test plan
- [ ] After merge, tag \`v0.2.3\` and confirm all three jobs (build-and-push, create-release, security-scan) succeed