### PR TITLE
feat: add platform DB migrations (users, tenants, audit_log)

### DIFF
--- a/internal/infrastructure/persistence/postgres/integration_test.go
+++ b/internal/infrastructure/persistence/postgres/integration_test.go
@@ -52,6 +52,17 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 	sqlDir := filepath.Join("..", "..", "..", "..", "deploy", "sql")
 	entries, err := os.ReadDir(sqlDir)
 	if err != nil {
+		// PR #150 moved tenant migrations from deploy/sql/ into
+		// internal/infrastructure/persistence/postgres/migrations/tenant/
+		// (so they can be embed.FS'd by the runtime migrator) but did
+		// not update this TestMain. When the directory is gone, assume
+		// the production migrator has already applied schema to the
+		// dev DB (the standard `task up` flow does exactly that), and
+		// fall through. Existing repo-level integration tests connect
+		// to the same dev DB and assume schema is present.
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("read sql dir: %w", err)
 	}
 

--- a/internal/infrastructure/persistence/postgres/migrations/platform/001_init_users.down.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/001_init_users.down.sql
@@ -1,0 +1,5 @@
+-- 001_init_users.down.sql: Reverse the users table + helper function.
+-- Idempotent: safe to run when objects don't exist.
+
+DROP TABLE IF EXISTS platform.users CASCADE;
+DROP FUNCTION IF EXISTS platform.update_updated_at_column() CASCADE;

--- a/internal/infrastructure/persistence/postgres/migrations/platform/001_init_users.up.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/001_init_users.up.sql
@@ -1,0 +1,49 @@
+-- 001_init_users.up.sql: Platform DB users table.
+--
+-- Lives in the singleton `duragraph_platform` database under a dedicated
+-- `platform` schema. The migrator (internal/infrastructure/persistence/postgres/
+-- migrator.go) queries `platform.tenants` schema-qualified, so all platform
+-- objects must live under this schema (NOT public). Tenant DBs use their
+-- own copy of the public-schema `update_updated_at_column()` helper, so we
+-- create a separate schema-qualified copy here for platform tables to use.
+
+CREATE SCHEMA IF NOT EXISTS platform;
+
+-- Helper trigger function that bumps updated_at to NOW() on UPDATE.
+-- Owned by the platform schema (the tenant DBs each define their own copy
+-- in public schema via tenant migrations).
+CREATE OR REPLACE FUNCTION platform.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Users table — see duragraph-spec/models/entities.yml#users for the
+-- authoritative column definitions, CHECK clauses, and indexes.
+--
+-- 1:1 user↔tenant. Created on first OAuth callback with status='pending'
+-- and role='user'. The first user signing up is auto-elevated to
+-- role='admin' (bootstrap path); subsequent users wait for an admin to
+-- approve via the admin UI before a tenant DB is provisioned.
+CREATE TABLE IF NOT EXISTS platform.users (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    oauth_provider VARCHAR(50)  NOT NULL,
+    oauth_id       VARCHAR(255) NOT NULL,
+    email          VARCHAR(320) NOT NULL UNIQUE,
+    role           VARCHAR(20)  NOT NULL DEFAULT 'user',
+    status         VARCHAR(20)  NOT NULL DEFAULT 'pending',
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT users_oauth_provider_check CHECK (oauth_provider IN ('google', 'github')),
+    CONSTRAINT users_role_check           CHECK (role IN ('user', 'admin')),
+    CONSTRAINT users_status_check         CHECK (status IN ('pending', 'approved', 'suspended')),
+    CONSTRAINT users_oauth_provider_id_unique UNIQUE (oauth_provider, oauth_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_status ON platform.users (status);
+
+CREATE TRIGGER update_users_updated_at
+BEFORE UPDATE ON platform.users
+FOR EACH ROW EXECUTE FUNCTION platform.update_updated_at_column();

--- a/internal/infrastructure/persistence/postgres/migrations/platform/002_init_tenants.down.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/002_init_tenants.down.sql
@@ -1,0 +1,4 @@
+-- 002_init_tenants.down.sql: Reverse the tenants table.
+-- Idempotent: safe to run when the table doesn't exist.
+
+DROP TABLE IF EXISTS platform.tenants CASCADE;

--- a/internal/infrastructure/persistence/postgres/migrations/platform/002_init_tenants.up.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/002_init_tenants.up.sql
@@ -1,0 +1,60 @@
+-- 002_init_tenants.up.sql: Platform DB tenants table.
+--
+-- See duragraph-spec/models/entities.yml#tenants for the authoritative
+-- column definitions, CHECKs, indexes, and state-machine description.
+--
+-- 1:1 with users. Each approved tenant owns a dedicated Postgres DB
+-- (`db_name`) inside the shared prod-postgres instance. The `db_name` is
+-- DETERMINISTICALLY DERIVED from `id` as
+--   'tenant_' || replace(id::text, '-', '')
+-- The table-level CHECK `tenants_db_name_derived_from_id` enforces the
+-- derivation at the schema layer; combined with the per-column regex
+-- check, no tenant row can point at a database that isn't its own.
+--
+-- State machine:
+--   pending → provisioning → approved | provisioning_failed | suspended
+--   provisioning_failed → provisioning  (admin retry)
+--   approved → suspended                (admin suspend)
+--
+-- State-coupled invariants (table-level CHECKs):
+--   - approved => schema_version IS NOT NULL
+--   - approved => provisioned_at IS NOT NULL
+--   - failure_reason set => status = 'provisioning_failed'
+
+CREATE TABLE IF NOT EXISTS platform.tenants (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID         NOT NULL REFERENCES platform.users (id) ON DELETE RESTRICT,
+    db_name         VARCHAR(63)  NOT NULL UNIQUE,
+    status          VARCHAR(30)  NOT NULL DEFAULT 'pending',
+    schema_version  INTEGER      NULL,
+    provisioned_at  TIMESTAMPTZ  NULL,
+    failure_reason  TEXT         NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    -- Column-level CHECKs.
+    CONSTRAINT tenants_status_check
+        CHECK (status IN ('pending', 'provisioning', 'approved', 'provisioning_failed', 'suspended')),
+    CONSTRAINT tenants_db_name_format_check
+        CHECK (db_name ~ '^tenant_[a-f0-9]{32}$'),
+
+    -- Table-level CHECKs (the round-2 fix from spec PR #14).
+    CONSTRAINT tenants_db_name_derived_from_id
+        CHECK (db_name = 'tenant_' || replace(id::text, '-', '')),
+    CONSTRAINT tenants_approved_requires_schema_version
+        CHECK (status != 'approved' OR schema_version IS NOT NULL),
+    CONSTRAINT tenants_approved_requires_provisioned_at
+        CHECK (status != 'approved' OR provisioned_at IS NOT NULL),
+    CONSTRAINT tenants_failure_reason_only_when_failed
+        CHECK (failure_reason IS NULL OR status = 'provisioning_failed'),
+
+    -- 1:1 user↔tenant.
+    CONSTRAINT tenants_user_id_unique UNIQUE (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenants_status         ON platform.tenants (status);
+CREATE INDEX IF NOT EXISTS idx_tenants_schema_version ON platform.tenants (schema_version);
+
+CREATE TRIGGER update_tenants_updated_at
+BEFORE UPDATE ON platform.tenants
+FOR EACH ROW EXECUTE FUNCTION platform.update_updated_at_column();

--- a/internal/infrastructure/persistence/postgres/migrations/platform/003_audit_log.down.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/003_audit_log.down.sql
@@ -1,0 +1,4 @@
+-- 003_audit_log.down.sql: Reverse the audit_log table.
+-- Idempotent: safe to run when the table doesn't exist.
+
+DROP TABLE IF EXISTS platform.audit_log CASCADE;

--- a/internal/infrastructure/persistence/postgres/migrations/platform/003_audit_log.up.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/003_audit_log.up.sql
@@ -1,0 +1,44 @@
+-- 003_audit_log.up.sql: Platform audit log (append-only).
+--
+-- Populated by the platform-audit-users / platform-audit-tenants NATS
+-- consumers (see duragraph-spec/async/asyncapi.yml — operations
+-- subscribePlatformAuditUsers / subscribePlatformAuditTenants), which
+-- project user.* and tenant.* events into this table for replay/audit.
+--
+-- DESIGN NOTES:
+-- - Append-only: NO update trigger. Once a row is inserted it must
+--   never change. Operators wanting to "correct" an audit record should
+--   insert a new compensating event instead.
+-- - NO foreign key to platform.users. Events outlive their actors —
+--   even if a user is later deleted (which is currently RESTRICTed by
+--   the tenants FK, but a future hard-delete path may exist), the audit
+--   trail must remain intact. A cascading FK would corrupt history.
+-- - `aggregate_id` references either a user_id or a tenant_id depending
+--   on aggregate_type; not constrained at the schema level because the
+--   FK rule above applies to both.
+-- - `occurred_at` carries the event's own timestamp (when the original
+--   domain event happened); `recorded_at` is the audit-row insert time.
+--   Distinguishing the two matters for late-arriving events / replay.
+
+CREATE TABLE IF NOT EXISTS platform.audit_log (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type     VARCHAR(100) NOT NULL,
+    aggregate_type VARCHAR(20)  NOT NULL,
+    aggregate_id   UUID         NOT NULL,
+    actor_user_id  UUID         NULL,
+    payload        JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    reason         TEXT         NULL,
+    ip_address     INET         NULL,
+    user_agent     TEXT         NULL,
+    occurred_at    TIMESTAMPTZ  NOT NULL,
+    recorded_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_aggregate
+    ON platform.audit_log (aggregate_type, aggregate_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_event_type
+    ON platform.audit_log (event_type);
+CREATE INDEX IF NOT EXISTS idx_audit_log_occurred_at
+    ON platform.audit_log (occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_actor_user_id
+    ON platform.audit_log (actor_user_id);

--- a/internal/infrastructure/persistence/postgres/migrator_test.go
+++ b/internal/infrastructure/persistence/postgres/migrator_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"testing/fstest"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -54,9 +56,19 @@ func dbExists(t *testing.T, ctx context.Context, dbName string) bool {
 }
 
 // tableExists connects directly to dbName (not through the migrator)
-// and checks information_schema for tableName. Used to verify that
-// tenant migrations actually created the expected schema objects.
+// and checks information_schema for tableName in the public schema.
+// Used to verify that tenant migrations actually created the expected
+// schema objects.
 func tableExists(t *testing.T, ctx context.Context, dbName, tableName string) bool {
+	t.Helper()
+	return tableExistsInSchema(t, ctx, dbName, "public", tableName)
+}
+
+// tableExistsInSchema is the schema-aware variant of tableExists. The
+// platform DB places its objects under the `platform` schema (per the
+// migrator's `SELECT FROM platform.tenants` query), so the platform
+// migrations need a schema-qualified existence check.
+func tableExistsInSchema(t *testing.T, ctx context.Context, dbName, schema, tableName string) bool {
 	t.Helper()
 	_, dsn := sharedContainer(t)
 	conn, err := pgx.Connect(ctx, adminURLForDB(t, dsn, dbName))
@@ -69,10 +81,10 @@ func tableExists(t *testing.T, ctx context.Context, dbName, tableName string) bo
 	if err := conn.QueryRow(ctx,
 		`SELECT EXISTS (
 			SELECT 1 FROM information_schema.tables
-			WHERE table_schema='public' AND table_name=$1
-		)`, tableName,
+			WHERE table_schema=$1 AND table_name=$2
+		)`, schema, tableName,
 	).Scan(&exists); err != nil {
-		t.Fatalf("check table %s.%s: %v", dbName, tableName, err)
+		t.Fatalf("check table %s.%s.%s: %v", dbName, schema, tableName, err)
 	}
 	return exists
 }
@@ -132,6 +144,72 @@ func newMigratorForTest(t *testing.T) (*Migrator, string) {
 	return m, platformDB
 }
 
+// platformConn opens a direct pgx connection to the platform DB for
+// tests that need to insert or assert against `platform.users` /
+// `platform.tenants` directly. Caller closes via the returned cleanup.
+func platformConn(t *testing.T, ctx context.Context, platformDB string) *pgx.Conn {
+	t.Helper()
+	_, dsn := sharedContainer(t)
+	conn, err := pgx.Connect(ctx, adminURLForDB(t, dsn, platformDB))
+	if err != nil {
+		t.Fatalf("connect platform DB %s: %v", platformDB, err)
+	}
+	t.Cleanup(func() { _ = conn.Close(context.Background()) })
+	return conn
+}
+
+// insertUser inserts a row into platform.users with overridable
+// status/role/email and returns the generated id. Defaults produce a
+// valid `pending`/`user`/google user.
+type userOpts struct {
+	id            *string
+	oauthProvider string
+	oauthID       string
+	email         string
+	role          string
+	status        string
+}
+
+func insertUser(t *testing.T, ctx context.Context, conn *pgx.Conn, o userOpts) string {
+	t.Helper()
+	if o.oauthProvider == "" {
+		o.oauthProvider = "google"
+	}
+	if o.oauthID == "" {
+		o.oauthID = "oauth-" + uuid.New().String()
+	}
+	if o.email == "" {
+		o.email = uuid.New().String() + "@example.com"
+	}
+	if o.role == "" {
+		o.role = "user"
+	}
+	if o.status == "" {
+		o.status = "pending"
+	}
+	var id string
+	if o.id != nil {
+		id = *o.id
+		_, err := conn.Exec(ctx, `
+			INSERT INTO platform.users (id, oauth_provider, oauth_id, email, role, status)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, id, o.oauthProvider, o.oauthID, o.email, o.role, o.status)
+		if err != nil {
+			t.Fatalf("insert user: %v", err)
+		}
+		return id
+	}
+	err := conn.QueryRow(ctx, `
+		INSERT INTO platform.users (oauth_provider, oauth_id, email, role, status)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id::text
+	`, o.oauthProvider, o.oauthID, o.email, o.role, o.status).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
 // TestMigrator_NewMigrator_DefaultPlatformDBName is the unit-test smoke
 // for the option pattern. No testcontainer needed; just confirms the
 // default is "duragraph_platform" and overriding sticks.
@@ -154,6 +232,41 @@ func TestMigrator_NewMigrator_DefaultPlatformDBName(t *testing.T) {
 	}
 }
 
+// TestMigrator_HasMigrations_DetectsEmptyDir preserves coverage of the
+// empty-FS short-circuit branch in MigratePlatform. The previous
+// integration test `Bootstrap_HandlesEmptyPlatformMigrationsDir`
+// relied on the embedded migrations/platform/ being empty — once
+// feat/platform-db-init lands real .up.sql files the branch can no
+// longer be exercised through Bootstrap, so this is now exercised
+// directly against `hasMigrations` with a synthetic in-memory FS.
+func TestMigrator_HasMigrations_DetectsEmptyDir(t *testing.T) {
+	// Empty (only a non-SQL file): hasMigrations must report false.
+	emptyFS := fstest.MapFS{
+		"migrations/platform/README.md": &fstest.MapFile{Data: []byte("placeholder")},
+	}
+	any, err := hasMigrations(emptyFS, "migrations/platform")
+	if err != nil {
+		t.Fatalf("hasMigrations(empty): %v", err)
+	}
+	if any {
+		t.Errorf("hasMigrations(empty) = true, want false")
+	}
+
+	// Populated with at least one .up.sql: must report true.
+	populatedFS := fstest.MapFS{
+		"migrations/platform/README.md":         &fstest.MapFile{Data: []byte("notes")},
+		"migrations/platform/001_init.up.sql":   &fstest.MapFile{Data: []byte("CREATE TABLE x();")},
+		"migrations/platform/001_init.down.sql": &fstest.MapFile{Data: []byte("DROP TABLE x;")},
+	}
+	any, err = hasMigrations(populatedFS, "migrations/platform")
+	if err != nil {
+		t.Fatalf("hasMigrations(populated): %v", err)
+	}
+	if !any {
+		t.Errorf("hasMigrations(populated) = false, want true")
+	}
+}
+
 func TestMigrator_Bootstrap_CreatesPlatformDB(t *testing.T) {
 	ctx := context.Background()
 	m, platformDB := newMigratorForTest(t)
@@ -170,21 +283,52 @@ func TestMigrator_Bootstrap_CreatesPlatformDB(t *testing.T) {
 	}
 }
 
-// TestMigrator_Bootstrap_HandlesEmptyPlatformMigrationsDir is the most
-// load-bearing test in this PR: the platform/ embed dir is empty (just
-// a README) until feat/platform-db-init lands. Bootstrap must succeed
-// in that state.
-func TestMigrator_Bootstrap_HandlesEmptyPlatformMigrationsDir(t *testing.T) {
+// TestMigrator_MigratePlatform_AppliesAllPlatformMigrations replaces
+// the previous `Bootstrap_HandlesEmptyPlatformMigrationsDir` test now
+// that real platform migrations exist. Verifies that Bootstrap creates
+// the DB and runs platform/* migrations end-to-end.
+func TestMigrator_MigratePlatform_AppliesAllPlatformMigrations(t *testing.T) {
 	ctx := context.Background()
 	m, platformDB := newMigratorForTest(t)
 
-	// First call creates the DB and runs MigratePlatform with empty FS.
-	// Should NOT return an error despite no migrations being applied.
 	if err := m.Bootstrap(ctx); err != nil {
-		t.Fatalf("Bootstrap with empty platform migrations: %v", err)
+		t.Fatalf("Bootstrap: %v", err)
 	}
 	if !dbExists(t, ctx, platformDB) {
 		t.Fatalf("expected platform DB %s to exist", platformDB)
+	}
+
+	for _, table := range []string{"users", "tenants", "audit_log"} {
+		if !tableExistsInSchema(t, ctx, platformDB, "platform", table) {
+			t.Errorf("expected table platform.%s in %s, not found", table, platformDB)
+		}
+	}
+}
+
+// TestMigrator_PlatformMigrations_Idempotent verifies that re-running
+// Bootstrap (and therefore MigratePlatform) is a no-op against an
+// already-migrated platform DB.
+func TestMigrator_PlatformMigrations_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("first Bootstrap: %v", err)
+	}
+	v1, dirty := migrationVersion(t, ctx, platformDB)
+	if dirty {
+		t.Fatalf("schema_migrations dirty after first Bootstrap")
+	}
+
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("second Bootstrap: %v", err)
+	}
+	v2, dirty := migrationVersion(t, ctx, platformDB)
+	if dirty {
+		t.Fatalf("schema_migrations dirty after second Bootstrap")
+	}
+	if v1 != v2 {
+		t.Errorf("platform migration version changed across idempotent runs: v1=%d v2=%d", v1, v2)
 	}
 }
 
@@ -316,16 +460,20 @@ func TestMigrator_ProvisionTenant_Idempotent(t *testing.T) {
 	}
 }
 
-// TestMigrator_MigrateAllTenants_EmptyWhenNoTenantsTable verifies the
-// graceful-empty path: when the platform DB exists but the
-// platform.tenants table doesn't (no platform migrations applied),
-// MigrateAllTenants returns no results without error.
-func TestMigrator_MigrateAllTenants_EmptyWhenNoTenantsTable(t *testing.T) {
+// TestMigrator_MigrateAllTenants_EmptyWhenNoApprovedTenants verifies
+// the empty-result path now that platform migrations create the
+// `platform.tenants` table: when the table exists but has no
+// status='approved' rows, MigrateAllTenants returns no results.
+//
+// Note: the previous test `EmptyWhenNoTenantsTable` exercised the
+// 42P01 (undefined_table) error path inside listApprovedTenants. That
+// path is now harder to trigger because Bootstrap creates the table —
+// see TestMigrator_MigrateAllTenants_EmptyWhenTenantsTableMissing for
+// the explicit coverage.
+func TestMigrator_MigrateAllTenants_EmptyWhenNoApprovedTenants(t *testing.T) {
 	ctx := context.Background()
 	m, _ := newMigratorForTest(t)
 
-	// Bootstrap creates the empty platform DB. No platform.tenants
-	// table is created because the platform migrations FS is empty.
 	if err := m.Bootstrap(ctx); err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
@@ -333,6 +481,31 @@ func TestMigrator_MigrateAllTenants_EmptyWhenNoTenantsTable(t *testing.T) {
 	results := m.MigrateAllTenants(ctx)
 	if len(results) != 0 {
 		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+// TestMigrator_MigrateAllTenants_EmptyWhenTenantsTableMissing
+// preserves coverage of the 42P01 fall-through branch by manually
+// dropping `platform.tenants` after Bootstrap to simulate a partially
+// initialized platform DB (e.g. mid-migration). The migrator must not
+// panic and must return no results.
+func TestMigrator_MigrateAllTenants_EmptyWhenTenantsTableMissing(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	// Drop platform.tenants directly to simulate the pre-init state.
+	conn := platformConn(t, ctx, platformDB)
+	if _, err := conn.Exec(ctx, `DROP TABLE platform.tenants`); err != nil {
+		t.Fatalf("drop platform.tenants: %v", err)
+	}
+
+	results := m.MigrateAllTenants(ctx)
+	if len(results) != 0 {
+		t.Errorf("expected empty results when tenants table missing, got %d", len(results))
 	}
 }
 
@@ -351,6 +524,53 @@ func TestMigrator_MigrateAllTenants_EmptyWhenNoPlatformDB(t *testing.T) {
 	results := m.MigrateAllTenants(ctx)
 	if len(results) != 0 {
 		t.Errorf("expected empty results when platform DB missing, got %d", len(results))
+	}
+}
+
+// TestMigrator_MigrateAllTenants_FindsApprovedTenants is the
+// end-to-end success path: insert a user + tenant in `platform.users`
+// + `platform.tenants` with status='approved', then call
+// MigrateAllTenants and assert the tenant is included in the results.
+// This proves the schema-qualified `platform.tenants` query connects.
+func TestMigrator_MigrateAllTenants_FindsApprovedTenants(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	// Provision a real tenant DB (so MigrateTenant succeeds against it).
+	tenantID := uuid.New().String()
+	dbName, err := tenant.DBName(tenantID)
+	if err != nil {
+		t.Fatalf("tenant.DBName: %v", err)
+	}
+	t.Cleanup(func() { dropDatabase(t, context.Background(), dbName) })
+	if err := m.ProvisionTenant(ctx, tenantID); err != nil {
+		t.Fatalf("ProvisionTenant: %v", err)
+	}
+
+	// Now register the tenant in platform.tenants with status='approved'.
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{status: "approved"})
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status, schema_version, provisioned_at)
+		VALUES ($1, $2, $3, 'approved', 1, NOW())
+	`, tenantID, userID, dbName)
+	if err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+
+	results := m.MigrateAllTenants(ctx)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].TenantID != tenantID {
+		t.Errorf("result tenant id = %q, want %q", results[0].TenantID, tenantID)
+	}
+	if results[0].Err != nil {
+		t.Errorf("expected no error on already-migrated tenant, got: %v", results[0].Err)
 	}
 }
 
@@ -420,6 +640,286 @@ func TestMigrator_MigrateTenant_RejectsInvalidUUID(t *testing.T) {
 	}
 	if _, err := m.MigrateTenant(context.Background(), "not-a-uuid"); err == nil {
 		t.Fatal("expected error for invalid UUID")
+	}
+}
+
+// =============================================================================
+// platform.users / platform.tenants CHECK + UNIQUE constraint coverage
+// =============================================================================
+
+// TestPlatformDB_UsersConstraints exercises the column-level CHECK
+// constraints (oauth_provider, role, status) and the two UNIQUE
+// constraints (email; (oauth_provider, oauth_id)) on platform.users.
+func TestPlatformDB_UsersConstraints(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+
+	// Baseline: a valid user inserts cleanly.
+	insertUser(t, ctx, conn, userOpts{})
+
+	// Invalid role.
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.users (oauth_provider, oauth_id, email, role)
+		VALUES ('google', 'oid-x', 'bad-role@example.com', 'superadmin')
+	`)
+	if err == nil {
+		t.Errorf("expected CHECK violation for role='superadmin', got nil")
+	}
+
+	// Invalid status.
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.users (oauth_provider, oauth_id, email, status)
+		VALUES ('google', 'oid-y', 'bad-status@example.com', 'banned')
+	`)
+	if err == nil {
+		t.Errorf("expected CHECK violation for status='banned', got nil")
+	}
+
+	// Invalid oauth_provider.
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.users (oauth_provider, oauth_id, email)
+		VALUES ('facebook', 'oid-z', 'bad-provider@example.com')
+	`)
+	if err == nil {
+		t.Errorf("expected CHECK violation for oauth_provider='facebook', got nil")
+	}
+
+	// Duplicate email rejection.
+	insertUser(t, ctx, conn, userOpts{email: "dup@example.com", oauthID: "oid-a"})
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.users (oauth_provider, oauth_id, email)
+		VALUES ('github', 'oid-b', 'dup@example.com')
+	`)
+	if err == nil {
+		t.Errorf("expected UNIQUE violation for duplicate email, got nil")
+	}
+
+	// Duplicate (oauth_provider, oauth_id) rejection.
+	insertUser(t, ctx, conn, userOpts{oauthProvider: "github", oauthID: "shared-oid"})
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.users (oauth_provider, oauth_id, email)
+		VALUES ('github', 'shared-oid', 'other-user@example.com')
+	`)
+	if err == nil {
+		t.Errorf("expected UNIQUE violation on (oauth_provider, oauth_id), got nil")
+	}
+}
+
+// validTenantInsert performs the canonical insert path: derives db_name
+// from id and writes status='pending' (no schema_version /
+// provisioned_at required). Returns (id, db_name).
+func validTenantInsert(t *testing.T, ctx context.Context, conn *pgx.Conn, userID string) (string, string) {
+	t.Helper()
+	id := uuid.New().String()
+	dbName := "tenant_" + strings.ReplaceAll(id, "-", "")
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status)
+		VALUES ($1, $2, $3, 'pending')
+	`, id, userID, dbName)
+	if err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	return id, dbName
+}
+
+// TestPlatformDB_TenantsDerivationCheck verifies the table-level
+// `tenants_db_name_derived_from_id` CHECK rejects rows where db_name
+// is not equal to 'tenant_' || replace(id::text, '-', ”).
+func TestPlatformDB_TenantsDerivationCheck(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{})
+
+	// Mismatched db_name (different UUID under the prefix). The format
+	// regex passes (32 hex chars) but the derivation CHECK fails.
+	id := uuid.New().String()
+	otherDBName := "tenant_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status)
+		VALUES ($1, $2, $3, 'pending')
+	`, id, userID, otherDBName)
+	if err == nil {
+		t.Errorf("expected CHECK violation tenants_db_name_derived_from_id, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "tenants_db_name_derived_from_id") {
+		// Postgres does include the constraint name in its error
+		// detail; if it doesn't, the test still catches the rejection
+		// but we log to surface the change.
+		t.Logf("derivation CHECK rejection (constraint name not in msg): %v", err)
+	}
+}
+
+// TestPlatformDB_TenantsApprovedRequiresSchemaVersion verifies the
+// `tenants_approved_requires_schema_version` table-level CHECK.
+func TestPlatformDB_TenantsApprovedRequiresSchemaVersion(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{status: "approved"})
+
+	id := uuid.New().String()
+	dbName := "tenant_" + strings.ReplaceAll(id, "-", "")
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status, provisioned_at)
+		VALUES ($1, $2, $3, 'approved', NOW())
+	`, id, userID, dbName)
+	if err == nil {
+		t.Errorf("expected CHECK violation for approved tenant with NULL schema_version, got nil")
+	}
+}
+
+// TestPlatformDB_TenantsApprovedRequiresProvisionedAt verifies the
+// `tenants_approved_requires_provisioned_at` table-level CHECK.
+func TestPlatformDB_TenantsApprovedRequiresProvisionedAt(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{status: "approved"})
+
+	id := uuid.New().String()
+	dbName := "tenant_" + strings.ReplaceAll(id, "-", "")
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status, schema_version)
+		VALUES ($1, $2, $3, 'approved', 1)
+	`, id, userID, dbName)
+	if err == nil {
+		t.Errorf("expected CHECK violation for approved tenant with NULL provisioned_at, got nil")
+	}
+}
+
+// TestPlatformDB_TenantsFailureReasonGuard verifies the
+// `tenants_failure_reason_only_when_failed` CHECK: failure_reason can
+// only be non-NULL when status='provisioning_failed'.
+func TestPlatformDB_TenantsFailureReasonGuard(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{})
+
+	id := uuid.New().String()
+	dbName := "tenant_" + strings.ReplaceAll(id, "-", "")
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status, failure_reason)
+		VALUES ($1, $2, $3, 'pending', 'should not be allowed when pending')
+	`, id, userID, dbName)
+	if err == nil {
+		t.Errorf("expected CHECK violation for failure_reason on non-failed tenant, got nil")
+	}
+
+	// Sanity: the same row with status='provisioning_failed' is allowed.
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status, failure_reason)
+		VALUES ($1, $2, $3, 'provisioning_failed', 'CREATE DATABASE failed')
+	`, id, userID, dbName)
+	if err != nil {
+		t.Errorf("provisioning_failed + failure_reason should be allowed, got: %v", err)
+	}
+}
+
+// TestPlatformDB_TenantsUserIdUnique verifies the 1:1 user↔tenant
+// constraint via tenants_user_id_unique.
+func TestPlatformDB_TenantsUserIdUnique(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{})
+
+	// First tenant for this user inserts cleanly.
+	validTenantInsert(t, ctx, conn, userID)
+
+	// Second tenant for the same user is rejected.
+	id := uuid.New().String()
+	dbName := "tenant_" + strings.ReplaceAll(id, "-", "")
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status)
+		VALUES ($1, $2, $3, 'pending')
+	`, id, userID, dbName)
+	if err == nil {
+		t.Errorf("expected UNIQUE violation on tenants_user_id_unique, got nil")
+	}
+}
+
+// TestPlatformDB_TenantsDBNameFormatCheck verifies the column-level
+// regex check on db_name (independent from the derivation check).
+func TestPlatformDB_TenantsDBNameFormatCheck(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+	userID := insertUser(t, ctx, conn, userOpts{})
+
+	id := uuid.New().String()
+	// Wrong format — uppercase hex would violate the regex
+	// `^tenant_[a-f0-9]{32}$`.
+	badDBName := "tenant_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.tenants (id, user_id, db_name, status)
+		VALUES ($1, $2, $3, 'pending')
+	`, id, userID, badDBName)
+	if err == nil {
+		t.Errorf("expected CHECK violation for invalid db_name format, got nil")
+	}
+}
+
+// TestPlatformDB_AuditLogAppendOnly is a smoke test that the audit_log
+// table accepts inserts shaped like the spec's UserSignedUp /
+// TenantApproved events. Designed to fail loud if a future migration
+// accidentally drops a required column.
+func TestPlatformDB_AuditLogAppendOnly(t *testing.T) {
+	ctx := context.Background()
+	m, platformDB := newMigratorForTest(t)
+	if err := m.Bootstrap(ctx); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	conn := platformConn(t, ctx, platformDB)
+
+	userID := insertUser(t, ctx, conn, userOpts{})
+
+	// Insert a sample user.signed_up audit row.
+	_, err := conn.Exec(ctx, `
+		INSERT INTO platform.audit_log (event_type, aggregate_type, aggregate_id, payload, occurred_at)
+		VALUES ('user.signed_up', 'user', $1, '{"email":"new@example.com"}'::jsonb, $2)
+	`, userID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("insert audit_log row: %v", err)
+	}
+
+	// Insert a sample tenant.approved with actor + reason.
+	tenantID := uuid.New().String()
+	_, err = conn.Exec(ctx, `
+		INSERT INTO platform.audit_log (
+			event_type, aggregate_type, aggregate_id, actor_user_id,
+			payload, reason, ip_address, user_agent, occurred_at
+		)
+		VALUES (
+			'tenant.approved', 'tenant', $1, $2,
+			'{"db_name":"tenant_x"}'::jsonb, 'manual review', '127.0.0.1', 'test-agent', $3
+		)
+	`, tenantID, userID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("insert audit_log row with full fields: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wave 1 of v1.0-platform: populates the (until-now empty) platform migrations directory with the SQL schema for the singleton `duragraph_platform` DB. Bootstrap on engine startup will now apply these migrations end-to-end. Builds on the migrator infrastructure merged in #150.

Three tables under a dedicated `platform` schema (the runtime migrator queries `platform.tenants` schema-qualified — see `migrator.go:437`):

- **`platform.users`** — OAuth identity (`oauth_provider` + `oauth_id`), role (`user`/`admin`), approval status (`pending`/`approved`/`suspended`).
- **`platform.tenants`** — 1:1 with users, FK `ON DELETE RESTRICT`. State machine: `pending → provisioning → approved | provisioning_failed | suspended`.
- **`platform.audit_log`** — append-only (no UPDATE trigger). Captures `actor_user_id`, `reason`, `ip_address`, `user_agent`, `payload` JSONB, `occurred_at` + `recorded_at`.

## Files

```
internal/infrastructure/persistence/postgres/migrations/platform/
  001_init_users.up.sql        (NEW)
  001_init_users.down.sql      (NEW)
  002_init_tenants.up.sql      (NEW)
  002_init_tenants.down.sql    (NEW)
  003_audit_log.up.sql         (NEW)
  003_audit_log.down.sql       (NEW)

internal/infrastructure/persistence/postgres/
  migrator_test.go             (extended — see Tests below)
  integration_test.go          (drive-by fix — see Drive-by section)
```

## Key invariants enforced at the schema layer

**`platform.users`**
- `CHECK role IN ('user', 'admin')`
- `CHECK status IN ('pending', 'approved', 'suspended')`
- `CHECK oauth_provider IN ('google', 'github')`
- `UNIQUE (oauth_provider, oauth_id)`
- `UNIQUE (email)`
- `BEFORE UPDATE` trigger updates `updated_at`

**`platform.tenants`** (matches spec PR Duragraph/duragraph-spec#14 round-2 fix)
- `CHECK status IN (...)` (5-valued state machine)
- `CHECK db_name ~ '^tenant_[a-f0-9]{32}$'` (column-level regex)
- **`tenants_db_name_derived_from_id`**: `db_name = 'tenant_' || replace(id::text, '-', '')` — no tenant row can point at a database that isn't its own
- **`tenants_approved_requires_schema_version`**: `status != 'approved' OR schema_version IS NOT NULL`
- **`tenants_approved_requires_provisioned_at`**: `status != 'approved' OR provisioned_at IS NOT NULL`
- **`tenants_failure_reason_only_when_failed`**: `failure_reason IS NULL OR status = 'provisioning_failed'`
- **`tenants_user_id_unique`** (1:1 user↔tenant)
- FK `user_id REFERENCES platform.users(id) ON DELETE RESTRICT`
- `BEFORE UPDATE` trigger updates `updated_at`

**`platform.audit_log`** (no FK to users; events outlive their actors)
- Append-only — explicitly NO update trigger (documented in the migration comment)
- Indexed by `(aggregate_type, aggregate_id)`, `event_type`, `occurred_at DESC`, `actor_user_id`

## Schema choice (platform vs public)

All platform tables live under a **`platform`** schema, NOT `public`. The runtime migrator queries `platform.tenants` schema-qualified (`migrator.go:437`) — placing the tables in `public` would have made `MigrateAllTenants` silently return zero approved tenants forever (PG's `3F000` invalid_schema_name doesn't match the migrator's `42P01` undefined_table catch). The trigger helper `update_updated_at_column()` lives at `platform.update_updated_at_column()` so the platform DB owns its own copy independent of the tenant DBs (which keep theirs in `public`).

## Tests

26 integration tests pass (`go test -tags=integration -timeout=10m -run 'TestMigrator|TestPlatformDB' -count=1 ./internal/infrastructure/persistence/postgres/...` — testcontainers-driven Postgres 16):

**New migrator-level tests:**
- `TestMigrator_MigratePlatform_AppliesAllPlatformMigrations` — Bootstrap creates all three platform tables.
- `TestMigrator_PlatformMigrations_Idempotent` — re-running Bootstrap is a no-op.
- `TestMigrator_MigrateAllTenants_FindsApprovedTenants` — end-to-end: insert `platform.users` + `platform.tenants` rows with `status='approved'`, verify `MigrateAllTenants` returns the tenant. Proves the schema-qualified `platform.tenants` query connects.
- `TestMigrator_HasMigrations_DetectsEmptyDir` — unit test of the empty-FS short-circuit using `fstest.MapFS`. Replaces the previous `TestMigrator_Bootstrap_HandlesEmptyPlatformMigrationsDir` (which relied on `migrations/platform/` actually being empty — no longer the case after this PR).
- `TestMigrator_MigrateAllTenants_EmptyWhenTenantsTableMissing` — drops `platform.tenants` post-Bootstrap to keep coverage of the 42P01 fall-through path.

**New platform-DB constraint tests** (eight total):
- `TestPlatformDB_UsersConstraints` — invalid role/status/oauth_provider; duplicate email; duplicate `(oauth_provider, oauth_id)`.
- `TestPlatformDB_TenantsDerivationCheck` — db_name not derived from id is rejected.
- `TestPlatformDB_TenantsApprovedRequiresSchemaVersion` — approved+NULL schema_version rejected.
- `TestPlatformDB_TenantsApprovedRequiresProvisionedAt` — approved+NULL provisioned_at rejected.
- `TestPlatformDB_TenantsFailureReasonGuard` — failure_reason on non-failed status rejected; provisioning_failed+failure_reason allowed.
- `TestPlatformDB_TenantsUserIdUnique` — second tenant for same user_id rejected.
- `TestPlatformDB_TenantsDBNameFormatCheck` — uppercase hex db_name rejected by column-level regex CHECK.
- `TestPlatformDB_AuditLogAppendOnly` — smoke test for audit_log inserts shaped like `user.signed_up` and `tenant.approved` events.

**Existing tests preserved:** all `TestMigrator_Bootstrap_*`, `TestMigrator_MigrateMainDB_*`, `TestMigrator_ProvisionTenant_*`, `TestMigrator_DropTenant_*`, `TestMigrator_NewMigrator_*`, `TestMigrator_MigrateTenant_RejectsInvalidUUID` continue to pass unchanged. Two existing tests were renamed for accuracy (see commit message body).

## Drive-by fix

`internal/infrastructure/persistence/postgres/integration_test.go` has a `TestMain` that called `runMigrations()` against `deploy/sql/` — a path PR #150 deleted when migrations were embedded into the package. Without a fix, `TestMain` bailed before any test in the binary ran, blocking ALL `-tags=integration` tests in the postgres package on main. CI didn't catch it because CI runs `-short` only.

The fix is a 5-line graceful skip: when `deploy/sql/` is missing, return nil and trust that the production migrator has already applied schema to the dev DB (the `task up` flow does this). This is the minimal change that unblocks integration verification of THIS PR; pre-existing repo integration tests continue to assume the dev DB is already migrated, exactly as before.

If preferred, this can be split into a separate fix-up PR — happy to do so.

## Cross-references

- Schema authoritatively defined in **Duragraph/duragraph-spec PR #14** (`models/entities.yml` `users` + `tenants` entities, including the round-2 table-level CHECK constraints).
- `audit_log` shape inferred from **Duragraph/duragraph-spec PR #18** (`async/asyncapi.yml` — `platform-audit-users` / `platform-audit-tenants` consumers project user.* and tenant.* events into this table).

## Test plan

- [x] `go vet ./internal/infrastructure/persistence/postgres/...` — clean
- [x] `go fmt ./internal/infrastructure/persistence/postgres/...` — applied
- [x] `go build ./...` — clean
- [x] `go test -short ./internal/infrastructure/persistence/postgres/...` — passes (no test files in package short mode)
- [x] `go test -tags=integration -timeout=10m -run 'TestMigrator|TestPlatformDB' -count=1 ./internal/infrastructure/persistence/postgres/...` — **26/26 pass** locally (testcontainers Postgres 16)
- [ ] CI to verify on push (existing `-short` path; integration tag not in CI)

## Out of scope

- No `cmd/server/main.go` changes — Bootstrap is already wired (PR #150).
- No spec-repo edits — `models/entities.yml` already documents these tables.
- No Go domain code changes — Tenant + User aggregates are PRs #147 and #148.

## Decisions made under uncertainty

The `audit_log` schema is partially specified (asyncapi.yml documents the consumer pattern but not the column shape). I designed for:
- `aggregate_type VARCHAR(20)` constrained downstream by application-layer validation (likely values: `'user'`, `'tenant'`).
- `aggregate_id UUID NOT NULL` with no FK because cascades would corrupt the audit trail when actors are removed in future hard-delete paths.
- Both `occurred_at` (event time) AND `recorded_at` (insert time) — late-arriving events / replay would conflate the two if only one were stored.
- No update trigger; documented as "append-only" in the migration comment.