### PR TITLE
feat: add User aggregate (domain layer)

### DIFF
--- a/internal/domain/user/events.go
+++ b/internal/domain/user/events.go
@@ -1,0 +1,123 @@
+package user
+
+import "time"
+
+// Event type constants — dot-form, mirroring the spec at
+// duragraph-spec/models/events.yml under user_events.
+const (
+	EventTypeUserSignedUp        = "user.signed_up"
+	EventTypeUserPromotedToAdmin = "user.promoted_to_admin"
+	EventTypeUserApproved        = "user.approved"
+	EventTypeUserRejected        = "user.rejected"
+	EventTypeUserSuspended       = "user.suspended"
+)
+
+// aggregateTypeUser is the AggregateType() value for all user-domain events.
+const aggregateTypeUser = "user"
+
+// UserSignedUp is emitted when a user completes OAuth callback for the first
+// time (status=pending). In the bootstrap path it is followed atomically by
+// UserPromotedToAdmin and UserApproved.
+type UserSignedUp struct {
+	UserID        string    `json:"user_id"`
+	Email         string    `json:"email"`
+	OAuthProvider string    `json:"oauth_provider"`
+	OAuthID       string    `json:"oauth_id"`
+	OccurredAt    time.Time `json:"occurred_at"`
+}
+
+// EventType returns the dot-form event type identifier.
+func (e UserSignedUp) EventType() string { return EventTypeUserSignedUp }
+
+// AggregateID returns the User aggregate ID this event belongs to.
+func (e UserSignedUp) AggregateID() string { return e.UserID }
+
+// AggregateType returns the aggregate type identifier ("user").
+func (e UserSignedUp) AggregateType() string { return aggregateTypeUser }
+
+// UserPromotedToAdmin is emitted when a user's role is set to admin.
+//
+// Two contexts:
+//   - Bootstrap (very first signup): emitted alongside UserSignedUp and
+//     UserApproved. PromotedByUserID is nil — there is no human actor.
+//   - Manual elevation: PromotedByUserID is the acting admin's user_id.
+//
+// PromotedByUserID is a pointer so nil is faithfully preserved across
+// JSON serialization (with `omitempty` the field is omitted entirely from
+// the bootstrap event payload, matching the spec's "null because there's
+// no actor" wording).
+type UserPromotedToAdmin struct {
+	UserID           string    `json:"user_id"`
+	PromotedByUserID *string   `json:"promoted_by_user_id,omitempty"`
+	OccurredAt       time.Time `json:"occurred_at"`
+}
+
+// EventType returns the dot-form event type identifier.
+func (e UserPromotedToAdmin) EventType() string { return EventTypeUserPromotedToAdmin }
+
+// AggregateID returns the User aggregate ID this event belongs to.
+func (e UserPromotedToAdmin) AggregateID() string { return e.UserID }
+
+// AggregateType returns the aggregate type identifier ("user").
+func (e UserPromotedToAdmin) AggregateType() string { return aggregateTypeUser }
+
+// UserApproved is emitted when an admin approves a pending user
+// (status pending → approved). Pairs with tenant.provisioning /
+// tenant.approved on the tenant aggregate.
+//
+// Also emitted when a suspended user is resumed back to approved
+// (suspended → approved); the spec does not define a separate
+// "user.resumed" event so the state-restoring transition reuses
+// user.approved with ApprovedByUserID set to the admin who resumed.
+type UserApproved struct {
+	UserID           string    `json:"user_id"`
+	ApprovedByUserID string    `json:"approved_by_user_id"`
+	OccurredAt       time.Time `json:"occurred_at"`
+}
+
+// EventType returns the dot-form event type identifier.
+func (e UserApproved) EventType() string { return EventTypeUserApproved }
+
+// AggregateID returns the User aggregate ID this event belongs to.
+func (e UserApproved) AggregateID() string { return e.UserID }
+
+// AggregateType returns the aggregate type identifier ("user").
+func (e UserApproved) AggregateType() string { return aggregateTypeUser }
+
+// UserRejected is emitted when an admin rejects a pending user. The user
+// transitions to status=suspended without ever provisioning a tenant.
+// Distinct from UserSuspended (which applies to a previously-approved user).
+type UserRejected struct {
+	UserID           string    `json:"user_id"`
+	RejectedByUserID string    `json:"rejected_by_user_id"`
+	Reason           string    `json:"reason,omitempty"`
+	OccurredAt       time.Time `json:"occurred_at"`
+}
+
+// EventType returns the dot-form event type identifier.
+func (e UserRejected) EventType() string { return EventTypeUserRejected }
+
+// AggregateID returns the User aggregate ID this event belongs to.
+func (e UserRejected) AggregateID() string { return e.UserID }
+
+// AggregateType returns the aggregate type identifier ("user").
+func (e UserRejected) AggregateType() string { return aggregateTypeUser }
+
+// UserSuspended is emitted when an admin suspends a previously-approved
+// user (status approved → suspended). Distinct from UserRejected (which
+// applies to a still-pending user).
+type UserSuspended struct {
+	UserID            string    `json:"user_id"`
+	SuspendedByUserID string    `json:"suspended_by_user_id"`
+	Reason            string    `json:"reason,omitempty"`
+	OccurredAt        time.Time `json:"occurred_at"`
+}
+
+// EventType returns the dot-form event type identifier.
+func (e UserSuspended) EventType() string { return EventTypeUserSuspended }
+
+// AggregateID returns the User aggregate ID this event belongs to.
+func (e UserSuspended) AggregateID() string { return e.UserID }
+
+// AggregateType returns the aggregate type identifier ("user").
+func (e UserSuspended) AggregateType() string { return aggregateTypeUser }

--- a/internal/domain/user/repository.go
+++ b/internal/domain/user/repository.go
@@ -1,0 +1,40 @@
+package user
+
+import "context"
+
+// Repository is the persistence port for the User aggregate.
+//
+// Implementations live in internal/infrastructure/persistence (Wave 1
+// follow-up — postgres adapter against duragraph_platform.users) and are
+// responsible for atomically persisting the aggregate's uncommitted events
+// alongside the projection row, then calling ClearEvents on the aggregate.
+//
+// All methods take context.Context for cancellation / deadlines. Lookups
+// that find nothing return errors.NotFound; storage failures return
+// errors.Internal.
+type Repository interface {
+	// Save persists a User aggregate (projection row + uncommitted events
+	// to event store + outbox) in a single transaction.
+	Save(ctx context.Context, u *User) error
+
+	// GetByID retrieves a user by aggregate ID. Returns errors.NotFound
+	// when no row matches.
+	GetByID(ctx context.Context, id string) (*User, error)
+
+	// GetByOAuth retrieves a user by the immutable external identity
+	// (oauth_provider, oauth_id) — the lookup key used during the OAuth
+	// callback decision tree (see auth/oauth.yml). Returns errors.NotFound
+	// when no row matches.
+	GetByOAuth(ctx context.Context, provider, oauthID string) (*User, error)
+
+	// ListByStatus retrieves users matching the given status with
+	// pagination. Used by the admin UI to render the pending-users
+	// whitelist.
+	ListByStatus(ctx context.Context, status Status, limit, offset int) ([]*User, error)
+
+	// CountAll returns the total number of users in the platform DB.
+	// Used by the OAuth callback to detect the bootstrap-first-user
+	// branch atomically (in conjunction with a serializable transaction
+	// or bootstrap-lock row — see auth/oauth.yml).
+	CountAll(ctx context.Context) (int, error)
+}

--- a/internal/domain/user/role.go
+++ b/internal/domain/user/role.go
@@ -1,0 +1,33 @@
+package user
+
+// Role represents the authorization tier of a platform user.
+// Per auth/jwt.yml, the role claim drives access to admin surfaces:
+//   - "user"  — dashboard + engine APIs (subject to tenant_id presence)
+//   - "admin" — adds admin surfaces (/admin/*, /api/admin/*)
+//
+// The very first user to sign up is auto-elevated to admin (bootstrap path);
+// subsequent users default to "user" and only an existing admin can promote
+// them.
+type Role string
+
+const (
+	// RoleUser is the default authorization tier for end users.
+	RoleUser Role = "user"
+
+	// RoleAdmin grants access to admin surfaces and operator-only commands.
+	RoleAdmin Role = "admin"
+)
+
+// IsValid reports whether r is a recognized Role.
+func (r Role) IsValid() bool {
+	switch r {
+	case RoleUser, RoleAdmin:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation of the Role.
+func (r Role) String() string {
+	return string(r)
+}

--- a/internal/domain/user/role_test.go
+++ b/internal/domain/user/role_test.go
@@ -1,0 +1,34 @@
+package user
+
+import "testing"
+
+func TestRoleValid(t *testing.T) {
+	tests := []struct {
+		name string
+		role Role
+		want bool
+	}{
+		{"user is valid", RoleUser, true},
+		{"admin is valid", RoleAdmin, true},
+		{"empty is invalid", Role(""), false},
+		{"unknown is invalid", Role("operator"), false},
+		{"capitalised is invalid (case-sensitive)", Role("User"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.role.IsValid(); got != tt.want {
+				t.Errorf("Role(%q).IsValid() = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoleString(t *testing.T) {
+	if RoleUser.String() != "user" {
+		t.Errorf("RoleUser.String() = %q, want %q", RoleUser.String(), "user")
+	}
+	if RoleAdmin.String() != "admin" {
+		t.Errorf("RoleAdmin.String() = %q, want %q", RoleAdmin.String(), "admin")
+	}
+}

--- a/internal/domain/user/status.go
+++ b/internal/domain/user/status.go
@@ -1,0 +1,74 @@
+package user
+
+// Status represents the approval lifecycle state of a platform user.
+//
+// State machine (per auth/oauth.yml callback decision tree and the platform
+// plan):
+//
+//	pending   → approved   (admin Approve)
+//	pending   → suspended  (admin Reject)
+//	approved  → suspended  (admin Suspend)
+//	suspended → approved   (admin Resume)
+//
+// Reject and Suspend both produce status=suspended but are distinct domain
+// events (user.rejected vs user.suspended) — see events.go and the spec at
+// duragraph-spec/models/events.yml. The User aggregate methods enforce the
+// correct source state for each transition.
+type Status string
+
+const (
+	// StatusPending is the initial status for a newly signed-up user awaiting
+	// admin approval.
+	StatusPending Status = "pending"
+
+	// StatusApproved indicates the user has been approved and (in the normal
+	// flow) has a tenant provisioned.
+	StatusApproved Status = "approved"
+
+	// StatusSuspended indicates the user is barred from sign-in. Reached by
+	// Reject (from pending) or Suspend (from approved).
+	StatusSuspended Status = "suspended"
+)
+
+// IsValid reports whether s is a recognized Status.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusApproved, StatusSuspended:
+		return true
+	}
+	return false
+}
+
+// CanTransitionTo reports whether the state machine permits a transition from
+// the receiver to next.
+//
+// Note: callers must additionally enforce the *specific* source state for
+// methods that share a target state (Reject and Suspend both target
+// suspended). CanTransitionTo answers "is target reachable" but cannot
+// distinguish reject-vs-suspend on its own.
+func (s Status) CanTransitionTo(next Status) bool {
+	allowed := map[Status][]Status{
+		StatusPending: {
+			StatusApproved,  // Approve
+			StatusSuspended, // Reject
+		},
+		StatusApproved: {
+			StatusSuspended, // Suspend
+		},
+		StatusSuspended: {
+			StatusApproved, // Resume
+		},
+	}
+
+	for _, target := range allowed[s] {
+		if target == next {
+			return true
+		}
+	}
+	return false
+}
+
+// String returns the string representation of the Status.
+func (s Status) String() string {
+	return string(s)
+}

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -1,0 +1,312 @@
+// Package user implements the User aggregate for the platform domain.
+//
+// Per the platform plan (project_duragraph_cd.md), the User aggregate lives
+// in `duragraph_platform.users` and is 1:1 with the Tenant aggregate.
+// The User aggregate is the source of truth for:
+//   - identity (oauth_provider, oauth_id, email)
+//   - authorization role (user | admin)
+//   - approval status (pending | approved | suspended)
+//
+// Tenant provisioning is a separate aggregate driven by user.approved events
+// — see internal/domain/tenant (Wave 2) for that lifecycle.
+package user
+
+import (
+	"time"
+
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
+	pkguuid "github.com/duragraph/duragraph/internal/pkg/uuid"
+)
+
+// User represents the User aggregate root.
+type User struct {
+	id            string
+	email         string
+	oauthProvider string
+	oauthID       string
+	role          Role
+	status        Status
+	createdAt     time.Time
+	updatedAt     time.Time
+	version       int
+
+	// events holds uncommitted domain events recorded by aggregate methods.
+	events []eventbus.Event
+}
+
+// RegisterUser creates a new User aggregate from a successful OAuth callback.
+//
+// Bootstrap path (isFirstUser == true): the very first user to sign up is
+// auto-elevated to admin and auto-approved. Three events are recorded
+// atomically in this exact order: UserSignedUp, UserPromotedToAdmin (with
+// PromotedByUserID == nil — no human actor), UserApproved (ApprovedByUserID
+// == the user's own ID; this is the documented bootstrap exception to the
+// self-action guard).
+//
+// Normal signup (isFirstUser == false): user starts at role=user,
+// status=pending, awaiting admin approval. Only UserSignedUp is recorded.
+//
+// Inputs are validated for non-empty values. The (oauth_provider, oauth_id)
+// uniqueness invariant is enforced at the persistence layer.
+func RegisterUser(email, oauthProvider, oauthID string, isFirstUser bool) (*User, error) {
+	if email == "" {
+		return nil, errors.InvalidInput("email", "email is required")
+	}
+	if oauthProvider == "" {
+		return nil, errors.InvalidInput("oauth_provider", "oauth_provider is required")
+	}
+	if oauthID == "" {
+		return nil, errors.InvalidInput("oauth_id", "oauth_id is required")
+	}
+
+	now := time.Now()
+	id := pkguuid.New()
+
+	u := &User{
+		id:            id,
+		email:         email,
+		oauthProvider: oauthProvider,
+		oauthID:       oauthID,
+		role:          RoleUser,
+		status:        StatusPending,
+		createdAt:     now,
+		updatedAt:     now,
+		version:       1,
+		events:        make([]eventbus.Event, 0),
+	}
+
+	u.recordEvent(UserSignedUp{
+		UserID:        id,
+		Email:         email,
+		OAuthProvider: oauthProvider,
+		OAuthID:       oauthID,
+		OccurredAt:    now,
+	})
+
+	if isFirstUser {
+		// Bootstrap path: self-elevate and self-approve. Per auth/oauth.yml,
+		// this is the documented exception to the self-action guard — there
+		// is no other admin to perform either operation. Events are recorded
+		// directly here; we do NOT call PromoteToAdmin / Approve because
+		// those methods enforce the self-action guard that we are explicitly
+		// bypassing for bootstrap.
+		u.role = RoleAdmin
+		u.status = StatusApproved
+
+		u.recordEvent(UserPromotedToAdmin{
+			UserID:           id,
+			PromotedByUserID: nil, // bootstrap — no human actor
+			OccurredAt:       now,
+		})
+		u.recordEvent(UserApproved{
+			UserID:           id,
+			ApprovedByUserID: id, // bootstrap self-approval
+			OccurredAt:       now,
+		})
+	}
+
+	return u, nil
+}
+
+// Approve transitions a pending user to approved.
+//
+// Self-approval is blocked for the normal flow (approvedByUserID must not
+// equal u.ID()). The bootstrap path bypasses this method entirely and
+// records UserApproved directly from RegisterUser.
+func (u *User) Approve(approvedByUserID string) error {
+	if approvedByUserID == "" {
+		return errors.InvalidInput("approved_by_user_id", "approved_by_user_id is required")
+	}
+	if approvedByUserID == u.id {
+		return errors.InvalidInput("approved_by_user_id", "cannot approve self")
+	}
+	if u.status != StatusPending {
+		return errors.InvalidState(u.status.String(), "approve")
+	}
+
+	now := time.Now()
+	u.status = StatusApproved
+	u.updatedAt = now
+
+	u.recordEvent(UserApproved{
+		UserID:           u.id,
+		ApprovedByUserID: approvedByUserID,
+		OccurredAt:       now,
+	})
+
+	return nil
+}
+
+// Reject transitions a pending user to suspended without ever provisioning
+// a tenant. Distinct from Suspend (which applies to an already-approved
+// user) — Reject emits user.rejected, Suspend emits user.suspended.
+//
+// Self-rejection is blocked.
+func (u *User) Reject(rejectedByUserID, reason string) error {
+	if rejectedByUserID == "" {
+		return errors.InvalidInput("rejected_by_user_id", "rejected_by_user_id is required")
+	}
+	if rejectedByUserID == u.id {
+		return errors.InvalidInput("rejected_by_user_id", "cannot reject self")
+	}
+	if u.status != StatusPending {
+		return errors.InvalidState(u.status.String(), "reject")
+	}
+
+	now := time.Now()
+	u.status = StatusSuspended
+	u.updatedAt = now
+
+	u.recordEvent(UserRejected{
+		UserID:           u.id,
+		RejectedByUserID: rejectedByUserID,
+		Reason:           reason,
+		OccurredAt:       now,
+	})
+
+	return nil
+}
+
+// Suspend transitions an approved user to suspended. Distinct from Reject
+// (which applies to a pending user) — Suspend emits user.suspended,
+// Reject emits user.rejected.
+//
+// Self-suspension is blocked.
+func (u *User) Suspend(suspendedByUserID, reason string) error {
+	if suspendedByUserID == "" {
+		return errors.InvalidInput("suspended_by_user_id", "suspended_by_user_id is required")
+	}
+	if suspendedByUserID == u.id {
+		return errors.InvalidInput("suspended_by_user_id", "cannot suspend self")
+	}
+	if u.status != StatusApproved {
+		return errors.InvalidState(u.status.String(), "suspend")
+	}
+
+	now := time.Now()
+	u.status = StatusSuspended
+	u.updatedAt = now
+
+	u.recordEvent(UserSuspended{
+		UserID:            u.id,
+		SuspendedByUserID: suspendedByUserID,
+		Reason:            reason,
+		OccurredAt:        now,
+	})
+
+	return nil
+}
+
+// Resume transitions a suspended user back to approved.
+//
+// Unlike Approve / Reject / Suspend, Resume does NOT have a self-action
+// guard. An admin recovering their own suspended account is a legitimate
+// operation, and the operator-approval flow at this scale (1:1 user↔tenant,
+// single operator deployment) does not assume a second admin is always
+// available to perform the unsuspend. Authorization to resume is the
+// responsibility of the application/middleware layer.
+//
+// The spec at duragraph-spec/models/events.yml does not define a separate
+// "user.resumed" event; the state-restoring transition reuses UserApproved
+// with ApprovedByUserID set to the admin who resumed. This is a deliberate
+// design choice — only the resulting state matters for projection, and
+// reusing UserApproved keeps the projection logic single-pathed.
+func (u *User) Resume(resumedByUserID string) error {
+	if resumedByUserID == "" {
+		return errors.InvalidInput("resumed_by_user_id", "resumed_by_user_id is required")
+	}
+	if u.status != StatusSuspended {
+		return errors.InvalidState(u.status.String(), "resume")
+	}
+
+	now := time.Now()
+	u.status = StatusApproved
+	u.updatedAt = now
+
+	u.recordEvent(UserApproved{
+		UserID:           u.id,
+		ApprovedByUserID: resumedByUserID,
+		OccurredAt:       now,
+	})
+
+	return nil
+}
+
+// PromoteToAdmin elevates the user to role=admin. This is a role change,
+// not a status transition — status is unaffected.
+//
+// Self-promotion is blocked. The bootstrap path bypasses this method
+// entirely and records UserPromotedToAdmin directly from RegisterUser
+// (with PromotedByUserID == nil, signifying no human actor).
+//
+// Idempotency: promoting an already-admin user is permitted (no error)
+// but still records a UserPromotedToAdmin event. The application layer
+// should guard against redundant calls if it wants to suppress the
+// duplicate event.
+func (u *User) PromoteToAdmin(promotedByUserID string) error {
+	if promotedByUserID == "" {
+		return errors.InvalidInput("promoted_by_user_id", "promoted_by_user_id is required")
+	}
+	if promotedByUserID == u.id {
+		return errors.InvalidInput("promoted_by_user_id", "cannot promote self")
+	}
+
+	now := time.Now()
+	u.role = RoleAdmin
+	u.updatedAt = now
+
+	by := promotedByUserID
+	u.recordEvent(UserPromotedToAdmin{
+		UserID:           u.id,
+		PromotedByUserID: &by,
+		OccurredAt:       now,
+	})
+
+	return nil
+}
+
+// ID returns the user's UUID.
+func (u *User) ID() string { return u.id }
+
+// Email returns the user's email.
+func (u *User) Email() string { return u.email }
+
+// OAuthProvider returns the OAuth provider key (e.g. "google", "github").
+func (u *User) OAuthProvider() string { return u.oauthProvider }
+
+// OAuthID returns the provider-issued subject identifier.
+func (u *User) OAuthID() string { return u.oauthID }
+
+// Role returns the user's authorization role.
+func (u *User) Role() Role { return u.role }
+
+// IsAdmin reports whether the user has the admin role.
+func (u *User) IsAdmin() bool { return u.role == RoleAdmin }
+
+// Status returns the user's approval lifecycle status.
+func (u *User) Status() Status { return u.status }
+
+// CreatedAt returns the time the user aggregate was created.
+func (u *User) CreatedAt() time.Time { return u.createdAt }
+
+// UpdatedAt returns the time the user aggregate was last mutated.
+func (u *User) UpdatedAt() time.Time { return u.updatedAt }
+
+// Version returns the optimistic-concurrency version.
+func (u *User) Version() int { return u.version }
+
+// Events returns the uncommitted domain events recorded since the last
+// ClearEvents call.
+func (u *User) Events() []eventbus.Event { return u.events }
+
+// ClearEvents drops the uncommitted events list. Repositories call this
+// after persisting events to the event store + outbox.
+func (u *User) ClearEvents() {
+	u.events = make([]eventbus.Event, 0)
+}
+
+// recordEvent appends an event to the uncommitted events list.
+func (u *User) recordEvent(e eventbus.Event) {
+	u.events = append(u.events, e)
+}

--- a/internal/domain/user/user_test.go
+++ b/internal/domain/user/user_test.go
@@ -1,0 +1,621 @@
+package user
+
+import (
+	"strings"
+	"testing"
+
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// ----------------------------------------------------------------------------
+// RegisterUser tests
+// ----------------------------------------------------------------------------
+
+func TestRegisterUser_NormalSignup(t *testing.T) {
+	u, err := RegisterUser("alice@example.com", "google", "google-sub-1", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if u.ID() == "" {
+		t.Error("user ID should be generated")
+	}
+	if u.Email() != "alice@example.com" {
+		t.Errorf("Email() = %q, want %q", u.Email(), "alice@example.com")
+	}
+	if u.OAuthProvider() != "google" {
+		t.Errorf("OAuthProvider() = %q, want %q", u.OAuthProvider(), "google")
+	}
+	if u.OAuthID() != "google-sub-1" {
+		t.Errorf("OAuthID() = %q, want %q", u.OAuthID(), "google-sub-1")
+	}
+	if u.Role() != RoleUser {
+		t.Errorf("Role() = %q, want %q", u.Role(), RoleUser)
+	}
+	if u.IsAdmin() {
+		t.Error("IsAdmin() should be false for normal signup")
+	}
+	if u.Status() != StatusPending {
+		t.Errorf("Status() = %q, want %q", u.Status(), StatusPending)
+	}
+	if u.Version() != 1 {
+		t.Errorf("Version() = %d, want 1", u.Version())
+	}
+	if u.CreatedAt().IsZero() {
+		t.Error("CreatedAt() should be set")
+	}
+	if u.UpdatedAt().IsZero() {
+		t.Error("UpdatedAt() should be set")
+	}
+
+	events := u.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != EventTypeUserSignedUp {
+		t.Errorf("event[0].EventType() = %q, want %q", events[0].EventType(), EventTypeUserSignedUp)
+	}
+	if events[0].AggregateID() != u.ID() {
+		t.Errorf("event[0].AggregateID() = %q, want %q", events[0].AggregateID(), u.ID())
+	}
+	if events[0].AggregateType() != "user" {
+		t.Errorf("event[0].AggregateType() = %q, want %q", events[0].AggregateType(), "user")
+	}
+
+	signedUp, ok := events[0].(UserSignedUp)
+	if !ok {
+		t.Fatalf("event[0] is %T, want UserSignedUp", events[0])
+	}
+	if signedUp.UserID != u.ID() {
+		t.Errorf("UserSignedUp.UserID = %q, want %q", signedUp.UserID, u.ID())
+	}
+	if signedUp.Email != "alice@example.com" {
+		t.Errorf("UserSignedUp.Email = %q, want %q", signedUp.Email, "alice@example.com")
+	}
+	if signedUp.OAuthProvider != "google" {
+		t.Errorf("UserSignedUp.OAuthProvider = %q, want %q", signedUp.OAuthProvider, "google")
+	}
+	if signedUp.OAuthID != "google-sub-1" {
+		t.Errorf("UserSignedUp.OAuthID = %q, want %q", signedUp.OAuthID, "google-sub-1")
+	}
+	if signedUp.OccurredAt.IsZero() {
+		t.Error("UserSignedUp.OccurredAt should be set")
+	}
+}
+
+func TestRegisterUser_BootstrapFirstUser(t *testing.T) {
+	u, err := RegisterUser("operator@duragraph.ai", "github", "gh-1", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if u.Role() != RoleAdmin {
+		t.Errorf("bootstrap user Role() = %q, want %q", u.Role(), RoleAdmin)
+	}
+	if !u.IsAdmin() {
+		t.Error("bootstrap user IsAdmin() should be true")
+	}
+	if u.Status() != StatusApproved {
+		t.Errorf("bootstrap user Status() = %q, want %q", u.Status(), StatusApproved)
+	}
+
+	events := u.Events()
+	if len(events) != 3 {
+		t.Fatalf("bootstrap should record exactly 3 events, got %d", len(events))
+	}
+
+	wantOrder := []string{
+		EventTypeUserSignedUp,
+		EventTypeUserPromotedToAdmin,
+		EventTypeUserApproved,
+	}
+	for i, want := range wantOrder {
+		if events[i].EventType() != want {
+			t.Errorf("event[%d].EventType() = %q, want %q", i, events[i].EventType(), want)
+		}
+		if events[i].AggregateID() != u.ID() {
+			t.Errorf("event[%d].AggregateID() = %q, want %q", i, events[i].AggregateID(), u.ID())
+		}
+		if events[i].AggregateType() != "user" {
+			t.Errorf("event[%d].AggregateType() = %q, want %q", i, events[i].AggregateType(), "user")
+		}
+	}
+
+	// Bootstrap UserPromotedToAdmin must have nil PromotedByUserID.
+	promoted, ok := events[1].(UserPromotedToAdmin)
+	if !ok {
+		t.Fatalf("event[1] is %T, want UserPromotedToAdmin", events[1])
+	}
+	if promoted.PromotedByUserID != nil {
+		t.Errorf("bootstrap UserPromotedToAdmin.PromotedByUserID = %v, want nil",
+			*promoted.PromotedByUserID)
+	}
+	if promoted.UserID != u.ID() {
+		t.Errorf("UserPromotedToAdmin.UserID = %q, want %q", promoted.UserID, u.ID())
+	}
+
+	// Bootstrap UserApproved must have ApprovedByUserID == u.ID() (self-approval).
+	approved, ok := events[2].(UserApproved)
+	if !ok {
+		t.Fatalf("event[2] is %T, want UserApproved", events[2])
+	}
+	if approved.ApprovedByUserID != u.ID() {
+		t.Errorf("bootstrap UserApproved.ApprovedByUserID = %q, want %q (self-approval)",
+			approved.ApprovedByUserID, u.ID())
+	}
+	if approved.UserID != u.ID() {
+		t.Errorf("UserApproved.UserID = %q, want %q", approved.UserID, u.ID())
+	}
+}
+
+func TestRegisterUser_RejectsEmptyInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		email       string
+		provider    string
+		oauthID     string
+		errContains string
+	}{
+		{"empty email", "", "google", "x", "email"},
+		{"empty provider", "a@b.com", "", "x", "oauth_provider"},
+		{"empty oauthID", "a@b.com", "google", "", "oauth_id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := RegisterUser(tt.email, tt.provider, tt.oauthID, false)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error %q should mention %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// State machine table-driven test
+// ----------------------------------------------------------------------------
+
+func TestUser_StateMachine(t *testing.T) {
+	const adminID = "admin-actor-1"
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) *User
+		action    func(u *User) error
+		wantState Status
+		wantErr   bool
+	}{
+		// Approve transitions
+		{
+			name:      "Approve: pending -> approved",
+			setup:     newPendingUser,
+			action:    func(u *User) error { return u.Approve(adminID) },
+			wantState: StatusApproved,
+		},
+		{
+			name: "Approve: approved -> error (not pending)",
+			setup: func(t *testing.T) *User {
+				u := newPendingUser(t)
+				must(t, u.Approve(adminID))
+				return u
+			},
+			action:  func(u *User) error { return u.Approve(adminID) },
+			wantErr: true,
+		},
+		{
+			name:    "Approve: suspended -> error (not pending)",
+			setup:   newSuspendedFromPendingUser,
+			action:  func(u *User) error { return u.Approve(adminID) },
+			wantErr: true,
+		},
+
+		// Reject transitions (pending -> suspended)
+		{
+			name:      "Reject: pending -> suspended",
+			setup:     newPendingUser,
+			action:    func(u *User) error { return u.Reject(adminID, "spam") },
+			wantState: StatusSuspended,
+		},
+		{
+			name:    "Reject: approved -> error (not pending)",
+			setup:   newApprovedUser,
+			action:  func(u *User) error { return u.Reject(adminID, "x") },
+			wantErr: true,
+		},
+		{
+			name:    "Reject: suspended -> error (not pending)",
+			setup:   newSuspendedFromPendingUser,
+			action:  func(u *User) error { return u.Reject(adminID, "x") },
+			wantErr: true,
+		},
+
+		// Suspend transitions (approved -> suspended)
+		{
+			name:      "Suspend: approved -> suspended",
+			setup:     newApprovedUser,
+			action:    func(u *User) error { return u.Suspend(adminID, "policy") },
+			wantState: StatusSuspended,
+		},
+		{
+			name:    "Suspend: pending -> error (not approved)",
+			setup:   newPendingUser,
+			action:  func(u *User) error { return u.Suspend(adminID, "x") },
+			wantErr: true,
+		},
+		{
+			name:    "Suspend: suspended -> error (not approved)",
+			setup:   newSuspendedFromApprovedUser,
+			action:  func(u *User) error { return u.Suspend(adminID, "x") },
+			wantErr: true,
+		},
+
+		// Resume transitions (suspended -> approved)
+		{
+			name:      "Resume: suspended (from rejected) -> approved",
+			setup:     newSuspendedFromPendingUser,
+			action:    func(u *User) error { return u.Resume(adminID) },
+			wantState: StatusApproved,
+		},
+		{
+			name:      "Resume: suspended (from approved) -> approved",
+			setup:     newSuspendedFromApprovedUser,
+			action:    func(u *User) error { return u.Resume(adminID) },
+			wantState: StatusApproved,
+		},
+		{
+			name:    "Resume: pending -> error (not suspended)",
+			setup:   newPendingUser,
+			action:  func(u *User) error { return u.Resume(adminID) },
+			wantErr: true,
+		},
+		{
+			name:    "Resume: approved -> error (not suspended)",
+			setup:   newApprovedUser,
+			action:  func(u *User) error { return u.Resume(adminID) },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := tt.setup(t)
+			err := tt.action(u)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (status=%q)", u.Status())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if u.Status() != tt.wantState {
+				t.Errorf("Status() = %q, want %q", u.Status(), tt.wantState)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Self-action guards
+// ----------------------------------------------------------------------------
+
+func TestUser_SelfActionGuards(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) *User
+		action    func(u *User) error
+		wantField string
+	}{
+		{
+			name:  "Approve self is blocked",
+			setup: newPendingUser,
+			action: func(u *User) error {
+				return u.Approve(u.ID())
+			},
+			wantField: "approved_by_user_id",
+		},
+		{
+			name:  "Reject self is blocked",
+			setup: newPendingUser,
+			action: func(u *User) error {
+				return u.Reject(u.ID(), "")
+			},
+			wantField: "rejected_by_user_id",
+		},
+		{
+			name:  "Suspend self is blocked",
+			setup: newApprovedUser,
+			action: func(u *User) error {
+				return u.Suspend(u.ID(), "")
+			},
+			wantField: "suspended_by_user_id",
+		},
+		{
+			name:  "PromoteToAdmin self is blocked",
+			setup: newPendingUser,
+			action: func(u *User) error {
+				return u.PromoteToAdmin(u.ID())
+			},
+			wantField: "promoted_by_user_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := tt.setup(t)
+			beforeStatus := u.Status()
+			beforeRole := u.Role()
+			beforeEvents := len(u.Events())
+
+			err := tt.action(u)
+			if err == nil {
+				t.Fatal("expected self-action to be blocked, got nil error")
+			}
+
+			// errors.InvalidInput puts the reason ("cannot ... self") in
+			// Details, not the formatted message — assert via the
+			// DomainError type rather than substring-searching err.Error().
+			de, ok := err.(*pkgerrors.DomainError)
+			if !ok {
+				t.Fatalf("err is %T, want *pkgerrors.DomainError; err=%v", err, err)
+			}
+			if de.Code != "INVALID_INPUT" {
+				t.Errorf("error Code = %q, want INVALID_INPUT", de.Code)
+			}
+			field, _ := de.Details["field"].(string)
+			if field != tt.wantField {
+				t.Errorf("error Details[field] = %q, want %q", field, tt.wantField)
+			}
+			reason, _ := de.Details["reason"].(string)
+			if !strings.Contains(reason, "self") {
+				t.Errorf("error Details[reason] = %q, should mention 'self'", reason)
+			}
+
+			// Self-action must NOT mutate state or record an event.
+			if u.Status() != beforeStatus {
+				t.Errorf("Status changed despite blocked self-action: %q -> %q", beforeStatus, u.Status())
+			}
+			if u.Role() != beforeRole {
+				t.Errorf("Role changed despite blocked self-action: %q -> %q", beforeRole, u.Role())
+			}
+			if len(u.Events()) != beforeEvents {
+				t.Errorf("Events recorded despite blocked self-action: %d -> %d",
+					beforeEvents, len(u.Events()))
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// PromoteToAdmin
+// ----------------------------------------------------------------------------
+
+func TestUser_PromoteToAdmin(t *testing.T) {
+	u := newApprovedUser(t)
+	priorEvents := len(u.Events())
+
+	if u.IsAdmin() {
+		t.Fatal("test setup: approved user should not be admin yet")
+	}
+
+	const promoter = "promoter-admin-1"
+	if err := u.PromoteToAdmin(promoter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !u.IsAdmin() {
+		t.Errorf("IsAdmin() = false, want true after PromoteToAdmin")
+	}
+	if u.Role() != RoleAdmin {
+		t.Errorf("Role() = %q, want %q", u.Role(), RoleAdmin)
+	}
+	// PromoteToAdmin is a role change; status should remain unchanged.
+	if u.Status() != StatusApproved {
+		t.Errorf("Status() = %q, want %q (PromoteToAdmin must not affect status)", u.Status(), StatusApproved)
+	}
+
+	events := u.Events()
+	if len(events) != priorEvents+1 {
+		t.Fatalf("expected %d events after promote, got %d", priorEvents+1, len(events))
+	}
+	last, ok := events[len(events)-1].(UserPromotedToAdmin)
+	if !ok {
+		t.Fatalf("last event is %T, want UserPromotedToAdmin", events[len(events)-1])
+	}
+	if last.PromotedByUserID == nil {
+		t.Fatal("manual elevation UserPromotedToAdmin.PromotedByUserID must be non-nil")
+	}
+	if *last.PromotedByUserID != promoter {
+		t.Errorf("PromotedByUserID = %q, want %q", *last.PromotedByUserID, promoter)
+	}
+	if last.UserID != u.ID() {
+		t.Errorf("UserPromotedToAdmin.UserID = %q, want %q", last.UserID, u.ID())
+	}
+	if last.EventType() != EventTypeUserPromotedToAdmin {
+		t.Errorf("EventType() = %q, want %q", last.EventType(), EventTypeUserPromotedToAdmin)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Resume
+// ----------------------------------------------------------------------------
+
+func TestUser_Resume(t *testing.T) {
+	u := newSuspendedFromApprovedUser(t)
+	priorEvents := len(u.Events())
+
+	if u.Status() != StatusSuspended {
+		t.Fatalf("test setup: status should be suspended, got %q", u.Status())
+	}
+
+	const resumer = "resumer-admin-1"
+	if err := u.Resume(resumer); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if u.Status() != StatusApproved {
+		t.Errorf("Status() = %q, want %q after Resume", u.Status(), StatusApproved)
+	}
+
+	events := u.Events()
+	if len(events) != priorEvents+1 {
+		t.Fatalf("expected %d events after resume, got %d", priorEvents+1, len(events))
+	}
+
+	// Resume reuses the user.approved event (no separate user.resumed in spec).
+	last := events[len(events)-1]
+	if last.EventType() != EventTypeUserApproved {
+		t.Errorf("Resume should emit %q (no separate user.resumed event), got %q",
+			EventTypeUserApproved, last.EventType())
+	}
+	approved, ok := last.(UserApproved)
+	if !ok {
+		t.Fatalf("last event is %T, want UserApproved", last)
+	}
+	if approved.ApprovedByUserID != resumer {
+		t.Errorf("UserApproved.ApprovedByUserID = %q, want %q", approved.ApprovedByUserID, resumer)
+	}
+	if approved.UserID != u.ID() {
+		t.Errorf("UserApproved.UserID = %q, want %q", approved.UserID, u.ID())
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Reject and Suspend emit distinct event types despite sharing target state
+// ----------------------------------------------------------------------------
+
+func TestUser_RejectAndSuspend_DistinctEvents(t *testing.T) {
+	const admin = "admin-1"
+
+	rejected := newPendingUser(t)
+	if err := rejected.Reject(admin, "spam"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rejectedLast := rejected.Events()[len(rejected.Events())-1]
+
+	suspended := newApprovedUser(t)
+	if err := suspended.Suspend(admin, "policy"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	suspendedLast := suspended.Events()[len(suspended.Events())-1]
+
+	// Same target state.
+	if rejected.Status() != StatusSuspended || suspended.Status() != StatusSuspended {
+		t.Fatalf("both should be suspended; got rejected=%q, suspended=%q",
+			rejected.Status(), suspended.Status())
+	}
+
+	// Distinct event types — load-bearing for the spec contract.
+	if rejectedLast.EventType() != EventTypeUserRejected {
+		t.Errorf("Reject emitted %q, want %q", rejectedLast.EventType(), EventTypeUserRejected)
+	}
+	if suspendedLast.EventType() != EventTypeUserSuspended {
+		t.Errorf("Suspend emitted %q, want %q", suspendedLast.EventType(), EventTypeUserSuspended)
+	}
+	if rejectedLast.EventType() == suspendedLast.EventType() {
+		t.Error("Reject and Suspend must emit distinct event types")
+	}
+
+	// And carry actor + reason on their typed payloads.
+	if r, ok := rejectedLast.(UserRejected); !ok {
+		t.Errorf("Reject event is %T, want UserRejected", rejectedLast)
+	} else {
+		if r.RejectedByUserID != admin {
+			t.Errorf("UserRejected.RejectedByUserID = %q, want %q", r.RejectedByUserID, admin)
+		}
+		if r.Reason != "spam" {
+			t.Errorf("UserRejected.Reason = %q, want %q", r.Reason, "spam")
+		}
+	}
+	if s, ok := suspendedLast.(UserSuspended); !ok {
+		t.Errorf("Suspend event is %T, want UserSuspended", suspendedLast)
+	} else {
+		if s.SuspendedByUserID != admin {
+			t.Errorf("UserSuspended.SuspendedByUserID = %q, want %q", s.SuspendedByUserID, admin)
+		}
+		if s.Reason != "policy" {
+			t.Errorf("UserSuspended.Reason = %q, want %q", s.Reason, "policy")
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// ClearEvents
+// ----------------------------------------------------------------------------
+
+func TestUser_ClearEvents(t *testing.T) {
+	u := newPendingUser(t)
+	if len(u.Events()) == 0 {
+		t.Fatal("test setup: pending user should have at least one event")
+	}
+
+	u.ClearEvents()
+
+	if len(u.Events()) != 0 {
+		t.Errorf("Events() length after ClearEvents = %d, want 0", len(u.Events()))
+	}
+
+	// Subsequent recordings should still work.
+	if err := u.Approve("admin-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(u.Events()) != 1 {
+		t.Errorf("Events() length after one new event = %d, want 1", len(u.Events()))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Test helpers
+// ----------------------------------------------------------------------------
+
+func newPendingUser(t *testing.T) *User {
+	t.Helper()
+	u, err := RegisterUser("pending@example.com", "google", "google-sub-pending", false)
+	if err != nil {
+		t.Fatalf("failed to create pending user: %v", err)
+	}
+	return u
+}
+
+func newApprovedUser(t *testing.T) *User {
+	t.Helper()
+	u := newPendingUser(t)
+	if err := u.Approve("admin-actor-bootstrap"); err != nil {
+		t.Fatalf("failed to approve user: %v", err)
+	}
+	return u
+}
+
+// newSuspendedFromPendingUser creates a user that reached suspended via Reject
+// (pending -> suspended).
+func newSuspendedFromPendingUser(t *testing.T) *User {
+	t.Helper()
+	u := newPendingUser(t)
+	if err := u.Reject("admin-actor-bootstrap", "rejected in setup"); err != nil {
+		t.Fatalf("failed to reject user: %v", err)
+	}
+	return u
+}
+
+// newSuspendedFromApprovedUser creates a user that reached suspended via
+// Suspend (approved -> suspended).
+func newSuspendedFromApprovedUser(t *testing.T) *User {
+	t.Helper()
+	u := newApprovedUser(t)
+	if err := u.Suspend("admin-actor-bootstrap", "suspended in setup"); err != nil {
+		t.Fatalf("failed to suspend user: %v", err)
+	}
+	return u
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Wave 1 of v1.0-platform: introduce the User aggregate in the open-core engine's DDD layer (`internal/domain/user/`), mirroring the existing `internal/domain/run/` pattern. Pure domain logic — no persistence adapter, HTTP handler, or `go.mod` changes in this PR.

This is the first of several aggregates the platform-tenancy slice needs (Tenant follows in Wave 2). The User aggregate owns identity (`oauth_provider`, `oauth_id`, `email`), authorization role (`user` | `admin`), and approval status (`pending` | `approved` | `suspended`).

### Key design points

- **Bootstrap rule** (per `auth/oauth.yml`'s `bootstrap_first_user` branch): `RegisterUser(..., isFirstUser=true)` self-elevates the very first signup to `role=admin status=approved` and records exactly three events in order — `UserSignedUp`, `UserPromotedToAdmin` (with `PromotedByUserID == nil`, signifying no human actor), `UserApproved` (with `ApprovedByUserID == own UserID`). The bootstrap path is the documented exception to the self-action guard and bypasses the `PromoteToAdmin` / `Approve` methods (which enforce the guard) by recording events directly. Subsequent signups land at `status=pending` and emit only `UserSignedUp`.
- **Reject vs Suspend**: both transition to `status=suspended` but emit distinct event types — `user.rejected` (pending → suspended) vs `user.suspended` (approved → suspended). Methods enforce the *specific* source state, not just `Status.CanTransitionTo`, so Reject cannot be called on an approved user and Suspend cannot be called on a pending user.
- **Resume design choice**: Resume (suspended → approved) reuses the `user.approved` event with `ApprovedByUserID` set to the resuming admin — the spec does not define a separate `user.resumed` event. Resume has NO self-action guard; an admin recovering their own suspended account is a legitimate operation in the 1:1 user↔tenant single-operator model.
- **`PromoteToAdmin`** is a role change, not a status transition; status is unaffected. It enforces the self-action guard for non-bootstrap callers and emits `UserPromotedToAdmin` with non-nil `PromotedByUserID`.

## Files

| Path | Purpose |
|---|---|
| `internal/domain/user/role.go` | `Role` enum (`user`, `admin`) with `IsValid` / `String` |
| `internal/domain/user/status.go` | `Status` enum (`pending`, `approved`, `suspended`) and `CanTransitionTo` matrix |
| `internal/domain/user/events.go` | Five `eventbus.Event` implementations (`UserSignedUp`, `UserPromotedToAdmin`, `UserApproved`, `UserRejected`, `UserSuspended`) with dot-form `EventType` constants matching `duragraph-spec/models/events.yml` |
| `internal/domain/user/user.go` | `User` aggregate: `RegisterUser` constructor + `Approve` / `Reject` / `Suspend` / `Resume` / `PromoteToAdmin` transitions; accessors; `Events` / `ClearEvents` |
| `internal/domain/user/repository.go` | `Repository` port (`Save`, `GetByID`, `GetByOAuth`, `ListByStatus`, `CountAll`) |
| `internal/domain/user/role_test.go` | `Role` valid / string |
| `internal/domain/user/user_test.go` | Aggregate tests (see Test plan) |

## Test plan

- [x] `go vet ./internal/domain/user/...` passes
- [x] `go fmt ./internal/domain/user/...` is a no-op (already formatted)
- [x] `go test ./internal/domain/user/... -short` passes — 12 top-level test funcs, 30 subtests
  - `TestRoleValid` / `TestRoleString`
  - `TestRegisterUser_NormalSignup` — exactly one `UserSignedUp`, role=user, status=pending
  - `TestRegisterUser_BootstrapFirstUser` — exactly 3 events in order, `UserPromotedToAdmin.PromotedByUserID` nil, `UserApproved.ApprovedByUserID == u.ID()`
  - `TestRegisterUser_RejectsEmptyInputs` — table-driven (email, oauth_provider, oauth_id)
  - `TestUser_StateMachine` — table-driven, every valid + invalid transition
  - `TestUser_SelfActionGuards` — Approve / Reject / Suspend / PromoteToAdmin all reject `actorID == u.ID()` with `INVALID_INPUT`; verifies state, role, and event list are unchanged on rejection
  - `TestUser_PromoteToAdmin` — role flips to admin, status unchanged, non-nil `PromotedByUserID`
  - `TestUser_Resume` — suspended → approved emits `UserApproved` (no separate `user.resumed`)
  - `TestUser_RejectAndSuspend_DistinctEvents` — same target state, distinct event types and payloads
  - `TestUser_ClearEvents`
- [x] `go build ./internal/domain/...` (no breakage to other packages)

## Cross-references

- Duragraph/duragraph-spec#14 — `models/entities.yml` `users:` entity (UNIQUE on `(oauth_provider, oauth_id)`, status / role checks)
- Duragraph/duragraph-spec#15 — `models/events.yml` `user_events:` block (defines the five events landed here)
- Duragraph/duragraph-spec#18 — `auth/jwt.yml` (`role`, `tenant_id` claims, bootstrap rule) and `auth/oauth.yml` (`bootstrap_first_user` and `new_user` callback branches)

## Out of scope

- Postgres adapter for `Repository` — Wave 1 follow-up
- HTTP handlers (`/api/auth/{provider}/callback` etc.) — Wave 1 follow-up
- Tenant aggregate — Wave 2

DO NOT MERGE this PR — it is part of a larger Wave 1 series and will be merged together with the other Wave 1 PRs.