### PR TITLE
feat: add Tenant aggregate (domain layer)

### DIFF
--- a/internal/domain/tenant/dbname.go
+++ b/internal/domain/tenant/dbname.go
@@ -1,0 +1,37 @@
+package tenant
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// dbNameRegex enforces the canonical tenant DB name format: the literal
+// prefix "tenant_" followed by exactly 32 lowercase hex characters (the
+// UUID with hyphens stripped). Total length 39 chars, well under PG's
+// 63-char identifier limit, and within [a-z0-9_] so DDL string-interpolation
+// is safe when combined with ValidateDBName.
+var dbNameRegex = regexp.MustCompile(`^tenant_[a-f0-9]{32}$`)
+
+// DBName returns the deterministic Postgres database name for tenantID.
+// Format: "tenant_" + 32 hex chars of UUID with hyphens stripped.
+// Per duragraph-spec models/entities.yml#tenants derivation rule.
+func DBName(tenantID string) (string, error) {
+	u, err := uuid.Parse(tenantID)
+	if err != nil {
+		return "", fmt.Errorf("invalid tenant id: %w", err)
+	}
+	return "tenant_" + strings.ReplaceAll(u.String(), "-", ""), nil
+}
+
+// ValidateDBName checks that name matches the canonical derived format.
+// Defense-in-depth before any DDL string interpolation — Postgres can't
+// parameterize identifiers, so callers building DDL must validate first.
+func ValidateDBName(name string) error {
+	if !dbNameRegex.MatchString(name) {
+		return fmt.Errorf("invalid tenant db name: %s", name)
+	}
+	return nil
+}

--- a/internal/domain/tenant/dbname_test.go
+++ b/internal/domain/tenant/dbname_test.go
@@ -1,0 +1,123 @@
+package tenant
+
+import (
+	"testing"
+)
+
+func TestDBName_Deterministic(t *testing.T) {
+	id := "0123abcd-4567-89ef-0123-456789abcdef"
+	a, err := DBName(id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, err := DBName(id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a != b {
+		t.Errorf("DBName not deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestDBName_FormatCorrect(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{
+			name: "all-zero uuid",
+			id:   "00000000-0000-0000-0000-000000000000",
+			want: "tenant_00000000000000000000000000000000",
+		},
+		{
+			name: "mixed-case input is normalised to lowercase",
+			id:   "0123ABCD-4567-89EF-0123-456789ABCDEF",
+			want: "tenant_0123abcd456789ef0123456789abcdef",
+		},
+		{
+			name: "all-f uuid",
+			id:   "ffffffff-ffff-ffff-ffff-ffffffffffff",
+			want: "tenant_ffffffffffffffffffffffffffffffff",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DBName(tt.id)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("DBName(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+			// Whatever DBName produces must also pass ValidateDBName.
+			if err := ValidateDBName(got); err != nil {
+				t.Errorf("ValidateDBName(%q) failed: %v", got, err)
+			}
+		})
+	}
+}
+
+func TestDBName_RejectsInvalidUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"empty string", ""},
+		{"not a uuid", "not-a-uuid"},
+		{"too short", "0123abcd"},
+		{"random text", "hello world"},
+		{"trailing garbage", "0123abcd-4567-89ef-0123-456789abcdefXX"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DBName(tt.id)
+			if err == nil {
+				t.Errorf("expected error for invalid uuid %q", tt.id)
+			}
+		})
+	}
+}
+
+func TestValidateDBName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Accept canonical
+		{"canonical zeroes", "tenant_00000000000000000000000000000000", false},
+		{"canonical mixed hex", "tenant_0123abcd456789ef0123456789abcdef", false},
+		{"canonical all f", "tenant_ffffffffffffffffffffffffffffffff", false},
+
+		// Reject malformed
+		{"empty", "", true},
+		{"missing prefix", "00000000000000000000000000000000", true},
+		{"wrong prefix", "tenants_00000000000000000000000000000000", true},
+		{"too short hex", "tenant_00", true},
+		{"too long hex", "tenant_000000000000000000000000000000000000", true},
+		{"uppercase hex (Postgres lower-only convention)", "tenant_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", true},
+		{"non-hex chars", "tenant_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", true},
+		{"with hyphens", "tenant_00000000-0000-0000-0000-000000000000", true},
+		{"trailing whitespace", "tenant_00000000000000000000000000000000 ", true},
+		{"leading whitespace", " tenant_00000000000000000000000000000000", true},
+		{"injection attempt", "tenant_00000000000000000000000000000000;DROP DATABASE foo", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDBName(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.input, err)
+			}
+		})
+	}
+}

--- a/internal/domain/tenant/events.go
+++ b/internal/domain/tenant/events.go
@@ -1,0 +1,88 @@
+package tenant
+
+import (
+	"time"
+)
+
+// Event types (dot-form, matches duragraph-spec models/events.yml#tenant_events).
+const (
+	EventTypeTenantPending            = "tenant.pending"
+	EventTypeTenantProvisioning       = "tenant.provisioning"
+	EventTypeTenantApproved           = "tenant.approved"
+	EventTypeTenantProvisioningFailed = "tenant.provisioning_failed"
+	EventTypeTenantSuspended          = "tenant.suspended"
+)
+
+// AggregateTypeTenant is the aggregate_type label carried on every tenant event.
+const AggregateTypeTenant = "tenant"
+
+// TenantPending is emitted when a tenant row is created in pending status
+// alongside a new user signup. The tenant is not yet provisioned (no DB,
+// no NATS Account); db_name is included because it is deterministically
+// derived from tenant_id and stable from creation.
+type TenantPending struct {
+	TenantID   string    `json:"tenant_id"`
+	UserID     string    `json:"user_id"`
+	DBName     string    `json:"db_name"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+func (e TenantPending) EventType() string     { return EventTypeTenantPending }
+func (e TenantPending) AggregateID() string   { return e.TenantID }
+func (e TenantPending) AggregateType() string { return AggregateTypeTenant }
+
+// TenantProvisioning is emitted when an admin approves a tenant and the
+// provisioning workflow starts (CREATE DATABASE + migrations + NATS Account).
+type TenantProvisioning struct {
+	TenantID   string    `json:"tenant_id"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+func (e TenantProvisioning) EventType() string     { return EventTypeTenantProvisioning }
+func (e TenantProvisioning) AggregateID() string   { return e.TenantID }
+func (e TenantProvisioning) AggregateType() string { return AggregateTypeTenant }
+
+// TenantApproved is emitted when provisioning completes successfully — tenant
+// DB exists, all tenant migrations applied, NATS Account created. The user's
+// next login JWT will carry this tenant_id.
+type TenantApproved struct {
+	TenantID         string    `json:"tenant_id"`
+	UserID           string    `json:"user_id"`
+	DBName           string    `json:"db_name"`
+	SchemaVersion    int       `json:"schema_version"`
+	ApprovedByUserID string    `json:"approved_by_user_id"`
+	OccurredAt       time.Time `json:"occurred_at"`
+}
+
+func (e TenantApproved) EventType() string     { return EventTypeTenantApproved }
+func (e TenantApproved) AggregateID() string   { return e.TenantID }
+func (e TenantApproved) AggregateType() string { return AggregateTypeTenant }
+
+// TenantProvisioningFailed is emitted when any step of provisioning fails
+// (CREATE DATABASE, migrate, NATS Account). The state machine permits
+// admin retry via provisioning_failed -> provisioning.
+type TenantProvisioningFailed struct {
+	TenantID   string    `json:"tenant_id"`
+	Reason     string    `json:"reason"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+func (e TenantProvisioningFailed) EventType() string {
+	return EventTypeTenantProvisioningFailed
+}
+func (e TenantProvisioningFailed) AggregateID() string   { return e.TenantID }
+func (e TenantProvisioningFailed) AggregateType() string { return AggregateTypeTenant }
+
+// TenantSuspended is emitted when an admin suspends a tenant. The tenant DB
+// and NATS Account remain intact; only API access is gated off via the JWT
+// middleware path.
+type TenantSuspended struct {
+	TenantID          string    `json:"tenant_id"`
+	SuspendedByUserID string    `json:"suspended_by_user_id"`
+	Reason            string    `json:"reason,omitempty"`
+	OccurredAt        time.Time `json:"occurred_at"`
+}
+
+func (e TenantSuspended) EventType() string     { return EventTypeTenantSuspended }
+func (e TenantSuspended) AggregateID() string   { return e.TenantID }
+func (e TenantSuspended) AggregateType() string { return AggregateTypeTenant }

--- a/internal/domain/tenant/repository.go
+++ b/internal/domain/tenant/repository.go
@@ -1,0 +1,22 @@
+package tenant
+
+import (
+	"context"
+)
+
+// Repository defines the interface for tenant persistence. Implementations
+// live in internal/infrastructure/persistence/postgres/.
+type Repository interface {
+	// Save persists a tenant aggregate and its uncommitted events
+	// transactionally (event store + outbox in one tx).
+	Save(ctx context.Context, t *Tenant) error
+
+	// GetByID retrieves a tenant by its ID.
+	GetByID(ctx context.Context, id string) (*Tenant, error)
+
+	// GetByUserID retrieves the tenant owned by the given user (1:1).
+	GetByUserID(ctx context.Context, userID string) (*Tenant, error)
+
+	// ListByStatus retrieves tenants in a particular status with pagination.
+	ListByStatus(ctx context.Context, status Status, limit, offset int) ([]*Tenant, error)
+}

--- a/internal/domain/tenant/status.go
+++ b/internal/domain/tenant/status.go
@@ -1,0 +1,80 @@
+package tenant
+
+// Status represents the provisioning state of a tenant.
+//
+// State machine (per duragraph-spec models/entities.yml#tenants):
+//
+//	pending              -> provisioning
+//	provisioning         -> approved | provisioning_failed
+//	provisioning_failed  -> provisioning   (admin retry)
+//	approved             -> suspended
+//	suspended            (terminal at the aggregate level)
+type Status string
+
+const (
+	// StatusPending indicates the tenant row exists but provisioning hasn't started.
+	StatusPending Status = "pending"
+
+	// StatusProvisioning indicates provisioning is in progress (CREATE DATABASE,
+	// migrations, NATS Account creation).
+	StatusProvisioning Status = "provisioning"
+
+	// StatusApproved indicates provisioning completed successfully and the
+	// tenant is reachable.
+	StatusApproved Status = "approved"
+
+	// StatusProvisioningFailed indicates provisioning failed and is awaiting
+	// admin retry.
+	StatusProvisioningFailed Status = "provisioning_failed"
+
+	// StatusSuspended indicates an admin has suspended the tenant. Terminal
+	// at the aggregate level.
+	StatusSuspended Status = "suspended"
+)
+
+// IsValid checks if a status value is one of the recognised tenant statuses.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusProvisioning, StatusApproved,
+		StatusProvisioningFailed, StatusSuspended:
+		return true
+	}
+	return false
+}
+
+// CanTransitionTo checks if transition from the current status to newStatus is
+// permitted by the tenant state machine.
+func (s Status) CanTransitionTo(newStatus Status) bool {
+	validTransitions := map[Status][]Status{
+		StatusPending: {
+			StatusProvisioning,
+		},
+		StatusProvisioning: {
+			StatusApproved,
+			StatusProvisioningFailed,
+		},
+		StatusProvisioningFailed: {
+			StatusProvisioning,
+		},
+		StatusApproved: {
+			StatusSuspended,
+		},
+		// StatusSuspended is terminal.
+	}
+
+	allowed, ok := validTransitions[s]
+	if !ok {
+		return false
+	}
+	for _, a := range allowed {
+		if a == newStatus {
+			return true
+		}
+	}
+	return false
+}
+
+// String returns the string representation of the status.
+func (s Status) String() string {
+	return string(s)
+}

--- a/internal/domain/tenant/tenant.go
+++ b/internal/domain/tenant/tenant.go
@@ -1,0 +1,214 @@
+package tenant
+
+import (
+	"time"
+
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
+	pkguuid "github.com/duragraph/duragraph/internal/pkg/uuid"
+)
+
+// Tenant is the aggregate root for a platform tenant.
+//
+// 1:1 with a User; owns a dedicated Postgres database (db_name) inside the
+// shared prod-postgres instance. State machine and table-level invariants are
+// defined in duragraph-spec models/entities.yml#tenants and mirrored on the
+// Status type / table CHECK constraints.
+type Tenant struct {
+	id            string
+	userID        string
+	dbName        string
+	status        Status
+	schemaVersion *int
+	provisionedAt *time.Time
+	failureReason string
+	createdAt     time.Time
+	updatedAt     time.Time
+	version       int
+	events        []eventbus.Event
+}
+
+// NewTenant creates a new Tenant aggregate in pending status. The tenant ID
+// is generated server-side; db_name is derived deterministically from the ID
+// and stable from creation. Emits a TenantPending event.
+func NewTenant(userID string) (*Tenant, error) {
+	if userID == "" {
+		return nil, errors.InvalidInput("user_id", "user_id is required")
+	}
+
+	tenantID := pkguuid.New()
+	dbName, err := DBName(tenantID)
+	if err != nil {
+		// Defense-in-depth: pkguuid.New() always returns a valid UUID, so
+		// this branch is unreachable in practice.
+		return nil, errors.Internal("failed to derive tenant db name", err)
+	}
+
+	now := time.Now()
+	t := &Tenant{
+		id:        tenantID,
+		userID:    userID,
+		dbName:    dbName,
+		status:    StatusPending,
+		createdAt: now,
+		updatedAt: now,
+		version:   1,
+		events:    make([]eventbus.Event, 0),
+	}
+
+	t.recordEvent(TenantPending{
+		TenantID:   tenantID,
+		UserID:     userID,
+		DBName:     dbName,
+		OccurredAt: now,
+	})
+
+	return t, nil
+}
+
+// StartProvisioning transitions the tenant to provisioning status.
+// Valid from pending (initial provisioning) or provisioning_failed (admin
+// retry). On the retry path failureReason is cleared. Emits TenantProvisioning.
+func (t *Tenant) StartProvisioning() error {
+	if !t.status.CanTransitionTo(StatusProvisioning) {
+		return errors.InvalidState(t.status.String(), "start_provisioning")
+	}
+
+	now := time.Now()
+	t.status = StatusProvisioning
+	t.failureReason = ""
+	t.updatedAt = now
+
+	t.recordEvent(TenantProvisioning{
+		TenantID:   t.id,
+		OccurredAt: now,
+	})
+
+	return nil
+}
+
+// Approve transitions the tenant to approved status. Sets schemaVersion (the
+// golang-migrate version applied during provisioning) and provisionedAt.
+// Valid only from provisioning. Emits TenantApproved.
+func (t *Tenant) Approve(approvedByUserID string, schemaVersion int) error {
+	if !t.status.CanTransitionTo(StatusApproved) {
+		return errors.InvalidState(t.status.String(), "approve")
+	}
+
+	now := time.Now()
+	t.status = StatusApproved
+	sv := schemaVersion
+	t.schemaVersion = &sv
+	t.provisionedAt = &now
+	t.updatedAt = now
+
+	t.recordEvent(TenantApproved{
+		TenantID:         t.id,
+		UserID:           t.userID,
+		DBName:           t.dbName,
+		SchemaVersion:    schemaVersion,
+		ApprovedByUserID: approvedByUserID,
+		OccurredAt:       now,
+	})
+
+	return nil
+}
+
+// MarkProvisioningFailed transitions the tenant to provisioning_failed status
+// and records the failure reason. Valid only from provisioning. Emits
+// TenantProvisioningFailed.
+func (t *Tenant) MarkProvisioningFailed(reason string) error {
+	if !t.status.CanTransitionTo(StatusProvisioningFailed) {
+		return errors.InvalidState(t.status.String(), "mark_provisioning_failed")
+	}
+
+	now := time.Now()
+	t.status = StatusProvisioningFailed
+	t.failureReason = reason
+	t.updatedAt = now
+
+	t.recordEvent(TenantProvisioningFailed{
+		TenantID:   t.id,
+		Reason:     reason,
+		OccurredAt: now,
+	})
+
+	return nil
+}
+
+// Suspend transitions the tenant to suspended status. Valid only from
+// approved. An admin cannot suspend their own tenant — the self-suspend
+// guard prevents an admin from accidentally locking themselves out.
+//
+// Order matters: state-machine validity is checked first so attempting to
+// suspend a non-approved tenant surfaces the more informative InvalidState
+// error rather than the self-suspend guard. Emits TenantSuspended.
+func (t *Tenant) Suspend(suspendedByUserID, reason string) error {
+	if !t.status.CanTransitionTo(StatusSuspended) {
+		return errors.InvalidState(t.status.String(), "suspend")
+	}
+	if suspendedByUserID == t.userID {
+		return errors.InvalidInput("suspended_by_user_id", "cannot suspend own tenant")
+	}
+
+	now := time.Now()
+	t.status = StatusSuspended
+	t.updatedAt = now
+
+	t.recordEvent(TenantSuspended{
+		TenantID:          t.id,
+		SuspendedByUserID: suspendedByUserID,
+		Reason:            reason,
+		OccurredAt:        now,
+	})
+
+	return nil
+}
+
+// ID returns the tenant ID.
+func (t *Tenant) ID() string { return t.id }
+
+// UserID returns the owning user ID.
+func (t *Tenant) UserID() string { return t.userID }
+
+// DBName returns the deterministically derived Postgres database name.
+func (t *Tenant) DBName() string { return t.dbName }
+
+// Status returns the current provisioning status.
+func (t *Tenant) Status() Status { return t.status }
+
+// SchemaVersion returns the latest migrated schema version, or nil if the
+// tenant has never been approved.
+func (t *Tenant) SchemaVersion() *int { return t.schemaVersion }
+
+// ProvisionedAt returns the timestamp at which the tenant first reached
+// approved status, or nil if it never has.
+func (t *Tenant) ProvisionedAt() *time.Time { return t.provisionedAt }
+
+// FailureReason returns the most recent provisioning failure reason. Empty
+// string in any state other than provisioning_failed.
+func (t *Tenant) FailureReason() string { return t.failureReason }
+
+// CreatedAt returns the creation timestamp.
+func (t *Tenant) CreatedAt() time.Time { return t.createdAt }
+
+// UpdatedAt returns the last-update timestamp.
+func (t *Tenant) UpdatedAt() time.Time { return t.updatedAt }
+
+// Version returns the optimistic concurrency version. Bumped by the
+// repository layer on each successful Save.
+func (t *Tenant) Version() int { return t.version }
+
+// Events returns the uncommitted events recorded on this aggregate.
+func (t *Tenant) Events() []eventbus.Event { return t.events }
+
+// ClearEvents drops all uncommitted events. Called by the repository after
+// a successful Save.
+func (t *Tenant) ClearEvents() {
+	t.events = make([]eventbus.Event, 0)
+}
+
+// recordEvent appends an event to the uncommitted events list.
+func (t *Tenant) recordEvent(event eventbus.Event) {
+	t.events = append(t.events, event)
+}

--- a/internal/domain/tenant/tenant_test.go
+++ b/internal/domain/tenant/tenant_test.go
@@ -1,0 +1,366 @@
+package tenant
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+const testUserID = "00000000-0000-0000-0000-000000000001"
+const otherAdminID = "00000000-0000-0000-0000-0000000000aa"
+
+var dbNamePattern = regexp.MustCompile(`^tenant_[a-f0-9]{32}$`)
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+func TestNewTenant(t *testing.T) {
+	tenant, err := NewTenant(testUserID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tenant.ID() == "" {
+		t.Error("tenant ID should be generated")
+	}
+	if tenant.UserID() != testUserID {
+		t.Errorf("UserID = %q, want %q", tenant.UserID(), testUserID)
+	}
+	if tenant.Status() != StatusPending {
+		t.Errorf("Status = %q, want %q", tenant.Status(), StatusPending)
+	}
+	if !dbNamePattern.MatchString(tenant.DBName()) {
+		t.Errorf("DBName = %q does not match %s", tenant.DBName(), dbNamePattern)
+	}
+	if tenant.SchemaVersion() != nil {
+		t.Error("SchemaVersion should be nil for a newly created tenant")
+	}
+	if tenant.ProvisionedAt() != nil {
+		t.Error("ProvisionedAt should be nil for a newly created tenant")
+	}
+	if tenant.FailureReason() != "" {
+		t.Errorf("FailureReason should be empty, got %q", tenant.FailureReason())
+	}
+	if tenant.Version() != 1 {
+		t.Errorf("Version = %d, want 1", tenant.Version())
+	}
+	if tenant.CreatedAt().IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+	if tenant.UpdatedAt().IsZero() {
+		t.Error("UpdatedAt should be set")
+	}
+
+	events := tenant.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != EventTypeTenantPending {
+		t.Errorf("event type = %q, want %q", events[0].EventType(), EventTypeTenantPending)
+	}
+	if events[0].AggregateID() != tenant.ID() {
+		t.Errorf("event AggregateID = %q, want %q", events[0].AggregateID(), tenant.ID())
+	}
+	if events[0].AggregateType() != AggregateTypeTenant {
+		t.Errorf("event AggregateType = %q, want %q", events[0].AggregateType(), AggregateTypeTenant)
+	}
+
+	pending, ok := events[0].(TenantPending)
+	if !ok {
+		t.Fatalf("event is not TenantPending: %T", events[0])
+	}
+	if pending.TenantID != tenant.ID() {
+		t.Errorf("TenantPending.TenantID = %q, want %q", pending.TenantID, tenant.ID())
+	}
+	if pending.UserID != testUserID {
+		t.Errorf("TenantPending.UserID = %q, want %q", pending.UserID, testUserID)
+	}
+	if pending.DBName != tenant.DBName() {
+		t.Errorf("TenantPending.DBName = %q, want %q", pending.DBName, tenant.DBName())
+	}
+	if pending.OccurredAt.IsZero() {
+		t.Error("TenantPending.OccurredAt should be set")
+	}
+}
+
+func TestNewTenant_RejectsEmptyUserID(t *testing.T) {
+	_, err := NewTenant("")
+	if err == nil {
+		t.Fatal("expected error for empty user_id")
+	}
+	if !errors.Is(err, pkgerrors.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// State machine: every valid transition + every invalid one
+// ---------------------------------------------------------------------------
+
+func TestTenant_StateMachine(t *testing.T) {
+	type op string
+	const (
+		opStartProvisioning op = "start_provisioning"
+		opApprove           op = "approve"
+		opMarkFailed        op = "mark_failed"
+		opSuspend           op = "suspend"
+	)
+
+	// setup builders, one per starting state.
+	pendingTenant := func(t *testing.T) *Tenant {
+		t.Helper()
+		tenant, err := NewTenant(testUserID)
+		mustNoErr(t, err)
+		return tenant
+	}
+	provisioningTenant := func(t *testing.T) *Tenant {
+		t.Helper()
+		tenant := pendingTenant(t)
+		mustNoErr(t, tenant.StartProvisioning())
+		return tenant
+	}
+	approvedTenant := func(t *testing.T) *Tenant {
+		t.Helper()
+		tenant := provisioningTenant(t)
+		mustNoErr(t, tenant.Approve(otherAdminID, 4))
+		return tenant
+	}
+	failedTenant := func(t *testing.T) *Tenant {
+		t.Helper()
+		tenant := provisioningTenant(t)
+		mustNoErr(t, tenant.MarkProvisioningFailed("boom"))
+		return tenant
+	}
+	suspendedTenant := func(t *testing.T) *Tenant {
+		t.Helper()
+		tenant := approvedTenant(t)
+		mustNoErr(t, tenant.Suspend(otherAdminID, "policy"))
+		return tenant
+	}
+
+	doOp := func(t *Tenant, o op) error {
+		switch o {
+		case opStartProvisioning:
+			return t.StartProvisioning()
+		case opApprove:
+			return t.Approve(otherAdminID, 1)
+		case opMarkFailed:
+			return t.MarkProvisioningFailed("err")
+		case opSuspend:
+			return t.Suspend(otherAdminID, "policy")
+		}
+		panic("unknown op")
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) *Tenant
+		op        op
+		wantState Status
+		wantErr   bool
+	}{
+		// Valid transitions
+		{"pending->provisioning", pendingTenant, opStartProvisioning, StatusProvisioning, false},
+		{"provisioning->approved", provisioningTenant, opApprove, StatusApproved, false},
+		{"provisioning->provisioning_failed", provisioningTenant, opMarkFailed, StatusProvisioningFailed, false},
+		{"provisioning_failed->provisioning (retry)", failedTenant, opStartProvisioning, StatusProvisioning, false},
+		{"approved->suspended", approvedTenant, opSuspend, StatusSuspended, false},
+
+		// Invalid: pending
+		{"pending cannot approve", pendingTenant, opApprove, "", true},
+		{"pending cannot mark_failed", pendingTenant, opMarkFailed, "", true},
+		{"pending cannot suspend", pendingTenant, opSuspend, "", true},
+
+		// Invalid: provisioning
+		{"provisioning cannot start_provisioning", provisioningTenant, opStartProvisioning, "", true},
+		{"provisioning cannot suspend", provisioningTenant, opSuspend, "", true},
+
+		// Invalid: approved
+		{"approved cannot start_provisioning", approvedTenant, opStartProvisioning, "", true},
+		{"approved cannot approve", approvedTenant, opApprove, "", true},
+		{"approved cannot mark_failed", approvedTenant, opMarkFailed, "", true},
+
+		// Invalid: provisioning_failed
+		{"provisioning_failed cannot approve", failedTenant, opApprove, "", true},
+		{"provisioning_failed cannot mark_failed", failedTenant, opMarkFailed, "", true},
+		{"provisioning_failed cannot suspend", failedTenant, opSuspend, "", true},
+
+		// Invalid: suspended (terminal)
+		{"suspended cannot start_provisioning", suspendedTenant, opStartProvisioning, "", true},
+		{"suspended cannot approve", suspendedTenant, opApprove, "", true},
+		{"suspended cannot mark_failed", suspendedTenant, opMarkFailed, "", true},
+		{"suspended cannot suspend", suspendedTenant, opSuspend, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenant := tt.setup(t)
+			err := doOp(tenant, tt.op)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (state=%q)", tenant.Status())
+				}
+				if !errors.Is(err, pkgerrors.ErrInvalidState) {
+					t.Errorf("expected ErrInvalidState, got %v", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tenant.Status() != tt.wantState {
+				t.Errorf("Status = %q, want %q", tenant.Status(), tt.wantState)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Approve sets schema version + provisioned_at and emits the right event
+// ---------------------------------------------------------------------------
+
+func TestTenant_Approve_SetsSchemaAndTimestamp(t *testing.T) {
+	tenant, err := NewTenant(testUserID)
+	mustNoErr(t, err)
+	mustNoErr(t, tenant.StartProvisioning())
+
+	mustNoErr(t, tenant.Approve(otherAdminID, 7))
+
+	if tenant.Status() != StatusApproved {
+		t.Errorf("Status = %q, want %q", tenant.Status(), StatusApproved)
+	}
+	if tenant.SchemaVersion() == nil {
+		t.Fatal("SchemaVersion should be set after Approve")
+	}
+	if *tenant.SchemaVersion() != 7 {
+		t.Errorf("SchemaVersion = %d, want 7", *tenant.SchemaVersion())
+	}
+	if tenant.ProvisionedAt() == nil {
+		t.Fatal("ProvisionedAt should be set after Approve")
+	}
+
+	events := tenant.Events()
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events (pending+provisioning+approved), got %d", len(events))
+	}
+	approved, ok := events[2].(TenantApproved)
+	if !ok {
+		t.Fatalf("event[2] is not TenantApproved: %T", events[2])
+	}
+	if approved.SchemaVersion != 7 {
+		t.Errorf("TenantApproved.SchemaVersion = %d, want 7", approved.SchemaVersion)
+	}
+	if approved.ApprovedByUserID != otherAdminID {
+		t.Errorf("TenantApproved.ApprovedByUserID = %q, want %q", approved.ApprovedByUserID, otherAdminID)
+	}
+	if approved.DBName != tenant.DBName() {
+		t.Errorf("TenantApproved.DBName = %q, want %q", approved.DBName, tenant.DBName())
+	}
+	if approved.UserID != testUserID {
+		t.Errorf("TenantApproved.UserID = %q, want %q", approved.UserID, testUserID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// provisioning_failed -> provisioning retry path clears failure_reason
+// ---------------------------------------------------------------------------
+
+func TestTenant_RetryFromFailed(t *testing.T) {
+	tenant, err := NewTenant(testUserID)
+	mustNoErr(t, err)
+	mustNoErr(t, tenant.StartProvisioning())
+	mustNoErr(t, tenant.MarkProvisioningFailed("create database failed"))
+
+	if tenant.Status() != StatusProvisioningFailed {
+		t.Fatalf("Status = %q, want %q", tenant.Status(), StatusProvisioningFailed)
+	}
+	if tenant.FailureReason() != "create database failed" {
+		t.Errorf("FailureReason = %q, want 'create database failed'", tenant.FailureReason())
+	}
+
+	mustNoErr(t, tenant.StartProvisioning())
+
+	if tenant.Status() != StatusProvisioning {
+		t.Errorf("Status = %q, want %q", tenant.Status(), StatusProvisioning)
+	}
+	if tenant.FailureReason() != "" {
+		t.Errorf("FailureReason should be cleared on retry, got %q", tenant.FailureReason())
+	}
+
+	// Event log: pending, provisioning, provisioning_failed, provisioning
+	events := tenant.Events()
+	wantTypes := []string{
+		EventTypeTenantPending,
+		EventTypeTenantProvisioning,
+		EventTypeTenantProvisioningFailed,
+		EventTypeTenantProvisioning,
+	}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("got %d events, want %d", len(events), len(wantTypes))
+	}
+	for i, want := range wantTypes {
+		if events[i].EventType() != want {
+			t.Errorf("event[%d] = %q, want %q", i, events[i].EventType(), want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Self-suspend guard
+// ---------------------------------------------------------------------------
+
+func TestTenant_Suspend_SelfSuspendBlocked(t *testing.T) {
+	tenant, err := NewTenant(testUserID)
+	mustNoErr(t, err)
+	mustNoErr(t, tenant.StartProvisioning())
+	mustNoErr(t, tenant.Approve(otherAdminID, 1))
+
+	err = tenant.Suspend(testUserID, "trying to self-suspend")
+	if err == nil {
+		t.Fatal("expected error when admin tries to suspend own tenant")
+	}
+	if !errors.Is(err, pkgerrors.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput, got %v", err)
+	}
+	if tenant.Status() != StatusApproved {
+		t.Errorf("status should be unchanged after blocked self-suspend, got %q", tenant.Status())
+	}
+
+	// And another admin can suspend.
+	mustNoErr(t, tenant.Suspend(otherAdminID, "policy"))
+	if tenant.Status() != StatusSuspended {
+		t.Errorf("status = %q, want %q", tenant.Status(), StatusSuspended)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ClearEvents
+// ---------------------------------------------------------------------------
+
+func TestTenant_ClearEvents(t *testing.T) {
+	tenant, err := NewTenant(testUserID)
+	mustNoErr(t, err)
+	if len(tenant.Events()) == 0 {
+		t.Fatal("tenant should have events after creation")
+	}
+	tenant.ClearEvents()
+	if len(tenant.Events()) != 0 {
+		t.Errorf("Events should be empty after ClearEvents, got %d", len(tenant.Events()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func mustNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Wave 1** of the v1.0 platform plan: the `Tenant` aggregate root that underpins multi-tenant isolation in `platform.duragraph.ai`. Pure domain layer only — no persistence, HTTP, or wiring yet. Mirrors the structure and conventions of `internal/domain/run/`.

- **5 domain events** implementing `eventbus.Event`, dot-form types matching `duragraph-spec/models/events.yml#tenant_events`
- **State machine** (per `duragraph-spec/models/entities.yml#tenants`):
  - `pending → provisioning`
  - `provisioning → approved | provisioning_failed`
  - `provisioning_failed → provisioning` (admin retry; clears `failure_reason`)
  - `approved → suspended`
  - `suspended` is terminal at the aggregate level
- **Deterministic `DBName`** derivation (`tenant_<32-hex>`) with regex validator for safe DDL string-interpolation
- **Self-suspend guard**: an admin cannot suspend their own tenant (state-machine validity is checked first so non-approved self-suspend attempts surface `InvalidState` rather than `InvalidInput`)

## Files

All under `internal/domain/tenant/`:

| File | Purpose |
|------|---------|
| `status.go` | `Status` type + `IsValid` / `CanTransitionTo` / `String` |
| `events.go` | `TenantPending`, `TenantProvisioning`, `TenantApproved`, `TenantProvisioningFailed`, `TenantSuspended` |
| `dbname.go` | `DBName(id) (string, error)` + `ValidateDBName(name) error` |
| `tenant.go` | `Tenant` aggregate, `NewTenant`, transition methods, accessors |
| `repository.go` | `Repository` interface (`Save` / `GetByID` / `GetByUserID` / `ListByStatus`) |
| `tenant_test.go` | Aggregate construction, full state-machine matrix, retry path, self-suspend guard, `ClearEvents` |
| `dbname_test.go` | Determinism, canonical format, invalid-UUID rejection, table-driven `ValidateDBName` (incl. injection attempt) |

## Conventions

- IDs are `string`, generated via `internal/pkg/uuid.New()` (matching `run/`)
- Errors use `internal/pkg/errors`: `InvalidInput` / `InvalidState`
- Events implement `internal/pkg/eventbus.Event` (`EventType` / `AggregateID` / `AggregateType`)
- JSON tags snake_case; optional fields use `omitempty`
- No `Reconstruct` / `applyEvent` / projection rebuilder yet — those land with the persistence layer

## Test plan

- [x] `go vet ./internal/domain/tenant/...` clean
- [x] `go fmt ./internal/domain/tenant/...` no diff
- [x] `go test ./internal/domain/tenant/... -short` all pass
- [x] State-machine matrix covers every valid transition + every invalid one (errors via `errors.Is(err, ErrInvalidState)`)
- [x] Retry path asserts `FailureReason()` cleared on `provisioning_failed → provisioning`
- [x] Self-suspend test asserts `errors.Is(err, ErrInvalidInput)` and that another admin can still suspend
- [x] `DBName` determinism + format + invalid-UUID rejection
- [x] `ValidateDBName` accepts canonical, rejects malformed (missing prefix, wrong prefix, wrong length, uppercase hex, hyphens, whitespace, injection attempt)

## Cross-references

- `Duragraph/duragraph-spec#14` — `tenants` entity + state machine + table CHECKs
- `Duragraph/duragraph-spec#18` — `tenant_events` payloads

## Out of scope (follow-up PRs)

- Postgres `Repository` implementation (event store + outbox)
- `MigratePlatform` / `ProvisionTenant` / `MigrateAllTenants` pipeline
- `ApproveTenant` / `RejectTenant` / `SuspendTenant` command handlers
- HTTP handlers, middleware, NATS Account provisioning

DO NOT MERGE.