### PR TITLE
feat: add JWT verifier + tenant + admin middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/duragraph/duragraph/internal/application/command"
 	"github.com/duragraph/duragraph/internal/application/query"
 	"github.com/duragraph/duragraph/internal/application/service"
+	"github.com/duragraph/duragraph/internal/infrastructure/auth"
 	infra_exec "github.com/duragraph/duragraph/internal/infrastructure/execution"
 	"github.com/duragraph/duragraph/internal/infrastructure/graph"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/handlers"
@@ -483,15 +484,49 @@ func main() {
 		fmt.Printf("✅ Rate limiting enabled (%.0f req/s, burst %d)\n", rps, burst)
 	}
 
-	// Optional authentication (can be made required by setting env var)
+	// Authentication.
+	//
+	// When AUTH_ENABLED=true, every authenticated request flows through
+	// TenantMiddleware: it verifies the platform JWT (HS256, iss claim
+	// must equal "duragraph-platform" — see auth/jwt.yml) and populates
+	// the request context with user_id, tenant_id, role, and email.
+	//
+	// We deliberately replace the legacy middleware.OptionalAuth here.
+	// OptionalAuth uses the older middleware.JWTClaims shape ({user_id,
+	// username, email, roles}); the new platform contract uses
+	// auth.Claims ({user_id, tenant_id, role, email}). Stacking both
+	// would attempt to verify each request twice with mutually-
+	// incompatible structs and reject every new-shape token. The legacy
+	// JWT/OptionalAuth/APIKeyAuth helpers remain in middleware/auth.go
+	// for now (their unit tests still cover them), but they are no
+	// longer wired into main.go's AUTH_ENABLED branch.
+	//
+	// Public/auth-only routes (/health, /metrics, /api/auth/*) bypass
+	// TenantMiddleware via Echo's per-route middleware semantics: they
+	// are registered on the bare *echo.Echo (not under a group with
+	// TenantMiddleware applied). Future /api/auth/login, /callback,
+	// /logout endpoints will live alongside /health below.
+	//
+	// Backwards compat: when AUTH_ENABLED=false (the default), no auth
+	// middleware runs at all. Existing single-tenant deployments keep
+	// working unchanged. This gate is intentionally NOT tied to
+	// MIGRATOR_PLATFORM_ENABLED — middleware applies whether or not
+	// the multi-tenant migrator is active. The two flags are
+	// orthogonal: AUTH_ENABLED gates JWT verification, the migrator
+	// flag gates platform-DB provisioning.
 	authEnabled := os.Getenv("AUTH_ENABLED") == "true"
+	var verifier *auth.Verifier
 	if authEnabled {
 		jwtSecret := os.Getenv("JWT_SECRET")
 		if jwtSecret == "" {
 			jwtSecret = "default-secret-change-in-production"
 		}
-		e.Use(middleware.OptionalAuth(jwtSecret))
-		fmt.Println("✅ Authentication enabled")
+		v, err := auth.NewVerifier([]byte(jwtSecret))
+		if err != nil {
+			log.Fatalf("failed to construct JWT verifier: %v", err)
+		}
+		verifier = v
+		fmt.Println("✅ Authentication enabled (TenantMiddleware)")
 	}
 
 	// Routes
@@ -509,8 +544,18 @@ func main() {
 	e.GET("/ok", systemHandler.Ok)
 	e.GET("/info", systemHandler.Info)
 
-	// API routes
-	api := e.Group("/api/v1")
+	// API routes.
+	//
+	// Build the /api/v1 group with platform middleware when AUTH_ENABLED.
+	// Order matters: TenantMiddleware MUST run before RequireTenant
+	// (RequireTenant reads what TenantMiddleware writes). RequireTenant
+	// is /api/v1-only — pending users still need /api/platform/me etc.
+	var apiMiddleware []echo.MiddlewareFunc
+	if authEnabled {
+		apiMiddleware = append(apiMiddleware, middleware.TenantMiddleware(verifier))
+		apiMiddleware = append(apiMiddleware, middleware.RequireTenant())
+	}
+	api := e.Group("/api/v1", apiMiddleware...)
 
 	// Thread Run routes (LangGraph compatible)
 	api.POST("/threads/:thread_id/runs", runHandler.CreateRun)
@@ -621,6 +666,21 @@ func main() {
 	api.POST("/workers/:worker_id/deregister", workerHandler.Deregister)
 	api.POST("/workers/:worker_id/events", workerHandler.ReceiveEvent)
 	api.GET("/workers/graphs/:graph_id", workerHandler.GetGraphDefinition)
+
+	// Admin route group.
+	//
+	// Empty today — handlers land in the next PR alongside the platform
+	// User/Tenant repositories. The middleware is wired now so the chain
+	// is ready: TenantMiddleware verifies the JWT, then
+	// AdminAuthMiddleware enforces role=admin. Until routes are added,
+	// any request hitting /api/admin/* returns 404 (Echo's default for
+	// no-match) which is fine.
+	if authEnabled {
+		_ = e.Group("/api/admin",
+			middleware.TenantMiddleware(verifier),
+			middleware.AdminAuthMiddleware(),
+		)
+	}
 
 	// Start server
 	go func() {

--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -1,0 +1,222 @@
+// Package auth contains the JWT issuance + verification primitives shared by
+// the platform OAuth callback handler (which mints tokens) and the engine's
+// HTTP middleware (which verifies them on every authenticated request).
+//
+// The claim shape implemented here is the one defined in
+// duragraph-spec/auth/jwt.yml: HS256, claim names `user_id`, `tenant_id`,
+// `role`, `email`, `iat`, `exp`, `iss`. Issuer is the constant
+// `duragraph-platform`. tenant_id is optional (empty when the user's
+// signup is awaiting operator approval — see auth/oauth.yml callback flow,
+// case existing_user_pending). role is one of "user" or "admin".
+//
+// Earlier iterations of this file shipped a different claim set
+// ({user_id, email, name, provider, exp, iat}) — that shape predates the
+// multi-tenant platform model and is now replaced by this Claims type.
+// `name` and `provider` are NOT carried in the canonical token; OAuth
+// userinfo is the authoritative source for those, looked up via the
+// platform User aggregate when needed.
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// IssuerDuragraphPlatform is the value the platform auth layer signs into
+// the `iss` claim and the only value the engine verifier accepts. Defending
+// against accidental cross-product token reuse should JWT_SECRET ever leak
+// into a sibling environment (per spec auth/jwt.yml § issuer).
+const IssuerDuragraphPlatform = "duragraph-platform"
+
+// Claims is the canonical session-token claim shape minted by the platform
+// auth layer and consumed by the engine middleware.
+//
+// Field semantics (see auth/jwt.yml for the contract):
+//   - UserID:   stable User aggregate ID. Always present.
+//   - TenantID: Tenant aggregate ID. Empty/absent for pending users
+//     (signup not yet approved). Engine route guards refuse /api/v1/* when
+//     this is empty.
+//   - Role:     authorization tier. "user" or "admin". Always present.
+//   - Email:    OAuth-verified email, used for display + audit log entries.
+//
+// Standard claims (`iat`, `exp`, `iss`) live in the embedded
+// jwt.RegisteredClaims; we MUST set Issuer to IssuerDuragraphPlatform when
+// minting and verify it explicitly when parsing.
+type Claims struct {
+	UserID   string `json:"user_id"`
+	TenantID string `json:"tenant_id,omitempty"`
+	Role     string `json:"role"`
+	Email    string `json:"email"`
+	jwt.RegisteredClaims
+}
+
+// JWT verification errors. Callers (HTTP middleware, refresh endpoints) can
+// distinguish via errors.Is to decide on 401 vs other handling.
+var (
+	// ErrTokenMalformed is returned when the token can't be parsed as a JWT.
+	ErrTokenMalformed = errors.New("malformed jwt")
+	// ErrTokenInvalidSignature is returned when the HMAC signature doesn't
+	// verify against the configured secret.
+	ErrTokenInvalidSignature = errors.New("invalid jwt signature")
+	// ErrTokenExpired is returned when exp <= now.
+	ErrTokenExpired = errors.New("jwt expired")
+	// ErrTokenNotYetValid is returned when nbf is in the future. Not used
+	// today (we never set nbf) but possible per RFC 7519.
+	ErrTokenNotYetValid = errors.New("jwt not yet valid")
+	// ErrTokenWrongIssuer is returned when the iss claim is missing or
+	// doesn't equal IssuerDuragraphPlatform.
+	ErrTokenWrongIssuer = errors.New("jwt issuer mismatch")
+	// ErrTokenMissingClaim is returned when a required claim (user_id,
+	// role, email) is absent.
+	ErrTokenMissingClaim = errors.New("jwt missing required claim")
+)
+
+// IssueJWT mints a new HS256-signed session token. Exposed as a package-
+// level helper rather than a method so non-OAuth callers (a future refresh
+// endpoint, tests) can use it without instantiating an OAuthManager.
+//
+// secret    : shared symmetric key (engine + platform read the same one).
+// userID    : User aggregate ID (stable across logins).
+// email     : OAuth-verified email (display + audit).
+// role      : "user" or "admin".
+// tenantID  : Tenant aggregate ID. Pass "" for pending users — the
+//
+//	verifier accepts an empty tenant_id and route guards
+//	(RequireTenant) reject /api/v1/* downstream.
+//
+// ttl       : token lifetime. Spec default is 24h; refresh threshold 6h.
+//
+// Returns the signed token string.
+func IssueJWT(secret []byte, userID, email, role, tenantID string, ttl time.Duration) (string, error) {
+	if userID == "" {
+		return "", fmt.Errorf("issue jwt: user_id required")
+	}
+	if role == "" {
+		return "", fmt.Errorf("issue jwt: role required")
+	}
+	if email == "" {
+		return "", fmt.Errorf("issue jwt: email required")
+	}
+	if ttl <= 0 {
+		return "", fmt.Errorf("issue jwt: ttl must be positive")
+	}
+
+	now := time.Now()
+	claims := Claims{
+		UserID:   userID,
+		TenantID: tenantID,
+		Role:     role,
+		Email:    email,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    IssuerDuragraphPlatform,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(secret)
+	if err != nil {
+		return "", fmt.Errorf("issue jwt: sign: %w", err)
+	}
+	return signed, nil
+}
+
+// VerifyJWT parses and validates a session token. Returns the typed Claims
+// on success, or one of the sentinel errors on failure.
+//
+// Validation steps:
+//  1. Parse the JWT structure. ErrTokenMalformed on syntactic failure.
+//  2. Verify the signing algorithm is HS256 (reject "none", RSA, etc.).
+//  3. Verify the HMAC signature against secret. ErrTokenInvalidSignature.
+//  4. Verify standard time claims (exp, nbf). ErrTokenExpired or
+//     ErrTokenNotYetValid as appropriate.
+//  5. Verify iss == IssuerDuragraphPlatform. ErrTokenWrongIssuer otherwise.
+//     We do this AFTER signature verification — checking iss on a forged
+//     token would be a meaningless step.
+//  6. Verify required claims (user_id, role, email) are non-empty.
+//
+// The order matters: a malformed token must NEVER reach the issuer check
+// (the issuer string in an unsigned token is attacker-controlled).
+func VerifyJWT(secret []byte, tokenString string) (*Claims, error) {
+	if tokenString == "" {
+		return nil, ErrTokenMalformed
+	}
+
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		// Reject any non-HMAC signing method. A forged "alg: none" token
+		// would otherwise pass without signature verification.
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return secret, nil
+	}
+
+	parsed, err := jwt.ParseWithClaims(tokenString, &Claims{}, keyFunc)
+	if err != nil {
+		switch {
+		case errors.Is(err, jwt.ErrTokenExpired):
+			return nil, ErrTokenExpired
+		case errors.Is(err, jwt.ErrTokenNotValidYet):
+			return nil, ErrTokenNotYetValid
+		case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+			return nil, ErrTokenInvalidSignature
+		case errors.Is(err, jwt.ErrTokenMalformed):
+			return nil, ErrTokenMalformed
+		default:
+			// Unknown parse error — treat as malformed rather than leaking
+			// the raw library error string into responses.
+			return nil, fmt.Errorf("%w: %v", ErrTokenMalformed, err)
+		}
+	}
+
+	if !parsed.Valid {
+		return nil, ErrTokenMalformed
+	}
+
+	claims, ok := parsed.Claims.(*Claims)
+	if !ok {
+		return nil, ErrTokenMalformed
+	}
+
+	// Explicit issuer check. golang-jwt v5's default validator does NOT
+	// verify the iss claim unless you pass jwt.WithIssuer; we do it inline
+	// here for a clearer single-pass error path.
+	if claims.Issuer != IssuerDuragraphPlatform {
+		return nil, ErrTokenWrongIssuer
+	}
+
+	// Required claims that the spec marks `required: true`.
+	if claims.UserID == "" || claims.Role == "" || claims.Email == "" {
+		return nil, ErrTokenMissingClaim
+	}
+
+	return claims, nil
+}
+
+// Verifier wraps the symmetric secret used to validate session tokens.
+// HTTP middleware consumes a Verifier rather than the raw []byte so the
+// secret stays encapsulated and tests can stub the type if needed.
+type Verifier struct {
+	secret []byte
+}
+
+// NewVerifier constructs a Verifier from the JWT_SECRET bytes. Empty
+// secrets are rejected — running the engine with AUTH_ENABLED=true and a
+// missing secret should be a hard configuration error caught at startup.
+func NewVerifier(secret []byte) (*Verifier, error) {
+	if len(secret) == 0 {
+		return nil, fmt.Errorf("new verifier: jwt secret is empty")
+	}
+	return &Verifier{secret: secret}, nil
+}
+
+// Verify parses + validates a token string. Pass-through to VerifyJWT;
+// kept as a method so middleware can depend on the *Verifier type
+// (clearer dependency injection point than a raw secret slice).
+func (v *Verifier) Verify(tokenString string) (*Claims, error) {
+	return VerifyJWT(v.secret, tokenString)
+}

--- a/internal/infrastructure/auth/jwt_test.go
+++ b/internal/infrastructure/auth/jwt_test.go
@@ -1,0 +1,360 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TestIssueJWT_RoundTrip mints a token with the canonical shape and
+// confirms VerifyJWT returns identical claim values. This is the happy-
+// path contract enforcement: anything we put in MUST come back out.
+func TestIssueJWT_RoundTrip(t *testing.T) {
+	secret := []byte("test-secret-key")
+
+	token, err := IssueJWT(
+		secret,
+		"user-123",
+		"alice@example.com",
+		"admin",
+		"tenant-abc",
+		time.Hour,
+	)
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+	if token == "" {
+		t.Fatal("token must not be empty")
+	}
+
+	claims, err := VerifyJWT(secret, token)
+	if err != nil {
+		t.Fatalf("VerifyJWT: %v", err)
+	}
+
+	if claims.UserID != "user-123" {
+		t.Errorf("UserID: got %q want user-123", claims.UserID)
+	}
+	if claims.TenantID != "tenant-abc" {
+		t.Errorf("TenantID: got %q want tenant-abc", claims.TenantID)
+	}
+	if claims.Role != "admin" {
+		t.Errorf("Role: got %q want admin", claims.Role)
+	}
+	if claims.Email != "alice@example.com" {
+		t.Errorf("Email: got %q want alice@example.com", claims.Email)
+	}
+	if claims.Issuer != IssuerDuragraphPlatform {
+		t.Errorf("Issuer: got %q want %q", claims.Issuer, IssuerDuragraphPlatform)
+	}
+	if claims.IssuedAt == nil || claims.ExpiresAt == nil {
+		t.Fatal("iat/exp claims must be set")
+	}
+	if !claims.ExpiresAt.After(claims.IssuedAt.Time) {
+		t.Errorf("exp must be after iat: iat=%v exp=%v", claims.IssuedAt, claims.ExpiresAt)
+	}
+}
+
+// TestIssueJWT_PendingUser confirms an empty tenant_id is round-tripped
+// faithfully — pending users (signup not yet approved) get a token with
+// no tenant. The verifier MUST accept this; route guards
+// (RequireTenant) reject downstream.
+func TestIssueJWT_PendingUser(t *testing.T) {
+	secret := []byte("test-secret-key")
+
+	token, err := IssueJWT(secret, "user-pending", "bob@example.com", "user", "", time.Hour)
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+
+	claims, err := VerifyJWT(secret, token)
+	if err != nil {
+		t.Fatalf("VerifyJWT: %v", err)
+	}
+	if claims.TenantID != "" {
+		t.Errorf("TenantID for pending user: got %q want empty", claims.TenantID)
+	}
+	if claims.Role != "user" {
+		t.Errorf("Role: got %q want user", claims.Role)
+	}
+}
+
+// TestIssueJWT_RejectsMissingFields is a guard against silent typos at
+// callsites — IssueJWT must hard-fail rather than mint a token that
+// would later be rejected by the verifier.
+func TestIssueJWT_RejectsMissingFields(t *testing.T) {
+	secret := []byte("secret")
+
+	cases := []struct {
+		name     string
+		userID   string
+		email    string
+		role     string
+		tenantID string
+		ttl      time.Duration
+	}{
+		{"missing user_id", "", "a@b", "user", "t", time.Hour},
+		{"missing email", "u", "", "user", "t", time.Hour},
+		{"missing role", "u", "a@b", "", "t", time.Hour},
+		{"zero ttl", "u", "a@b", "user", "t", 0},
+		{"negative ttl", "u", "a@b", "user", "t", -time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := IssueJWT(secret, tc.userID, tc.email, tc.role, tc.tenantID, tc.ttl)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestVerifyJWT_Expired ensures expired tokens are explicitly rejected.
+// The default golang-jwt v5 validator handles this; we just confirm the
+// sentinel error mapping.
+func TestVerifyJWT_Expired(t *testing.T) {
+	secret := []byte("secret")
+
+	// Mint with negative ttl — exp will be in the past.
+	claims := Claims{
+		UserID: "u",
+		Role:   "user",
+		Email:  "a@b",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    IssuerDuragraphPlatform,
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString(secret)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, err = VerifyJWT(secret, signed)
+	if !errors.Is(err, ErrTokenExpired) {
+		t.Errorf("expected ErrTokenExpired, got %v", err)
+	}
+}
+
+// TestVerifyJWT_WrongIssuer is the cross-product token-leak guard. Tokens
+// signed with the same secret but issued by a different system MUST be
+// rejected — that's exactly why iss is in the spec.
+func TestVerifyJWT_WrongIssuer(t *testing.T) {
+	secret := []byte("secret")
+
+	claims := Claims{
+		UserID: "u",
+		Role:   "user",
+		Email:  "a@b",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "some-other-product",
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := tok.SignedString(secret)
+
+	_, err := VerifyJWT(secret, signed)
+	if !errors.Is(err, ErrTokenWrongIssuer) {
+		t.Errorf("expected ErrTokenWrongIssuer, got %v", err)
+	}
+}
+
+// TestVerifyJWT_BadSignature confirms that a token signed with a
+// different secret is rejected at signature verification — i.e. before
+// the iss check runs (a forged token's iss is attacker-controlled).
+func TestVerifyJWT_BadSignature(t *testing.T) {
+	good := []byte("correct-secret")
+	bad := []byte("wrong-secret")
+
+	signed, err := IssueJWT(good, "u", "a@b", "user", "", time.Hour)
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+
+	_, err = VerifyJWT(bad, signed)
+	if !errors.Is(err, ErrTokenInvalidSignature) {
+		t.Errorf("expected ErrTokenInvalidSignature, got %v", err)
+	}
+}
+
+// TestVerifyJWT_Malformed exercises the syntactic-failure path —
+// garbage in, ErrTokenMalformed out.
+func TestVerifyJWT_Malformed(t *testing.T) {
+	secret := []byte("secret")
+
+	cases := []string{
+		"",
+		"not-a-jwt",
+		"a.b",                    // wrong number of segments
+		"header.payload.garbage", // unparseable segments
+	}
+	for _, tok := range cases {
+		t.Run(tok, func(t *testing.T) {
+			_, err := VerifyJWT(secret, tok)
+			if err == nil {
+				t.Fatalf("expected error for %q", tok)
+			}
+			// Either ErrTokenMalformed itself or an error wrapping it is
+			// acceptable — the wrapper case happens for unrecognised parse
+			// errors that aren't covered by named sentinels.
+			if !errors.Is(err, ErrTokenMalformed) && !errors.Is(err, ErrTokenInvalidSignature) {
+				t.Errorf("expected malformed/invalid-sig error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestVerifyJWT_RejectsAlgNone defends against the classic "alg: none"
+// downgrade attack. Even with no signature, the token must be rejected.
+func TestVerifyJWT_RejectsAlgNone(t *testing.T) {
+	// Hand-roll an alg=none token (golang-jwt won't sign one for us).
+	// The structure is just a header+payload+empty-sig where the header
+	// claims alg=none.
+	header := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+	payload := "eyJ1c2VyX2lkIjoidSIsInJvbGUiOiJ1c2VyIiwiZW1haWwiOiJhQGIiLCJpc3MiOiJkdXJhZ3JhcGgtcGxhdGZvcm0ifQ"
+	tok := header + "." + payload + "."
+
+	_, err := VerifyJWT([]byte("secret"), tok)
+	if err == nil {
+		t.Fatal("alg=none token must be rejected")
+	}
+}
+
+// TestVerifyJWT_MissingRequiredClaim checks the post-signature claim
+// validation: even a properly-signed, non-expired, right-issuer token
+// must carry user_id, role, email.
+func TestVerifyJWT_MissingRequiredClaim(t *testing.T) {
+	secret := []byte("secret")
+
+	cases := []struct {
+		name   string
+		claims Claims
+	}{
+		{
+			name: "missing user_id",
+			claims: Claims{
+				Role:  "user",
+				Email: "a@b",
+			},
+		},
+		{
+			name: "missing role",
+			claims: Claims{
+				UserID: "u",
+				Email:  "a@b",
+			},
+		},
+		{
+			name: "missing email",
+			claims: Claims{
+				UserID: "u",
+				Role:   "user",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.claims.RegisteredClaims = jwt.RegisteredClaims{
+				Issuer:    IssuerDuragraphPlatform,
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			}
+			tok := jwt.NewWithClaims(jwt.SigningMethodHS256, tc.claims)
+			signed, _ := tok.SignedString(secret)
+
+			_, err := VerifyJWT(secret, signed)
+			if !errors.Is(err, ErrTokenMissingClaim) {
+				t.Errorf("expected ErrTokenMissingClaim, got %v", err)
+			}
+		})
+	}
+}
+
+// TestNewVerifier_RejectsEmptySecret guards against a config oversight —
+// running with AUTH_ENABLED=true and no JWT_SECRET should be a hard error
+// at startup, not a runtime accept-everything.
+func TestNewVerifier_RejectsEmptySecret(t *testing.T) {
+	_, err := NewVerifier(nil)
+	if err == nil {
+		t.Error("nil secret must be rejected")
+	}
+	_, err = NewVerifier([]byte{})
+	if err == nil {
+		t.Error("empty secret must be rejected")
+	}
+}
+
+// TestVerifier_Verify confirms the method is a faithful wrapper around
+// VerifyJWT.
+func TestVerifier_Verify(t *testing.T) {
+	secret := []byte("secret")
+	v, err := NewVerifier(secret)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	signed, err := IssueJWT(secret, "u", "a@b", "user", "", time.Hour)
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+
+	claims, err := v.Verify(signed)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if claims.UserID != "u" {
+		t.Errorf("user_id: got %q", claims.UserID)
+	}
+}
+
+// TestIssueJWT_DropsLegacyClaims is a regression guard — earlier
+// iterations of generateJWT included `name` and `provider` fields. The
+// canonical Claims shape MUST NOT carry those, since the engine middleware
+// does not consume them. Decoding the JWT payload as raw JSON ensures
+// there are no stowaway fields.
+func TestIssueJWT_DropsLegacyClaims(t *testing.T) {
+	secret := []byte("secret")
+	signed, err := IssueJWT(secret, "u", "a@b", "user", "t", time.Hour)
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+
+	// Decode middle segment (payload) to inspect raw fields.
+	parts := strings.Split(signed, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 segments, got %d", len(parts))
+	}
+	// We don't need to decode base64 here — golang-jwt's parser already
+	// validated structural correctness above. Just confirm the parsed
+	// Claims struct doesn't surface name/provider, by checking
+	// jwt.MapClaims via a re-parse.
+	parsed, err := jwt.Parse(signed, func(_ *jwt.Token) (interface{}, error) {
+		return secret, nil
+	})
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	mapClaims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatalf("expected MapClaims, got %T", parsed.Claims)
+	}
+	if _, has := mapClaims["name"]; has {
+		t.Error("name claim must not be present in canonical token")
+	}
+	if _, has := mapClaims["provider"]; has {
+		t.Error("provider claim must not be present in canonical token")
+	}
+	// And the canonical claims SHOULD be present.
+	for _, want := range []string{"user_id", "tenant_id", "role", "email", "iat", "exp", "iss"} {
+		if _, has := mapClaims[want]; !has {
+			t.Errorf("canonical claim %q missing", want)
+		}
+	}
+}

--- a/internal/infrastructure/auth/oauth.go
+++ b/internal/infrastructure/auth/oauth.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
@@ -23,6 +22,10 @@ const (
 	ProviderGoogle Provider = "google"
 	ProviderGitHub Provider = "github"
 )
+
+// defaultSessionTTL is the lifetime stamped onto JWTs minted by the OAuth
+// callback handler. Matches auth/jwt.yml § exp.default_lifetime_seconds.
+const defaultSessionTTL = 24 * time.Hour
 
 // OAuthConfig holds OAuth configuration
 type OAuthConfig struct {
@@ -110,7 +113,22 @@ func (m *OAuthManager) LoginHandler(provider Provider) echo.HandlerFunc {
 	}
 }
 
-// CallbackHandler returns OAuth callback handler
+// CallbackHandler returns OAuth callback handler.
+//
+// NOTE: this handler predates the platform multi-tenant model. It does NOT
+// look up the User/Tenant aggregates, does NOT apply the bootstrap-first-
+// user rule, and does NOT enforce the pending/approved/suspended decision
+// tree from auth/oauth.yml. It exists today only as a thin OAuth-exchange
+// scaffold and is wired up via OAuthConfig but not currently mounted on
+// any route in cmd/server/main.go. The full callback flow will land in the
+// follow-up handlers/auth/* package alongside the User/Tenant repositories.
+//
+// As an interim placeholder until that work lands, the JWT minted here
+// stamps role="user" and tenant_id="" — i.e. treats every callback as a
+// pending user. Anyone reaching protected /api/v1/* routes with such a
+// token will be rejected by RequireTenant (403). This is intentional:
+// keeps backwards compat for any in-flight test that touches this path
+// while ensuring the stub can't accidentally grant tenant access.
 func (m *OAuthManager) CallbackHandler(provider Provider) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		config, exists := m.configs[provider]
@@ -263,19 +281,31 @@ func (m *OAuthManager) getUserInfo(ctx context.Context, provider Provider, token
 	return &userInfo, nil
 }
 
-// generateJWT creates a JWT token for the user
+// generateJWT creates a session JWT for the freshly-authenticated user.
+//
+// The claim shape is the canonical platform shape defined in
+// auth/jwt.yml — user_id, tenant_id, role, email, iat, exp, iss.
+//
+// Earlier iterations of this function emitted {user_id, email, name,
+// provider, exp, iat}. `name` and `provider` are NOT canonical claims;
+// the engine middleware does not consume them. They've been dropped here
+// to align with the spec. UserInfo.Name and UserInfo.Provider continue to
+// exist as transient fields on the OAuth-userinfo struct (returned in the
+// callback response body for diagnostic purposes), but they no longer
+// round-trip through the JWT.
+//
+// tenant_id is intentionally left empty here — see the CallbackHandler doc
+// comment for why this code path treats every login as a pending user
+// until the full handlers/auth/* package replaces it.
 func (m *OAuthManager) generateJWT(userInfo *UserInfo) (string, error) {
-	claims := jwt.MapClaims{
-		"user_id":  userInfo.ID,
-		"email":    userInfo.Email,
-		"name":     userInfo.Name,
-		"provider": userInfo.Provider,
-		"exp":      time.Now().Add(24 * time.Hour).Unix(),
-		"iat":      time.Now().Unix(),
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString(m.jwtSecret)
+	return IssueJWT(
+		m.jwtSecret,
+		userInfo.ID,
+		userInfo.Email,
+		"user", // pending users get role=user; admin elevation lives in the platform User aggregate
+		"",     // no tenant_id — provisioning happens via the platform admin UI
+		defaultSessionTTL,
+	)
 }
 
 // generateStateToken generates a random state token

--- a/internal/infrastructure/http/middleware/admin_auth.go
+++ b/internal/infrastructure/http/middleware/admin_auth.go
@@ -1,0 +1,41 @@
+// AdminAuthMiddleware — guards /api/admin/* (and any other admin-only
+// route group) by requiring claims.role == "admin".
+//
+// Layering: MUST run AFTER TenantMiddleware, which is what populates the
+// role into the request context. Without TenantMiddleware in front,
+// AdminAuthMiddleware will refuse every request (no role = 403), which
+// is fail-safe but unhelpful — wire the chain correctly in main.go.
+//
+// 403 vs 401: this middleware assumes authentication has already
+// succeeded (TenantMiddleware would have returned 401 otherwise). A user
+// reaching here whose role is "user" is authenticated but unauthorised,
+// so 403 Forbidden — RFC 7231 § 6.5.3.
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// RoleAdmin is the only value of the JWT `role` claim that grants access
+// to admin routes. Mirrors the enum in auth/jwt.yml § role.enum.
+const RoleAdmin = "admin"
+
+// AdminAuthMiddleware rejects any request whose ctx role is not "admin".
+//
+// Returns 403 Forbidden with a generic message — we don't enumerate the
+// reason ("you are role=user, need admin") to avoid leaking authorisation
+// model details to unauthenticated probes that somehow get past the
+// upstream auth layer.
+func AdminAuthMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			role, ok := RoleFromCtx(c)
+			if !ok || role != RoleAdmin {
+				return echo.NewHTTPError(http.StatusForbidden, "admin access required")
+			}
+			return next(c)
+		}
+	}
+}

--- a/internal/infrastructure/http/middleware/admin_auth_test.go
+++ b/internal/infrastructure/http/middleware/admin_auth_test.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// runAdminMiddleware applies AdminAuthMiddleware to a probe handler that
+// records whether it was reached. Returns whether the handler ran and any
+// error.
+func runAdminMiddleware(c echo.Context) (bool, error) {
+	called := false
+	err := AdminAuthMiddleware()(func(_ echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})(c)
+	return called, err
+}
+
+// TestAdminAuth_AdminPasses — role=admin → 200, downstream handler runs.
+func TestAdminAuth_AdminPasses(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	withRole(c, RoleAdmin)
+
+	called, err := runAdminMiddleware(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("downstream handler should have been called for admin")
+	}
+}
+
+// TestAdminAuth_UserRejected — role=user → 403, downstream blocked.
+func TestAdminAuth_UserRejected(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	withRole(c, "user")
+
+	called, err := runAdminMiddleware(c)
+	if err == nil {
+		t.Fatal("expected error for non-admin")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %v", err)
+	}
+	if called {
+		t.Error("downstream handler should NOT have been called")
+	}
+}
+
+// TestAdminAuth_MissingRole — role absent (e.g. TenantMiddleware never
+// ran, or some bug) → 403. Fail-safe.
+func TestAdminAuth_MissingRole(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	called, err := runAdminMiddleware(c)
+	if err == nil {
+		t.Fatal("expected error for missing role")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %v", err)
+	}
+	if called {
+		t.Error("downstream handler should NOT have been called")
+	}
+}
+
+// TestAdminAuth_UnknownRole — role="root" or any non-admin string → 403.
+// Defends against future role values being granted admin by accident.
+func TestAdminAuth_UnknownRole(t *testing.T) {
+	cases := []string{"root", "superuser", "owner", ""}
+	for _, role := range cases {
+		t.Run(role, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+			c := e.NewContext(req, httptest.NewRecorder())
+
+			withRole(c, role)
+
+			_, err := runAdminMiddleware(c)
+			if err == nil {
+				t.Fatalf("expected error for role %q", role)
+			}
+			he, ok := err.(*echo.HTTPError)
+			if !ok || he.Code != http.StatusForbidden {
+				t.Errorf("role %q: expected 403, got %v", role, err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/http/middleware/ctxkeys.go
+++ b/internal/infrastructure/http/middleware/ctxkeys.go
@@ -1,0 +1,87 @@
+// Context-key plumbing for request-scoped identity values populated by
+// TenantMiddleware and consumed by handlers (and any subsequent
+// middleware in the chain — RequireTenant, AdminAuthMiddleware).
+//
+// Why a unique key namespace:
+//
+//	echo.Context's Set/Get accept arbitrary string keys. Two middleware
+//	authors picking the same key ("user_id") would silently collide. We
+//	therefore namespace the platform identity keys under "platform." so
+//	they can't clash with the legacy auth.go middleware's keys
+//	("user_id", "username", "email", "roles", "auth_type"). All reads MUST
+//	go through the typed accessors below — handlers should never call
+//	c.Get("platform.user_id") directly.
+package middleware
+
+import "github.com/labstack/echo/v4"
+
+const (
+	ctxKeyPlatformUserID   = "platform.user_id"
+	ctxKeyPlatformTenantID = "platform.tenant_id"
+	ctxKeyPlatformRole     = "platform.role"
+	ctxKeyPlatformEmail    = "platform.email"
+)
+
+// withUserID stores the authenticated user_id in request scope.
+func withUserID(c echo.Context, id string) {
+	c.Set(ctxKeyPlatformUserID, id)
+}
+
+// withTenantID stores the user's active tenant_id. Empty string is a
+// valid value (pending user — see TenantIDFromCtx).
+func withTenantID(c echo.Context, id string) {
+	c.Set(ctxKeyPlatformTenantID, id)
+}
+
+// withRole stores the authorisation tier ("user" | "admin").
+func withRole(c echo.Context, role string) {
+	c.Set(ctxKeyPlatformRole, role)
+}
+
+// withEmail stores the user's verified email address.
+func withEmail(c echo.Context, email string) {
+	c.Set(ctxKeyPlatformEmail, email)
+}
+
+// UserIDFromCtx returns the authenticated user_id and whether it was set.
+// The bool is false when no TenantMiddleware ran for this request.
+func UserIDFromCtx(c echo.Context) (string, bool) {
+	s, ok := c.Get(ctxKeyPlatformUserID).(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// TenantIDFromCtx returns the user's tenant_id and whether it's present.
+//
+// IMPORTANT: ("", false) is a normal state for pending users (signup not
+// yet approved by an operator). It does NOT signal an authentication
+// failure — TenantMiddleware will already have populated user_id, role,
+// and email for such users. Route guards (RequireTenant) decide whether
+// to allow the request given the absence of tenant_id.
+func TenantIDFromCtx(c echo.Context) (string, bool) {
+	s, ok := c.Get(ctxKeyPlatformTenantID).(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// RoleFromCtx returns the authorisation tier ("user" or "admin").
+func RoleFromCtx(c echo.Context) (string, bool) {
+	s, ok := c.Get(ctxKeyPlatformRole).(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// EmailFromCtx returns the user's email and whether it was set.
+func EmailFromCtx(c echo.Context) (string, bool) {
+	s, ok := c.Get(ctxKeyPlatformEmail).(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/internal/infrastructure/http/middleware/tenant.go
+++ b/internal/infrastructure/http/middleware/tenant.go
@@ -1,0 +1,180 @@
+// TenantMiddleware + RequireTenant — the authentication-and-authorisation
+// pair that guards platform.duragraph.ai routes.
+//
+// Layered design (mirrors auth/oauth.yml § session and auth/jwt.yml):
+//
+//  1. TenantMiddleware verifies the bearer JWT (or session cookie),
+//     populates the request context with the four identity claims
+//     (user_id, tenant_id, role, email), and rejects requests with a
+//     missing or invalid token. It does NOT enforce tenant_id presence —
+//     pending users (signup not yet approved) carry valid tokens with
+//     tenant_id="" and need to reach /api/platform/me, /api/auth/logout,
+//     etc. so the dashboard can render their "awaiting approval" state.
+//
+//  2. RequireTenant is a route-level guard applied to /api/v1/* (and any
+//     other group that requires a provisioned tenant). It rejects
+//     requests whose ctx lacks a tenant_id with 403 Forbidden. The status
+//     distinction matters: 401 = missing/bad token, 403 = valid token but
+//     no tenant. Spec auth/jwt.yml § lifecycle.invalid mandates 401 for
+//     unauthenticated requests; spec models the no-tenant case as
+//     "tenant not provisioned" → 403.
+//
+// Bearer-vs-cookie precedence (spec auth/oauth.yml § session): the
+// Authorization header WINS when both transports are present. Headless
+// callers being explicit shouldn't have their token shadowed by a stale
+// cookie.
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/duragraph/duragraph/internal/infrastructure/auth"
+	"github.com/labstack/echo/v4"
+)
+
+// SessionCookieName is the cookie that carries the platform JWT for
+// browser sessions. Set by the platform auth callback handler (per spec
+// auth/oauth.yml § session.primary_transport.name).
+const SessionCookieName = "duragraph_session"
+
+// transportContextKey stores which transport (bearer / cookie) the JWT
+// arrived on. Not part of the identity claims — kept under its own key
+// so it can't be confused with them. Surfaced to handlers via
+// TransportFromCtx for downstream cookie-rotation logic.
+const transportContextKey = "platform.transport"
+
+// TransportBearer / TransportCookie are the values stored under
+// transportContextKey.
+const (
+	TransportBearer = "bearer"
+	TransportCookie = "cookie"
+)
+
+// TenantMiddleware verifies the platform session JWT and populates the
+// request context with the four identity claims.
+//
+// Behaviour:
+//
+//   - No token (no Authorization header AND no duragraph_session cookie):
+//     401 Unauthorized.
+//   - Invalid token (bad signature, expired, wrong issuer, malformed):
+//     401 Unauthorized.
+//   - Valid token: claims attached to ctx via the withXxx helpers.
+//     Request proceeds to the next handler. If tenant_id is absent
+//     (pending user), the request still proceeds — RequireTenant decides
+//     route-level access.
+//
+// Returns an echo.MiddlewareFunc rather than wrapping it in a struct;
+// matches the surrounding idiom (auth.go, request_id.go, security.go).
+func TenantMiddleware(verifier *auth.Verifier) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			tokenString, transport := extractToken(c)
+			if tokenString == "" {
+				return echo.NewHTTPError(http.StatusUnauthorized, "missing session token")
+			}
+
+			claims, err := verifier.Verify(tokenString)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusUnauthorized, classifyVerifyError(err))
+			}
+
+			withUserID(c, claims.UserID)
+			withTenantID(c, claims.TenantID)
+			withRole(c, claims.Role)
+			withEmail(c, claims.Email)
+			c.Set(transportContextKey, transport)
+
+			return next(c)
+		}
+	}
+}
+
+// RequireTenant is a route-level guard that rejects requests whose ctx
+// lacks a tenant_id (pending users). MUST be applied AFTER
+// TenantMiddleware, since it reads the value TenantMiddleware writes.
+//
+// The 403 (vs 401) is deliberate: the user IS authenticated, they just
+// don't have a provisioned tenant yet. 401 would tell the dashboard to
+// log them out; 403 lets the dashboard render an "awaiting approval"
+// page using their identity from /api/platform/me.
+func RequireTenant() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if _, ok := TenantIDFromCtx(c); !ok {
+				return echo.NewHTTPError(http.StatusForbidden, "tenant not provisioned")
+			}
+			return next(c)
+		}
+	}
+}
+
+// TransportFromCtx returns "bearer" or "cookie" depending on how the JWT
+// reached the server, or ("", false) if no TenantMiddleware ran.
+func TransportFromCtx(c echo.Context) (string, bool) {
+	s, ok := c.Get(transportContextKey).(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// extractToken pulls the bearer token from either the Authorization
+// header or the session cookie, returning ("", "") when neither is
+// present.
+//
+// Header wins over cookie when both are present (spec auth/oauth.yml §
+// session.api_client_alternative.notes). The transport string is
+// returned for downstream telemetry / cookie-rotation logic.
+func extractToken(c echo.Context) (string, string) {
+	// Authorization: Bearer <jwt>
+	if authHeader := c.Request().Header.Get("Authorization"); authHeader != "" {
+		// Case-insensitive scheme match — "bearer", "Bearer", "BEARER"
+		// all work, matching the lenient HTTP convention.
+		const prefix = "bearer "
+		if len(authHeader) > len(prefix) && strings.EqualFold(authHeader[:len(prefix)], prefix) {
+			tok := strings.TrimSpace(authHeader[len(prefix):])
+			if tok != "" {
+				return tok, TransportBearer
+			}
+		}
+		// Header present but malformed — treat as no-token rather than
+		// transparently falling through to the cookie. A half-formed
+		// Bearer header is more likely a buggy SDK than an intentional
+		// cookie-auth attempt, and silently masking it would make that
+		// bug harder to diagnose.
+		return "", ""
+	}
+
+	// duragraph_session cookie
+	if cookie, err := c.Cookie(SessionCookieName); err == nil && cookie != nil {
+		if cookie.Value != "" {
+			return cookie.Value, TransportCookie
+		}
+	}
+
+	return "", ""
+}
+
+// classifyVerifyError converts the typed auth-package errors into a
+// short, non-leaky message for the 401 response body. We deliberately
+// don't echo the raw library error string — those can include token
+// fragments or library internals we'd rather not surface.
+func classifyVerifyError(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrTokenExpired):
+		return "token expired"
+	case errors.Is(err, auth.ErrTokenWrongIssuer):
+		return "token issuer mismatch"
+	case errors.Is(err, auth.ErrTokenInvalidSignature):
+		return "invalid token"
+	case errors.Is(err, auth.ErrTokenMissingClaim):
+		return "invalid token"
+	case errors.Is(err, auth.ErrTokenMalformed):
+		return "invalid token"
+	default:
+		return "invalid token"
+	}
+}

--- a/internal/infrastructure/http/middleware/tenant_test.go
+++ b/internal/infrastructure/http/middleware/tenant_test.go
@@ -1,0 +1,420 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/infrastructure/auth"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// testSecret is the shared HMAC key used across all middleware tests.
+// Keep it short and obviously-test (no env access — these are pure unit
+// tests).
+const testSecret = "tenant-middleware-test-secret"
+
+// newTestVerifier mints an *auth.Verifier the middleware can consume.
+// Helper rather than inline so tests stay tight.
+func newTestVerifier(t *testing.T) *auth.Verifier {
+	t.Helper()
+	v, err := auth.NewVerifier([]byte(testSecret))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return v
+}
+
+// signClaims builds a token with the canonical Claims shape. The default
+// case is a fully-populated approved user; cases override fields.
+func signClaims(t *testing.T, override func(*auth.Claims)) string {
+	t.Helper()
+	claims := &auth.Claims{
+		UserID:   "user-123",
+		TenantID: "tenant-abc",
+		Role:     "user",
+		Email:    "alice@example.com",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    auth.IssuerDuragraphPlatform,
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	if override != nil {
+		override(claims)
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte(testSecret))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+// runMiddleware wires TenantMiddleware in front of a probe handler that
+// records what it sees in ctx. Returns the recorder + the captured ctx
+// values so each test can assert on whatever it cares about.
+func runMiddleware(t *testing.T, req *http.Request, v *auth.Verifier) (*httptest.ResponseRecorder, map[string]string, error) {
+	t.Helper()
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	captured := make(map[string]string)
+	probe := func(c echo.Context) error {
+		if v, ok := UserIDFromCtx(c); ok {
+			captured["user_id"] = v
+		}
+		if v, ok := TenantIDFromCtx(c); ok {
+			captured["tenant_id"] = v
+		}
+		if v, ok := RoleFromCtx(c); ok {
+			captured["role"] = v
+		}
+		if v, ok := EmailFromCtx(c); ok {
+			captured["email"] = v
+		}
+		if v, ok := TransportFromCtx(c); ok {
+			captured["transport"] = v
+		}
+		return c.NoContent(http.StatusOK)
+	}
+	err := TenantMiddleware(v)(probe)(c)
+	return rec, captured, err
+}
+
+// TestTenantMiddleware_NoToken — neither header nor cookie present.
+// Spec auth/jwt.yml § lifecycle.invalid: 401.
+func TestTenantMiddleware_NoToken(t *testing.T) {
+	v := newTestVerifier(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+
+	_, _, err := runMiddleware(t, req, v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+// TestTenantMiddleware_BearerValid — happy path: Authorization Bearer
+// with an approved user's token populates all four identity values.
+func TestTenantMiddleware_BearerValid(t *testing.T) {
+	v := newTestVerifier(t)
+	tok := signClaims(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	rec, captured, err := runMiddleware(t, req, v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if captured["user_id"] != "user-123" {
+		t.Errorf("user_id: got %q", captured["user_id"])
+	}
+	if captured["tenant_id"] != "tenant-abc" {
+		t.Errorf("tenant_id: got %q", captured["tenant_id"])
+	}
+	if captured["role"] != "user" {
+		t.Errorf("role: got %q", captured["role"])
+	}
+	if captured["email"] != "alice@example.com" {
+		t.Errorf("email: got %q", captured["email"])
+	}
+	if captured["transport"] != TransportBearer {
+		t.Errorf("transport: got %q want %q", captured["transport"], TransportBearer)
+	}
+}
+
+// TestTenantMiddleware_ExpiredToken — exp in the past must yield 401.
+func TestTenantMiddleware_ExpiredToken(t *testing.T) {
+	v := newTestVerifier(t)
+	tok := signClaims(t, func(c *auth.Claims) {
+		c.IssuedAt = jwt.NewNumericDate(time.Now().Add(-2 * time.Hour))
+		c.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-time.Hour))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	_, _, err := runMiddleware(t, req, v)
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+// TestTenantMiddleware_WrongIssuer — even a properly signed token must
+// be rejected if iss is not duragraph-platform.
+func TestTenantMiddleware_WrongIssuer(t *testing.T) {
+	v := newTestVerifier(t)
+	tok := signClaims(t, func(c *auth.Claims) {
+		c.Issuer = "some-other-product"
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	_, _, err := runMiddleware(t, req, v)
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+// TestTenantMiddleware_PendingUser — token with empty tenant_id passes
+// through (pending users need to reach /api/platform/me etc.).
+// TenantIDFromCtx returns ("", false); the request reaches the probe.
+func TestTenantMiddleware_PendingUser(t *testing.T) {
+	v := newTestVerifier(t)
+	tok := signClaims(t, func(c *auth.Claims) {
+		c.TenantID = ""
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/platform/me", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	rec, captured, err := runMiddleware(t, req, v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if captured["user_id"] != "user-123" {
+		t.Errorf("user_id should still populate for pending user, got %q", captured["user_id"])
+	}
+	if _, ok := captured["tenant_id"]; ok {
+		t.Errorf("tenant_id should NOT be present for pending user, got %q", captured["tenant_id"])
+	}
+	if captured["role"] != "user" {
+		t.Errorf("role: got %q", captured["role"])
+	}
+}
+
+// TestTenantMiddleware_CookieValid — cookie-based session works
+// equivalently to bearer for browser clients.
+func TestTenantMiddleware_CookieValid(t *testing.T) {
+	v := newTestVerifier(t)
+	tok := signClaims(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/platform/me", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: tok})
+
+	rec, captured, err := runMiddleware(t, req, v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if captured["user_id"] != "user-123" {
+		t.Errorf("user_id: got %q", captured["user_id"])
+	}
+	if captured["transport"] != TransportCookie {
+		t.Errorf("transport: got %q want %q", captured["transport"], TransportCookie)
+	}
+}
+
+// TestTenantMiddleware_BearerWinsOverCookie — when both transports are
+// present, the bearer header is the one that gets verified. We confirm
+// this by giving the cookie an INVALID token (signed with the wrong
+// secret) and the header a VALID one — if cookie won, the request would
+// 401; if bearer wins, it succeeds. Spec auth/oauth.yml §
+// session.api_client_alternative.notes mandates bearer-wins.
+func TestTenantMiddleware_BearerWinsOverCookie(t *testing.T) {
+	v := newTestVerifier(t)
+	validBearer := signClaims(t, nil)
+
+	// Cookie with a token signed by a different secret — would 401 if
+	// cookie were the source we verified.
+	bogus := jwt.NewWithClaims(jwt.SigningMethodHS256, &auth.Claims{
+		UserID: "evil-user",
+		Role:   "admin",
+		Email:  "evil@example.com",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    auth.IssuerDuragraphPlatform,
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+	bogusSigned, err := bogus.SignedString([]byte("wrong-secret"))
+	if err != nil {
+		t.Fatalf("sign bogus: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+validBearer)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: bogusSigned})
+
+	rec, captured, runErr := runMiddleware(t, req, v)
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if captured["user_id"] != "user-123" {
+		t.Errorf("expected bearer's user_id, got %q (cookie wrongly took precedence?)", captured["user_id"])
+	}
+	if captured["transport"] != TransportBearer {
+		t.Errorf("transport: got %q want %q", captured["transport"], TransportBearer)
+	}
+}
+
+// TestTenantMiddleware_BadSignature — token signed with wrong key is
+// rejected with 401.
+func TestTenantMiddleware_BadSignature(t *testing.T) {
+	v := newTestVerifier(t)
+
+	bogus := jwt.NewWithClaims(jwt.SigningMethodHS256, &auth.Claims{
+		UserID: "u",
+		Role:   "user",
+		Email:  "a@b",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    auth.IssuerDuragraphPlatform,
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+	signed, err := bogus.SignedString([]byte("wrong-secret"))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+
+	_, _, runErr := runMiddleware(t, req, v)
+	he, ok := runErr.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", runErr)
+	}
+}
+
+// TestTenantMiddleware_MalformedHeader — "Bearer" without a token, or a
+// non-Bearer scheme: 401.
+func TestTenantMiddleware_MalformedHeader(t *testing.T) {
+	v := newTestVerifier(t)
+
+	cases := []string{
+		"Bearer",        // missing token
+		"Bearer ",       // empty token
+		"Basic abcdef",  // wrong scheme
+		"Token xyz",     // wrong scheme
+		"NotBearer foo", // close but no
+	}
+	for _, h := range cases {
+		t.Run(h, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+			req.Header.Set("Authorization", h)
+			_, _, err := runMiddleware(t, req, v)
+			he, ok := err.(*echo.HTTPError)
+			if !ok || he.Code != http.StatusUnauthorized {
+				t.Errorf("header %q: expected 401, got %v", h, err)
+			}
+		})
+	}
+}
+
+// TestRequireTenant_PassesWithTenant — the happy path for a downstream
+// route guard.
+func TestRequireTenant_PassesWithTenant(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	withTenantID(c, "tenant-abc")
+
+	called := false
+	mw := RequireTenant()(func(_ echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	if err := mw(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("downstream handler should have been called")
+	}
+}
+
+// TestRequireTenant_RejectsPendingUser — the 403 case.
+func TestRequireTenant_RejectsPendingUser(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Simulate TenantMiddleware having run for a pending user: user_id
+	// and role populated, but tenant_id empty.
+	withUserID(c, "pending-user")
+	withRole(c, "user")
+	withEmail(c, "bob@example.com")
+	withTenantID(c, "") // pending — empty
+
+	called := false
+	mw := RequireTenant()(func(_ echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	err := mw(c)
+	if err == nil {
+		t.Fatal("expected error for pending user")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %v", err)
+	}
+	if called {
+		t.Error("downstream handler should NOT have been called")
+	}
+}
+
+// TestRequireTenant_RejectsUnauthenticated — RequireTenant without
+// TenantMiddleware in front (a misconfiguration) MUST still fail-safe.
+func TestRequireTenant_RejectsUnauthenticated(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	mw := RequireTenant()(func(_ echo.Context) error {
+		t.Fatal("downstream must not be called")
+		return nil
+	})
+	err := mw(c)
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %v", err)
+	}
+}
+
+// TestCtxAccessors_EmptyContext — accessors return false on a fresh ctx.
+func TestCtxAccessors_EmptyContext(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	if _, ok := UserIDFromCtx(c); ok {
+		t.Error("UserIDFromCtx on empty ctx should return false")
+	}
+	if _, ok := TenantIDFromCtx(c); ok {
+		t.Error("TenantIDFromCtx on empty ctx should return false")
+	}
+	if _, ok := RoleFromCtx(c); ok {
+		t.Error("RoleFromCtx on empty ctx should return false")
+	}
+	if _, ok := EmailFromCtx(c); ok {
+		t.Error("EmailFromCtx on empty ctx should return false")
+	}
+}


### PR DESCRIPTION
## Summary

Wave 1 of v1.0-platform: introduces the JWT verification + per-request authorization layer that consumes the platform session token minted by the forthcoming OAuth callback handler. Adds three Echo middlewares — `TenantMiddleware`, `RequireTenant`, `AdminAuthMiddleware` — plus the typed `auth.Claims` / `IssueJWT` / `VerifyJWT` / `Verifier` primitives backing them. Wires them into `cmd/server/main.go` behind the existing `AUTH_ENABLED` flag.

**Do not merge.**

## Files

**Created:**
- `internal/infrastructure/auth/jwt.go` — `Claims`, `IssueJWT`, `VerifyJWT`, `Verifier`, sentinel errors.
- `internal/infrastructure/auth/jwt_test.go` — 12 test funcs.
- `internal/infrastructure/http/middleware/ctxkeys.go` — namespaced ctx accessors (`UserIDFromCtx`, `TenantIDFromCtx`, `RoleFromCtx`, `EmailFromCtx`).
- `internal/infrastructure/http/middleware/tenant.go` — `TenantMiddleware`, `RequireTenant`, `TransportFromCtx`.
- `internal/infrastructure/http/middleware/tenant_test.go` — 13 test funcs.
- `internal/infrastructure/http/middleware/admin_auth.go` — `AdminAuthMiddleware`, `RoleAdmin` constant.
- `internal/infrastructure/http/middleware/admin_auth_test.go` — 4 test funcs.

**Modified:**
- `internal/infrastructure/auth/oauth.go` — `generateJWT` now uses `IssueJWT` with the spec-canonical claim shape (replaces the old `{user_id, email, name, provider, exp, iat}` format). `name` and `provider` are no longer carried in the JWT.
- `cmd/server/main.go` — `AUTH_ENABLED=true` constructs a `Verifier`, applies `TenantMiddleware + RequireTenant` to `/api/v1`, and wires an empty `/api/admin` group with `TenantMiddleware + AdminAuthMiddleware`. The legacy `OptionalAuth` is no longer wired.

## Behavior

### JWT claim shape

Per `duragraph-spec/auth/jwt.yml` (HS256, snake_case fields):

```
{ user_id, tenant_id, role, email, iat, exp, iss }
```

- `iss` MUST equal the constant `duragraph-platform`. The verifier checks this explicitly (golang-jwt v5's default validator does NOT enforce iss without `jwt.WithIssuer`).
- `tenant_id` is optional/empty for pending users (signup not yet approved). The verifier accepts the empty value; `RequireTenant` enforces presence at the route layer.
- `role` is `user` or `admin`.
- The previous `name` and `provider` claims are dropped — they were never consumed by the engine middleware. A grep confirmed nothing outside the auth package or its tests reads them from the JWT.

### Middleware chain

| Route family       | Auth (when `AUTH_ENABLED=true`)                     | Pending user (no `tenant_id`) | Non-admin user        |
|--------------------|-----------------------------------------------------|-------------------------------|-----------------------|
| `/health`, `/metrics`, `/ok`, `/info`, `/mcp` | none                                | passes                        | passes                |
| `/api/v1/*`        | `TenantMiddleware` + `RequireTenant`                | 403 (tenant not provisioned)  | passes (role check is admin-only) |
| `/api/admin/*` (empty group, ready for next PR) | `TenantMiddleware` + `AdminAuthMiddleware`          | 403 (admin access required)   | 403                   |

- 401 = missing or invalid token.
- 403 = valid token but insufficient (no tenant or wrong role).
- Bearer header WINS over `duragraph_session` cookie when both are present (per `auth/oauth.yml § session.api_client_alternative.notes`).

### `OAuthManager.CallbackHandler` stub note

This handler is not currently mounted on any route in `main.go`. It predates the platform model and lacks the User/Tenant lookup, bootstrap-first-user rule, and pending/approved/suspended decision tree. As an interim measure, `generateJWT` now mints `role="user"` and `tenant_id=""` for every callback (treating every login as pending). `RequireTenant` blocks `/api/v1/*` downstream, so the stub cannot grant unintended access. The full callback flow lands in the next PR alongside the `handlers/auth/*` package.

### Side effect: routes outside `/api/v1` and `/api/admin`

The previous wiring applied `e.Use(OptionalAuth(...))` globally. Now `TenantMiddleware` is group-scoped, so `/mcp`, `/ok`, `/info`, `/health`, `/metrics` no longer populate any auth ctx. Functionally a no-op — no handler on those routes reads the legacy ctx keys.

### Backwards compat

- `AUTH_ENABLED=false` (default) skips all platform middleware. Single-tenant deployments unchanged.
- The new middleware is **NOT** gated by `MIGRATOR_PLATFORM_ENABLED`. The two flags are orthogonal: `AUTH_ENABLED` gates JWT verification, the migrator flag gates platform-DB provisioning.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -short ./...` — entire repo green
- [x] 29 new test functions in this PR all pass:
  - 12 in `jwt_test.go` (round-trip, pending user, missing-field guards, expired, wrong issuer, bad signature, malformed, alg=none rejection, missing-required-claim, `NewVerifier` empty-secret guard, `Verifier.Verify`, dropped-legacy-claims regression)
  - 13 in `tenant_test.go` (no token, valid bearer, expired, wrong issuer, pending user pass-through, valid cookie, bearer-wins-over-cookie, bad signature, malformed-header table, `RequireTenant` pass/reject/unauthenticated, ctx accessors on empty ctx)
  - 4 in `admin_auth_test.go` (admin passes, user rejected, missing role, unknown roles)
- [x] Existing `auth_test.go` and `auth/auth_test.go` (legacy `JWT()` / `OptionalAuth` / `APIKeyAuth` and `TestGenerateJWT`) still green
- [x] Pre-commit hooks (gofmt, goimports, go-mod-tidy, go vet, secret detect, commitizen) all passed

Manual verification deferred to a follow-up integration test PR — these unit tests exercise every documented behavior path.

## Cross-references

- Spec: `duragraph-spec/auth/jwt.yml` and `auth/oauth.yml` — the contract this PR implements (the verify side; minting lands in the next PR).
- Engine PR #150 — set up the `MIGRATOR_PLATFORM_ENABLED` env handling pattern this PR follows for `AUTH_ENABLED` orthogonality.
- Wave 1 predecessors: #147–#152 (Tenant/User aggregates, repos, migrations, migrator).

## Do NOT merge

Holding for review and the follow-up `handlers/auth/*` PR that will wire the OAuth callback to mint tokens of this shape.