### PR TITLE
ci: sync README.md to Docker Hub

### DIFF
--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -1,0 +1,26 @@
+name: Sync README to Docker Hub
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-readme.yml
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Push README to Docker Hub
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.INFISICAL_DOCKER_USERNAME }}
+          password: ${{ secrets.INFISICAL_DOCKER_PASSWORD }}
+          repository: ${{ secrets.INFISICAL_DOCKER_USERNAME }}/duragraph
+          short-description: "Open-source LangGraph Cloud-compatible AI workflow orchestration with event sourcing & CQRS"
+          enable-url-completion: true


### PR DESCRIPTION
## Summary

The Docker Hub repo page has no description right now. This adds a workflow that pushes \`README.md\` to the Docker Hub overview so the image page actually explains what DuraGraph is.

- Action: \`peter-evans/dockerhub-description@v4\`
- Auth: same \`INFISICAL_DOCKER_USERNAME\` / \`INFISICAL_DOCKER_PASSWORD\` secrets
- \`enable-url-completion: true\` — rewrites relative asset paths (e.g. \`assets/logo.svg\`) to absolute GitHub raw URLs so the logo + screenshots actually render
- Triggers on push to main when README.md changes, plus \`workflow_dispatch\` for one-shot syncs

## Test plan

- [ ] After merge, the workflow fires on the merge commit (README is in this PR's diff)
- [ ] Visit https://hub.docker.com/r/duragraph/duragraph and confirm the overview renders