### PR TITLE
feat: add admin orchestrator commands + tenant provisioner subscriber

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -206,6 +206,73 @@ func main() {
 
 	fmt.Println("✅ Outbox relay worker started")
 
+	// Platform-mode wiring: connect a separate pool to the platform DB
+	// (`duragraph_platform`) so the User/Tenant repositories can drive
+	// platform-admin commands and so the tenant-provisioner subscriber
+	// can complete the async provisioning workflow kicked off by an
+	// admin's Approve click.
+	//
+	// Gated behind MIGRATOR_PLATFORM_ENABLED — same flag the migrator
+	// uses for Bootstrap and MigrateAllTenants. The platform pool, the
+	// User/Tenant repositories and the TenantProvisioner are all
+	// optional today; existing single-DB deployments continue to work
+	// unchanged when the flag is off.
+	//
+	// When the flag is on, this block establishes:
+	//   - `platformPool` — pgxpool against the duragraph_platform DB
+	//   - userRepo + tenantRepo — projection writers for platform.users
+	//     and platform.tenants
+	//   - tenantProvisioner — NATS subscriber that turns
+	//     tenant.provisioning events into CREATE DATABASE + migrate +
+	//     (stubbed) NATS Account creation, then approves the tenant.
+	//
+	// The HTTP admin handlers (POST /api/admin/users/.../approve etc.)
+	// are NOT wired here — that's the next PR (feat/admin-handlers).
+	// The repos and the publisher are constructed so the handlers can
+	// pick them up; the publisher reused for command-side publishing
+	// is the existing `publisher` constructed above.
+	if platformEnabled {
+		platformConfig := postgres.Config{
+			Host:     cfg.Database.Host,
+			Port:     cfg.Database.Port,
+			User:     cfg.Database.User,
+			Password: cfg.Database.Password,
+			Database: "duragraph_platform",
+			SSLMode:  cfg.Database.SSLMode,
+		}
+		platformPool, err := postgres.NewPool(ctx, platformConfig)
+		if err != nil {
+			log.Fatalf("failed to connect to platform DB: %v", err)
+		}
+		defer platformPool.Close()
+		fmt.Println("✅ Platform DB connected (duragraph_platform)")
+
+		userRepo := postgres.NewUserRepository(platformPool)
+		tenantRepo := postgres.NewTenantRepository(platformPool)
+
+		// Suppress unused-variable warnings until feat/admin-handlers
+		// wires the HTTP handlers that consume these.
+		_ = userRepo
+		_ = tenantRepo
+
+		// Tenant provisioner subscriber. The migrator instance built
+		// above is reused — its ProvisionTenant + MigrateTenant methods
+		// are exactly what the subscriber needs.
+		tenantProvisioner := messaging.NewTenantProvisioner(
+			subscriber,
+			tenantRepo,
+			migrator,
+			messaging.NoopNATSAccountProvisioner{}, // operator-JWT wiring is a follow-up PR
+			log.Default(),
+		)
+		go func() {
+			if err := tenantProvisioner.Run(ctx); err != nil && ctx.Err() == nil {
+				log.Printf("tenant provisioner error: %v", err)
+			}
+		}()
+		fmt.Println("✅ Tenant provisioner subscriber started")
+	}
+
 	// Start cleanup worker
 	cleanupWorker := messaging.NewCleanupWorker(outbox, 1*time.Hour, 7)
 	go func() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -255,11 +255,27 @@ func main() {
 		_ = userRepo
 		_ = tenantRepo
 
-		// Tenant provisioner subscriber. The migrator instance built
-		// above is reused — its ProvisionTenant + MigrateTenant methods
-		// are exactly what the subscriber needs.
+		// Tenant provisioner subscriber. Uses a JetStream durable
+		// consumer (durable name "tenant-provisioner") bound to the
+		// existing duragraph-events stream — so tenant.provisioning
+		// events published while the engine was offline still get
+		// delivered when it comes back. Separate from the plain-NATS
+		// `subscriber` used by run/execution events because the
+		// platform-admin loop needs at-least-once durability.
+		jsSubscriber, err := nats.NewJetStreamSubscriber(nats.JetStreamSubscriberConfig{
+			URL:           cfg.NATS.URL,
+			StreamName:    messaging.JetStreamStreamName,
+			FilterSubject: messaging.TenantProvisioningTopic,
+			Durable:       messaging.DurableName,
+			MaxDeliver:    10, // bound poison-message redelivery loops
+		})
+		if err != nil {
+			log.Fatalf("failed to construct tenant provisioner JetStream subscriber: %v", err)
+		}
+		defer jsSubscriber.Close()
+
 		tenantProvisioner := messaging.NewTenantProvisioner(
-			subscriber,
+			jsSubscriber,
 			tenantRepo,
 			migrator,
 			messaging.NoopNATSAccountProvisioner{}, // operator-JWT wiring is a follow-up PR
@@ -270,7 +286,7 @@ func main() {
 				log.Printf("tenant provisioner error: %v", err)
 			}
 		}()
-		fmt.Println("✅ Tenant provisioner subscriber started")
+		fmt.Println("✅ Tenant provisioner JetStream subscriber started (durable: tenant-provisioner)")
 	}
 
 	// Start cleanup worker

--- a/internal/application/command/approve_user.go
+++ b/internal/application/command/approve_user.go
@@ -31,10 +31,16 @@
 //     RetryTenantMigration is for, so keeping that responsibility on
 //     one endpoint avoids accidental double-publishes from impatient
 //     admin clicks.
+//   - If user.Status == approved AND a tenant exists in
+//     `provisioning_failed`: defensively fall through to
+//     StartProvisioning + publish so a half-failed prior approval can
+//     recover by re-clicking Approve. (The dedicated retry-migration
+//     endpoint is the primary path; this is a safety net for admins
+//     who didn't notice the failure on the first click.)
 //   - If user.Status == approved AND a tenant exists in `approved` /
-//     `provisioning_failed` / `suspended` / `pending`: not a re-approve
-//     scenario; admin should use the retry-migration / resume / suspend
-//     endpoints instead. We return an InvalidState error.
+//     `suspended` / `pending`: not a re-approve scenario; admin should
+//     use the resume / suspend endpoints instead. We return an
+//     InvalidState error.
 //   - If user.Status != pending and != approved (i.e. suspended): the
 //     state machine on user.Approve will reject — no separate guard
 //     needed.
@@ -68,16 +74,17 @@ type EventPublisher interface {
 }
 
 // TenantProvisioningTopic is the NATS subject the platform-provisioner
-// subscriber listens on. The asyncapi spec specifies bare
-// `tenant.provisioning` in a `PLATFORM_TENANTS` JetStream stream that
-// does not yet exist in this engine's runtime; the engine's
-// publisher.ensureStreams only declares `duragraph-events`,
+// subscriber listens on as a JetStream durable consumer. The asyncapi
+// spec specifies bare `tenant.provisioning` in a `PLATFORM_TENANTS`
+// JetStream stream that does not yet exist in this engine's runtime;
+// the engine's publisher.ensureStreams declares `duragraph-events`,
 // `duragraph-executions`, `duragraph-runs`, and `duragraph-stream`. We
 // publish under `duragraph.events.tenant.provisioning` so the message
 // is captured by the existing `duragraph-events` stream (subjects
-// `duragraph.events.>`) and survives broker restart. A follow-up PR
-// will reconcile by adding the PLATFORM_TENANTS stream and switching to
-// the bare subject — at which point this constant changes in one place.
+// `duragraph.events.>`) and the consumer is durable — together that
+// gives at-least-once delivery across broker restarts. A follow-up PR
+// will reconcile the spec by adding the PLATFORM_TENANTS stream and
+// switching to the bare subject; this constant changes in one place.
 const TenantProvisioningTopic = "duragraph.events.tenant.provisioning"
 
 // ApproveUser is the input command for ApproveUserHandler.
@@ -98,14 +105,19 @@ type ApproveUserHandler struct {
 	publisher  EventPublisher
 }
 
-// NewApproveUserHandler constructs an ApproveUserHandler. publisher may
-// be nil only in unit tests that explicitly assert publisher==nil
-// short-circuits; production wiring always passes the real publisher.
+// NewApproveUserHandler constructs an ApproveUserHandler. Panics if
+// publisher is nil — a misconfigured handler that silently drops the
+// provisioning trigger appears to succeed but never starts the async
+// workflow, which is a footgun. Production wiring and unit tests both
+// pass an EventPublisher (real or mock).
 func NewApproveUserHandler(
 	userRepo user.Repository,
 	tenantRepo tenant.Repository,
 	publisher EventPublisher,
 ) *ApproveUserHandler {
+	if publisher == nil {
+		panic("command.NewApproveUserHandler: publisher must not be nil")
+	}
 	return &ApproveUserHandler{
 		userRepo:   userRepo,
 		tenantRepo: tenantRepo,
@@ -130,19 +142,26 @@ func (h *ApproveUserHandler) Handle(ctx context.Context, cmd ApproveUser) error 
 		return err
 	}
 
-	// Idempotency short-circuit: user already approved + tenant already
-	// in provisioning. No-op success — re-driving a stuck subscriber is
-	// the RetryTenantMigration endpoint's job; keeping Approve out of
-	// that loop avoids accidental double-publishes when an admin
-	// double-clicks the Approve button.
+	// Idempotency short-circuit: user already approved.
+	//   - tenant in `provisioning` → no-op success (double-click /
+	//     retry of an in-flight approval).
+	//   - tenant in `provisioning_failed` → fall through to
+	//     StartProvisioning + publish so a half-failed prior approval
+	//     can recover by re-clicking Approve.
+	//   - tenant missing → fall through (bootstrap-half-done).
+	//   - tenant in any other state → InvalidState; admin should use
+	//     resume / suspend.
 	if u.Status() == user.StatusApproved {
 		existing, getErr := h.tenantRepo.GetByUserID(ctx, cmd.UserID)
 		switch {
 		case getErr == nil && existing.Status() == tenant.StatusProvisioning:
 			return nil
+		case getErr == nil && existing.Status() == tenant.StatusProvisioningFailed:
+			// Fall through: re-emit StartProvisioning + publish below.
+			// The state machine on tenant.StartProvisioning permits
+			// provisioning_failed → provisioning, so this is safe.
 		case getErr == nil:
-			// User is approved but tenant is in some other state (approved,
-			// failed, suspended, pending). This is not a re-approve case.
+			// approved / suspended / pending: not a re-approve case.
 			return errors.InvalidState(string(existing.Status()), "approve")
 		case errors.Is(getErr, errors.ErrNotFound):
 			// Approved user with no tenant — drop through and create one.
@@ -197,11 +216,9 @@ func (h *ApproveUserHandler) Handle(ctx context.Context, cmd ApproveUser) error 
 // Payload shape mirrors tenant.TenantProvisioning (the canonical domain
 // event from internal/domain/tenant/events.go) so a future migration
 // to the outbox/audit-log path is a one-line topic change.
+//
+// Constructor guarantees h.publisher is non-nil; no nil check here.
 func (h *ApproveUserHandler) publishProvisioning(ctx context.Context, t *tenant.Tenant) error {
-	if h.publisher == nil {
-		// Unwired test path — caller asserted no publish.
-		return nil
-	}
 	payload := tenant.TenantProvisioning{
 		TenantID:   t.ID(),
 		OccurredAt: time.Now(),

--- a/internal/application/command/approve_user.go
+++ b/internal/application/command/approve_user.go
@@ -1,0 +1,213 @@
+// Package command — approve_user.go
+//
+// ApproveUserHandler is the platform admin orchestrator command for the
+// `pending → approved` user transition. It is the write side of
+// `POST /api/admin/users/{user_id}/approve` (see
+// duragraph-spec/api/platform.yaml).
+//
+// The transition has TWO aggregates in play and no shared transaction
+// primitive between the User and Tenant repositories (each Save is its
+// own tx; the repos are pure projection writers — see the headers on
+// internal/infrastructure/persistence/postgres/{user,tenant}_repository.go).
+// The handler therefore picks an order and documents the failure modes:
+//
+//  1. Save the User aggregate first. If this fails the operation is a
+//     no-op — admin sees an error, retries.
+//  2. Create or load the Tenant aggregate, call StartProvisioning, save.
+//     If this fails the User row is now `approved` with no associated
+//     tenant in `provisioning` state. The retry-migration endpoint and
+//     the idempotency short-circuit below let the operator recover by
+//     re-clicking Approve (the User stays approved, the Tenant moves
+//     pending → provisioning on the second pass).
+//  3. Publish `tenant.provisioning` to NATS for the platform-provisioner
+//     subscriber to pick up.
+//
+// Idempotency strategy:
+//   - If user.Status == approved AND a tenant exists already in
+//     `provisioning` status: the operation is a no-op success (handles
+//     the double-click / retry case where the first call partially
+//     succeeded or the response was lost in flight). No re-emission of
+//     events: re-driving a stuck subscriber is what
+//     RetryTenantMigration is for, so keeping that responsibility on
+//     one endpoint avoids accidental double-publishes from impatient
+//     admin clicks.
+//   - If user.Status == approved AND a tenant exists in `approved` /
+//     `provisioning_failed` / `suspended` / `pending`: not a re-approve
+//     scenario; admin should use the retry-migration / resume / suspend
+//     endpoints instead. We return an InvalidState error.
+//   - If user.Status != pending and != approved (i.e. suspended): the
+//     state machine on user.Approve will reject — no separate guard
+//     needed.
+//
+// Self-approval is blocked by user.Approve(); we do not double-check
+// here.
+//
+// Publishing path (deliberate departure from the outbox/event-store
+// flow used for run events): the User and Tenant repositories are
+// projection-only by design — they do not write to the outbox. The
+// audit-log mirror that consumes platform events lands in a follow-up
+// PR as a separate NATS subscriber. To kick off the async provisioning
+// workflow today we publish directly on the NATS publisher. See the
+// EventPublisher interface below.
+package command
+
+import (
+	"context"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// EventPublisher is the minimal pub surface needed by platform command
+// handlers. *nats.Publisher satisfies this interface, but using an
+// interface keeps the handler unit-testable without a NATS round-trip.
+type EventPublisher interface {
+	Publish(ctx context.Context, topic string, payload interface{}) error
+}
+
+// TenantProvisioningTopic is the NATS subject the platform-provisioner
+// subscriber listens on. The asyncapi spec specifies bare
+// `tenant.provisioning` in a `PLATFORM_TENANTS` JetStream stream that
+// does not yet exist in this engine's runtime; the engine's
+// publisher.ensureStreams only declares `duragraph-events`,
+// `duragraph-executions`, `duragraph-runs`, and `duragraph-stream`. We
+// publish under `duragraph.events.tenant.provisioning` so the message
+// is captured by the existing `duragraph-events` stream (subjects
+// `duragraph.events.>`) and survives broker restart. A follow-up PR
+// will reconcile by adding the PLATFORM_TENANTS stream and switching to
+// the bare subject — at which point this constant changes in one place.
+const TenantProvisioningTopic = "duragraph.events.tenant.provisioning"
+
+// ApproveUser is the input command for ApproveUserHandler.
+type ApproveUser struct {
+	// UserID is the platform.users row to approve.
+	UserID string
+
+	// ApprovedByUserID is the admin acting on this approval. Must not
+	// equal UserID (self-approval guard enforced by user.Approve).
+	ApprovedByUserID string
+}
+
+// ApproveUserHandler approves a pending user and kicks off async tenant
+// provisioning by publishing tenant.provisioning to NATS.
+type ApproveUserHandler struct {
+	userRepo   user.Repository
+	tenantRepo tenant.Repository
+	publisher  EventPublisher
+}
+
+// NewApproveUserHandler constructs an ApproveUserHandler. publisher may
+// be nil only in unit tests that explicitly assert publisher==nil
+// short-circuits; production wiring always passes the real publisher.
+func NewApproveUserHandler(
+	userRepo user.Repository,
+	tenantRepo tenant.Repository,
+	publisher EventPublisher,
+) *ApproveUserHandler {
+	return &ApproveUserHandler{
+		userRepo:   userRepo,
+		tenantRepo: tenantRepo,
+		publisher:  publisher,
+	}
+}
+
+// Handle approves the user, ensures a tenant exists, transitions the
+// tenant to provisioning, and publishes tenant.provisioning to NATS.
+func (h *ApproveUserHandler) Handle(ctx context.Context, cmd ApproveUser) error {
+	if cmd.UserID == "" {
+		return errors.InvalidInput("user_id", "user_id is required")
+	}
+	if cmd.ApprovedByUserID == "" {
+		return errors.InvalidInput("approved_by_user_id", "approved_by_user_id is required")
+	}
+
+	u, err := h.userRepo.GetByID(ctx, cmd.UserID)
+	if err != nil {
+		// Propagate NotFound / Internal as-is; the HTTP layer maps these
+		// to 404 / 500 respectively.
+		return err
+	}
+
+	// Idempotency short-circuit: user already approved + tenant already
+	// in provisioning. No-op success — re-driving a stuck subscriber is
+	// the RetryTenantMigration endpoint's job; keeping Approve out of
+	// that loop avoids accidental double-publishes when an admin
+	// double-clicks the Approve button.
+	if u.Status() == user.StatusApproved {
+		existing, getErr := h.tenantRepo.GetByUserID(ctx, cmd.UserID)
+		switch {
+		case getErr == nil && existing.Status() == tenant.StatusProvisioning:
+			return nil
+		case getErr == nil:
+			// User is approved but tenant is in some other state (approved,
+			// failed, suspended, pending). This is not a re-approve case.
+			return errors.InvalidState(string(existing.Status()), "approve")
+		case errors.Is(getErr, errors.ErrNotFound):
+			// Approved user with no tenant — drop through and create one.
+			// Mirrors the bootstrap-was-half-done recovery branch.
+		default:
+			return getErr
+		}
+	} else {
+		// Normal pending → approved path. user.Approve enforces the state
+		// machine and the self-approval guard.
+		if err := u.Approve(cmd.ApprovedByUserID); err != nil {
+			return err
+		}
+		if err := h.userRepo.Save(ctx, u); err != nil {
+			return errors.Internal("failed to save user", err)
+		}
+	}
+
+	// Ensure a tenant exists for this user. The OAuth bootstrap path may
+	// have created one inline; the normal pending path has not.
+	t, err := h.tenantRepo.GetByUserID(ctx, cmd.UserID)
+	if err != nil {
+		if !errors.Is(err, errors.ErrNotFound) {
+			return err
+		}
+		t, err = tenant.NewTenant(cmd.UserID)
+		if err != nil {
+			return errors.Internal("failed to create tenant", err)
+		}
+	}
+
+	// Transition pending → provisioning (or provisioning_failed →
+	// provisioning if this is the recovery branch of an approved user
+	// with a previously-failed tenant — though that case should normally
+	// be routed through retry-migration; we accept it here defensively).
+	if t.Status() == tenant.StatusProvisioning {
+		// Already moving — no-op success. Same idempotent rationale as
+		// the user.Status==approved short-circuit above.
+		return nil
+	}
+	if err := t.StartProvisioning(); err != nil {
+		return err
+	}
+	if err := h.tenantRepo.Save(ctx, t); err != nil {
+		return errors.Internal("failed to save tenant", err)
+	}
+
+	return h.publishProvisioning(ctx, t)
+}
+
+// publishProvisioning emits the tenant.provisioning event to NATS.
+// Payload shape mirrors tenant.TenantProvisioning (the canonical domain
+// event from internal/domain/tenant/events.go) so a future migration
+// to the outbox/audit-log path is a one-line topic change.
+func (h *ApproveUserHandler) publishProvisioning(ctx context.Context, t *tenant.Tenant) error {
+	if h.publisher == nil {
+		// Unwired test path — caller asserted no publish.
+		return nil
+	}
+	payload := tenant.TenantProvisioning{
+		TenantID:   t.ID(),
+		OccurredAt: time.Now(),
+	}
+	if err := h.publisher.Publish(ctx, TenantProvisioningTopic, payload); err != nil {
+		return errors.Internal("failed to publish tenant.provisioning", err)
+	}
+	return nil
+}

--- a/internal/application/command/platform_admin_test.go
+++ b/internal/application/command/platform_admin_test.go
@@ -160,15 +160,22 @@ func TestApproveUserHandler_AlreadyApprovedTenantInWrongState(t *testing.T) {
 	if err := uRepo.Save(context.Background(), pending); err != nil {
 		t.Fatalf("setup: save user: %v", err)
 	}
-	te, _ := tenant.NewTenant(pending.ID())
-	_ = te.StartProvisioning()
-	_ = te.Approve(admin.ID(), 5)
+	te, err := tenant.NewTenant(pending.ID())
+	if err != nil {
+		t.Fatalf("setup: NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup: StartProvisioning: %v", err)
+	}
+	if err := te.Approve(admin.ID(), 5); err != nil {
+		t.Fatalf("setup: Approve: %v", err)
+	}
 	if err := tRepo.Save(context.Background(), te); err != nil {
 		t.Fatalf("setup: save tenant: %v", err)
 	}
 
 	h := NewApproveUserHandler(uRepo, tRepo, pub)
-	err := h.Handle(context.Background(), ApproveUser{
+	err = h.Handle(context.Background(), ApproveUser{
 		UserID:           pending.ID(),
 		ApprovedByUserID: admin.ID(),
 	})
@@ -188,8 +195,12 @@ func TestApproveUserHandler_BootstrapHalfDoneRecovery(t *testing.T) {
 	pub := mocks.NewEventPublisher()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Approve(admin.ID())
-	_ = uRepo.Save(context.Background(), pending)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup approve: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup save: %v", err)
+	}
 
 	h := NewApproveUserHandler(uRepo, tRepo, pub)
 	err := h.Handle(context.Background(), ApproveUser{
@@ -202,6 +213,78 @@ func TestApproveUserHandler_BootstrapHalfDoneRecovery(t *testing.T) {
 	if len(tRepo.Tenants) != 1 {
 		t.Errorf("expected tenant created on recovery, got %d", len(tRepo.Tenants))
 	}
+}
+
+func TestApproveUserHandler_AlreadyApprovedFailedTenantRecovers(t *testing.T) {
+	// Edge case: user is approved + tenant in `provisioning_failed`
+	// (a previous approval got past user.Save but the async
+	// provisioning ultimately failed). Re-clicking Approve should
+	// fall through to StartProvisioning + publish so the admin can
+	// recover without going to the dedicated retry-migration
+	// endpoint. This is the #4 review-comment fix; without it the
+	// idempotency branch returns InvalidState and the admin's
+	// natural "click Approve again" gesture is rejected.
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup Approve: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup Save user: %v", err)
+	}
+	te, err := tenant.NewTenant(pending.ID())
+	if err != nil {
+		t.Fatalf("setup NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup StartProvisioning: %v", err)
+	}
+	if err := te.MarkProvisioningFailed("prior failure"); err != nil {
+		t.Fatalf("setup MarkProvisioningFailed: %v", err)
+	}
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup Save tenant: %v", err)
+	}
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	if err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("approve should recover from provisioning_failed, got: %v", err)
+	}
+	if got := tRepo.Tenants[te.ID()].Status(); got != tenant.StatusProvisioning {
+		t.Errorf("tenant should be back in provisioning, got %s", got)
+	}
+	if pub.Count() != 1 {
+		t.Errorf("expected 1 publish on recovery path, got %d", pub.Count())
+	}
+}
+
+func TestApproveUserHandler_NilPublisherPanics(t *testing.T) {
+	// Constructor must panic when publisher is nil — a misconfigured
+	// handler that silently drops the trigger appears to succeed but
+	// never starts the async workflow. #5 review-comment fix.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when constructing with nil publisher")
+		}
+	}()
+	NewApproveUserHandler(mocks.NewUserRepository(), mocks.NewTenantRepository(), nil)
+}
+
+func TestRetryTenantMigrationHandler_NilPublisherPanics(t *testing.T) {
+	// Same rationale as ApproveUserHandler — constructor enforces
+	// non-nil publisher.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when constructing with nil publisher")
+		}
+	}()
+	NewRetryTenantMigrationHandler(mocks.NewTenantRepository(), nil)
 }
 
 func TestApproveUserHandler_SaveError(t *testing.T) {
@@ -253,8 +336,12 @@ func TestRejectUserHandler_NotPending(t *testing.T) {
 	uRepo := mocks.NewUserRepository()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Approve(admin.ID())
-	_ = uRepo.Save(context.Background(), pending)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup approve: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup save: %v", err)
+	}
 
 	h := NewRejectUserHandler(uRepo)
 	err := h.Handle(context.Background(), RejectUser{
@@ -289,12 +376,25 @@ func TestSuspendUserHandler_Success(t *testing.T) {
 	tRepo := mocks.NewTenantRepository()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Approve(admin.ID())
-	_ = uRepo.Save(context.Background(), pending)
-	te, _ := tenant.NewTenant(pending.ID())
-	_ = te.StartProvisioning()
-	_ = te.Approve(admin.ID(), 5)
-	_ = tRepo.Save(context.Background(), te)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup approve: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup save: %v", err)
+	}
+	te, err := tenant.NewTenant(pending.ID())
+	if err != nil {
+		t.Fatalf("setup NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup StartProvisioning: %v", err)
+	}
+	if err := te.Approve(admin.ID(), 5); err != nil {
+		t.Fatalf("setup Approve: %v", err)
+	}
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewSuspendUserHandler(uRepo, tRepo)
 	if err := h.Handle(context.Background(), SuspendUser{
@@ -317,8 +417,12 @@ func TestSuspendUserHandler_AlreadySuspended(t *testing.T) {
 	tRepo := mocks.NewTenantRepository()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Reject(admin.ID(), "spam") // rejected → suspended
-	_ = uRepo.Save(context.Background(), pending)
+	if err := pending.Reject(admin.ID(), "spam"); err != nil { // rejected → suspended
+		t.Fatalf("setup Reject: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewSuspendUserHandler(uRepo, tRepo)
 	if err := h.Handle(context.Background(), SuspendUser{
@@ -337,8 +441,12 @@ func TestSuspendUserHandler_NoTenantOK(t *testing.T) {
 	tRepo := mocks.NewTenantRepository()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Approve(admin.ID())
-	_ = uRepo.Save(context.Background(), pending)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup approve: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup save: %v", err)
+	}
 
 	h := NewSuspendUserHandler(uRepo, tRepo)
 	if err := h.Handle(context.Background(), SuspendUser{
@@ -375,9 +483,15 @@ func TestResumeUserHandler_Success(t *testing.T) {
 	uRepo := mocks.NewUserRepository()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Approve(admin.ID())
-	_ = pending.Suspend(admin.ID(), "x")
-	_ = uRepo.Save(context.Background(), pending)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup Approve: %v", err)
+	}
+	if err := pending.Suspend(admin.ID(), "x"); err != nil {
+		t.Fatalf("setup Suspend: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewResumeUserHandler(uRepo)
 	if err := h.Handle(context.Background(), ResumeUser{
@@ -395,8 +509,12 @@ func TestResumeUserHandler_AlreadyApproved(t *testing.T) {
 	uRepo := mocks.NewUserRepository()
 	admin := seedAdminUser(t, uRepo)
 	pending := seedPendingUser(t, uRepo)
-	_ = pending.Approve(admin.ID())
-	_ = uRepo.Save(context.Background(), pending)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup approve: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup save: %v", err)
+	}
 
 	h := NewResumeUserHandler(uRepo)
 	if err := h.Handle(context.Background(), ResumeUser{
@@ -435,7 +553,9 @@ func TestResumeUserHandler_SelfResume(t *testing.T) {
 	if err := suspended.Reject(admin.ID(), "x"); err != nil {
 		t.Fatalf("setup reject: %v", err)
 	}
-	_ = uRepo.Save(context.Background(), suspended)
+	if err := uRepo.Save(context.Background(), suspended); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewResumeUserHandler(uRepo)
 	// Self-resume: resumed_by == user_id. Allowed.
@@ -454,10 +574,19 @@ func TestResumeUserHandler_SelfResume(t *testing.T) {
 func TestRetryTenantMigrationHandler_Success(t *testing.T) {
 	tRepo := mocks.NewTenantRepository()
 	pub := mocks.NewEventPublisher()
-	te, _ := tenant.NewTenant("user-1")
-	_ = te.StartProvisioning()
-	_ = te.MarkProvisioningFailed("migrate failed")
-	_ = tRepo.Save(context.Background(), te)
+	te, err := tenant.NewTenant("user-1")
+	if err != nil {
+		t.Fatalf("setup NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup StartProvisioning: %v", err)
+	}
+	if err := te.MarkProvisioningFailed("migrate failed"); err != nil {
+		t.Fatalf("setup MarkProvisioningFailed: %v", err)
+	}
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewRetryTenantMigrationHandler(tRepo, pub)
 	if err := h.Handle(context.Background(), RetryTenantMigration{
@@ -477,13 +606,22 @@ func TestRetryTenantMigrationHandler_Success(t *testing.T) {
 func TestRetryTenantMigrationHandler_WrongState(t *testing.T) {
 	tRepo := mocks.NewTenantRepository()
 	pub := mocks.NewEventPublisher()
-	te, _ := tenant.NewTenant("user-1")
-	_ = te.StartProvisioning()
-	_ = te.Approve("admin-1", 5)
-	_ = tRepo.Save(context.Background(), te)
+	te, err := tenant.NewTenant("user-1")
+	if err != nil {
+		t.Fatalf("setup NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup StartProvisioning: %v", err)
+	}
+	if err := te.Approve("admin-1", 5); err != nil {
+		t.Fatalf("setup Approve: %v", err)
+	}
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewRetryTenantMigrationHandler(tRepo, pub)
-	err := h.Handle(context.Background(), RetryTenantMigration{
+	err = h.Handle(context.Background(), RetryTenantMigration{
 		TenantID:        te.ID(),
 		RetriedByUserID: "admin-1",
 	})
@@ -511,9 +649,16 @@ func TestRetryTenantMigrationHandler_NotFound(t *testing.T) {
 func TestRetryTenantMigrationHandler_AlreadyProvisioning(t *testing.T) {
 	tRepo := mocks.NewTenantRepository()
 	pub := mocks.NewEventPublisher()
-	te, _ := tenant.NewTenant("user-1")
-	_ = te.StartProvisioning()
-	_ = tRepo.Save(context.Background(), te)
+	te, err := tenant.NewTenant("user-1")
+	if err != nil {
+		t.Fatalf("setup NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup StartProvisioning: %v", err)
+	}
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewRetryTenantMigrationHandler(tRepo, pub)
 	if err := h.Handle(context.Background(), RetryTenantMigration{
@@ -533,13 +678,22 @@ func TestRetryTenantMigrationHandler_PublishError(t *testing.T) {
 	pub.PublishFunc = func(ctx context.Context, topic string, payload interface{}) error {
 		return errors.New("nats down")
 	}
-	te, _ := tenant.NewTenant("user-1")
-	_ = te.StartProvisioning()
-	_ = te.MarkProvisioningFailed("x")
-	_ = tRepo.Save(context.Background(), te)
+	te, err := tenant.NewTenant("user-1")
+	if err != nil {
+		t.Fatalf("setup NewTenant: %v", err)
+	}
+	if err := te.StartProvisioning(); err != nil {
+		t.Fatalf("setup StartProvisioning: %v", err)
+	}
+	if err := te.MarkProvisioningFailed("x"); err != nil {
+		t.Fatalf("setup MarkProvisioningFailed: %v", err)
+	}
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup Save: %v", err)
+	}
 
 	h := NewRetryTenantMigrationHandler(tRepo, pub)
-	err := h.Handle(context.Background(), RetryTenantMigration{
+	err = h.Handle(context.Background(), RetryTenantMigration{
 		TenantID:        te.ID(),
 		RetriedByUserID: "admin-1",
 	})

--- a/internal/application/command/platform_admin_test.go
+++ b/internal/application/command/platform_admin_test.go
@@ -1,0 +1,554 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/mocks"
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// helper: register a normal pending user, return the persisted *user.User.
+func seedPendingUser(t *testing.T, repo *mocks.UserRepository) *user.User {
+	t.Helper()
+	u, err := user.RegisterUser("alice@example.com", "google", "google-id-1", false)
+	if err != nil {
+		t.Fatalf("seedPendingUser: RegisterUser: %v", err)
+	}
+	if err := repo.Save(context.Background(), u); err != nil {
+		t.Fatalf("seedPendingUser: Save: %v", err)
+	}
+	return u
+}
+
+// helper: seed an admin user (bootstrap path) so we have a separate
+// approver.
+func seedAdminUser(t *testing.T, repo *mocks.UserRepository) *user.User {
+	t.Helper()
+	a, err := user.RegisterUser("admin@example.com", "google", "google-admin", true)
+	if err != nil {
+		t.Fatalf("seedAdminUser: RegisterUser: %v", err)
+	}
+	if err := repo.Save(context.Background(), a); err != nil {
+		t.Fatalf("seedAdminUser: Save: %v", err)
+	}
+	return a
+}
+
+// =================
+// ApproveUserHandler
+// =================
+
+func TestApproveUserHandler_Success(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	if err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if uRepo.Users[pending.ID()].Status() != user.StatusApproved {
+		t.Fatalf("user should be approved, got %s", uRepo.Users[pending.ID()].Status())
+	}
+	if len(tRepo.Tenants) != 1 {
+		t.Fatalf("expected 1 tenant created, got %d", len(tRepo.Tenants))
+	}
+	for _, te := range tRepo.Tenants {
+		if te.Status() != tenant.StatusProvisioning {
+			t.Errorf("tenant should be provisioning, got %s", te.Status())
+		}
+		if te.UserID() != pending.ID() {
+			t.Errorf("tenant.UserID mismatch: got %s want %s", te.UserID(), pending.ID())
+		}
+	}
+	if pub.Count() != 1 {
+		t.Errorf("expected 1 publish, got %d", pub.Count())
+	}
+	if pub.Events[0].Topic != TenantProvisioningTopic {
+		t.Errorf("expected topic %s, got %s", TenantProvisioningTopic, pub.Events[0].Topic)
+	}
+}
+
+func TestApproveUserHandler_UserNotFound(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	err := h.Handle(context.Background(), ApproveUser{
+		UserID:           "nonexistent",
+		ApprovedByUserID: "admin-id",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing user")
+	}
+	if !pkgerrors.Is(err, pkgerrors.ErrNotFound) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestApproveUserHandler_SelfApprovalBlocked(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	pending := seedPendingUser(t, uRepo)
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: pending.ID(),
+	})
+	if err == nil {
+		t.Fatal("expected self-approval to be rejected")
+	}
+}
+
+func TestApproveUserHandler_AlreadyApprovedDoubleClick(t *testing.T) {
+	// Idempotency short-circuit: user already approved + tenant already
+	// provisioning. Should be a no-op success WITHOUT re-publishing —
+	// re-driving a stuck subscriber is the RetryTenantMigration
+	// endpoint's job, not Approve's.
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	if err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("first call unexpected error: %v", err)
+	}
+	// Second call — same user, same admin. No-op success, no publish.
+	if err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("second call should be idempotent, got: %v", err)
+	}
+	if len(tRepo.Tenants) != 1 {
+		t.Errorf("should still have 1 tenant, got %d", len(tRepo.Tenants))
+	}
+	if pub.Count() != 1 {
+		t.Errorf("expected 1 publish (no re-issue on idempotent path), got %d", pub.Count())
+	}
+}
+
+func TestApproveUserHandler_AlreadyApprovedTenantInWrongState(t *testing.T) {
+	// User is approved but tenant is in approved state — caller should
+	// use other endpoints, not Approve. We surface InvalidState.
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	if err := pending.Approve(admin.ID()); err != nil {
+		t.Fatalf("setup: approve user: %v", err)
+	}
+	if err := uRepo.Save(context.Background(), pending); err != nil {
+		t.Fatalf("setup: save user: %v", err)
+	}
+	te, _ := tenant.NewTenant(pending.ID())
+	_ = te.StartProvisioning()
+	_ = te.Approve(admin.ID(), 5)
+	if err := tRepo.Save(context.Background(), te); err != nil {
+		t.Fatalf("setup: save tenant: %v", err)
+	}
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	})
+	if err == nil {
+		t.Fatal("expected InvalidState error")
+	}
+	if !pkgerrors.Is(err, pkgerrors.ErrInvalidState) {
+		t.Errorf("expected InvalidState, got %v", err)
+	}
+}
+
+func TestApproveUserHandler_BootstrapHalfDoneRecovery(t *testing.T) {
+	// Edge case: user already approved (e.g. crash mid-bootstrap), no
+	// tenant exists. Approve should create the tenant and provision.
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Approve(admin.ID())
+	_ = uRepo.Save(context.Background(), pending)
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tRepo.Tenants) != 1 {
+		t.Errorf("expected tenant created on recovery, got %d", len(tRepo.Tenants))
+	}
+}
+
+func TestApproveUserHandler_SaveError(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	uRepo.SaveFunc = func(ctx context.Context, u *user.User) error {
+		return fmt.Errorf("db error")
+	}
+
+	h := NewApproveUserHandler(uRepo, tRepo, pub)
+	err := h.Handle(context.Background(), ApproveUser{
+		UserID:           pending.ID(),
+		ApprovedByUserID: admin.ID(),
+	})
+	if err == nil {
+		t.Fatal("expected error from save")
+	}
+	if pub.Count() != 0 {
+		t.Errorf("should not publish on save failure, got %d publishes", pub.Count())
+	}
+}
+
+// ================
+// RejectUserHandler
+// ================
+
+func TestRejectUserHandler_Success(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+
+	h := NewRejectUserHandler(uRepo)
+	if err := h.Handle(context.Background(), RejectUser{
+		UserID:           pending.ID(),
+		RejectedByUserID: admin.ID(),
+		Reason:           "spam",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uRepo.Users[pending.ID()].Status() != user.StatusSuspended {
+		t.Errorf("expected suspended status, got %s", uRepo.Users[pending.ID()].Status())
+	}
+}
+
+func TestRejectUserHandler_NotPending(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Approve(admin.ID())
+	_ = uRepo.Save(context.Background(), pending)
+
+	h := NewRejectUserHandler(uRepo)
+	err := h.Handle(context.Background(), RejectUser{
+		UserID:           pending.ID(),
+		RejectedByUserID: admin.ID(),
+	})
+	if err == nil {
+		t.Fatal("expected InvalidState for non-pending user")
+	}
+}
+
+func TestRejectUserHandler_SelfReject(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	pending := seedPendingUser(t, uRepo)
+
+	h := NewRejectUserHandler(uRepo)
+	err := h.Handle(context.Background(), RejectUser{
+		UserID:           pending.ID(),
+		RejectedByUserID: pending.ID(),
+	})
+	if err == nil {
+		t.Fatal("expected self-reject to be blocked")
+	}
+}
+
+// =================
+// SuspendUserHandler
+// =================
+
+func TestSuspendUserHandler_Success(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Approve(admin.ID())
+	_ = uRepo.Save(context.Background(), pending)
+	te, _ := tenant.NewTenant(pending.ID())
+	_ = te.StartProvisioning()
+	_ = te.Approve(admin.ID(), 5)
+	_ = tRepo.Save(context.Background(), te)
+
+	h := NewSuspendUserHandler(uRepo, tRepo)
+	if err := h.Handle(context.Background(), SuspendUser{
+		UserID:            pending.ID(),
+		SuspendedByUserID: admin.ID(),
+		Reason:            "violation",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uRepo.Users[pending.ID()].Status() != user.StatusSuspended {
+		t.Errorf("user should be suspended")
+	}
+	if tRepo.Tenants[te.ID()].Status() != tenant.StatusSuspended {
+		t.Errorf("tenant should be suspended, got %s", tRepo.Tenants[te.ID()].Status())
+	}
+}
+
+func TestSuspendUserHandler_AlreadySuspended(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Reject(admin.ID(), "spam") // rejected → suspended
+	_ = uRepo.Save(context.Background(), pending)
+
+	h := NewSuspendUserHandler(uRepo, tRepo)
+	if err := h.Handle(context.Background(), SuspendUser{
+		UserID:            pending.ID(),
+		SuspendedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("idempotent suspend should succeed, got %v", err)
+	}
+}
+
+func TestSuspendUserHandler_NoTenantOK(t *testing.T) {
+	// Pending user with no tenant: suspend the user only (no-op on
+	// tenant). Use Reject path to reach suspended status without a
+	// tenant; here we skip directly via approve+suspend flow instead.
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Approve(admin.ID())
+	_ = uRepo.Save(context.Background(), pending)
+
+	h := NewSuspendUserHandler(uRepo, tRepo)
+	if err := h.Handle(context.Background(), SuspendUser{
+		UserID:            pending.ID(),
+		SuspendedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("suspend with no tenant should succeed, got %v", err)
+	}
+	if uRepo.Users[pending.ID()].Status() != user.StatusSuspended {
+		t.Errorf("user should be suspended")
+	}
+}
+
+func TestSuspendUserHandler_SelfSuspend(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	tRepo := mocks.NewTenantRepository()
+	admin := seedAdminUser(t, uRepo)
+	// admin is approved; admin tries to suspend self.
+	h := NewSuspendUserHandler(uRepo, tRepo)
+	err := h.Handle(context.Background(), SuspendUser{
+		UserID:            admin.ID(),
+		SuspendedByUserID: admin.ID(),
+	})
+	if err == nil {
+		t.Fatal("expected self-suspend to be blocked")
+	}
+}
+
+// ================
+// ResumeUserHandler
+// ================
+
+func TestResumeUserHandler_Success(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Approve(admin.ID())
+	_ = pending.Suspend(admin.ID(), "x")
+	_ = uRepo.Save(context.Background(), pending)
+
+	h := NewResumeUserHandler(uRepo)
+	if err := h.Handle(context.Background(), ResumeUser{
+		UserID:          pending.ID(),
+		ResumedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uRepo.Users[pending.ID()].Status() != user.StatusApproved {
+		t.Errorf("user should be approved after resume")
+	}
+}
+
+func TestResumeUserHandler_AlreadyApproved(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	admin := seedAdminUser(t, uRepo)
+	pending := seedPendingUser(t, uRepo)
+	_ = pending.Approve(admin.ID())
+	_ = uRepo.Save(context.Background(), pending)
+
+	h := NewResumeUserHandler(uRepo)
+	if err := h.Handle(context.Background(), ResumeUser{
+		UserID:          pending.ID(),
+		ResumedByUserID: admin.ID(),
+	}); err != nil {
+		t.Fatalf("idempotent resume should succeed, got %v", err)
+	}
+}
+
+func TestResumeUserHandler_NotFound(t *testing.T) {
+	uRepo := mocks.NewUserRepository()
+	h := NewResumeUserHandler(uRepo)
+	err := h.Handle(context.Background(), ResumeUser{
+		UserID:          "missing",
+		ResumedByUserID: "admin",
+	})
+	if err == nil || !pkgerrors.Is(err, pkgerrors.ErrNotFound) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestResumeUserHandler_SelfResume(t *testing.T) {
+	// Resume has NO self-action guard by design. A solo-admin must be
+	// able to recover their own suspended account. This test asserts
+	// the documented behavior.
+	uRepo := mocks.NewUserRepository()
+	admin := seedAdminUser(t, uRepo)
+	// Manually suspend admin (bypassing Suspend's self-block) by
+	// reconstructing in suspended state. We use a fresh user via the
+	// reject path to reach suspended without self-suspend.
+	suspended, err := user.RegisterUser("u@e", "google", "g2", false)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := suspended.Reject(admin.ID(), "x"); err != nil {
+		t.Fatalf("setup reject: %v", err)
+	}
+	_ = uRepo.Save(context.Background(), suspended)
+
+	h := NewResumeUserHandler(uRepo)
+	// Self-resume: resumed_by == user_id. Allowed.
+	if err := h.Handle(context.Background(), ResumeUser{
+		UserID:          suspended.ID(),
+		ResumedByUserID: suspended.ID(),
+	}); err != nil {
+		t.Fatalf("self-resume should succeed, got %v", err)
+	}
+}
+
+// ===========================
+// RetryTenantMigrationHandler
+// ===========================
+
+func TestRetryTenantMigrationHandler_Success(t *testing.T) {
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	te, _ := tenant.NewTenant("user-1")
+	_ = te.StartProvisioning()
+	_ = te.MarkProvisioningFailed("migrate failed")
+	_ = tRepo.Save(context.Background(), te)
+
+	h := NewRetryTenantMigrationHandler(tRepo, pub)
+	if err := h.Handle(context.Background(), RetryTenantMigration{
+		TenantID:        te.ID(),
+		RetriedByUserID: "admin-1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tRepo.Tenants[te.ID()].Status() != tenant.StatusProvisioning {
+		t.Errorf("expected provisioning, got %s", tRepo.Tenants[te.ID()].Status())
+	}
+	if pub.Count() != 1 {
+		t.Errorf("expected 1 publish, got %d", pub.Count())
+	}
+}
+
+func TestRetryTenantMigrationHandler_WrongState(t *testing.T) {
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	te, _ := tenant.NewTenant("user-1")
+	_ = te.StartProvisioning()
+	_ = te.Approve("admin-1", 5)
+	_ = tRepo.Save(context.Background(), te)
+
+	h := NewRetryTenantMigrationHandler(tRepo, pub)
+	err := h.Handle(context.Background(), RetryTenantMigration{
+		TenantID:        te.ID(),
+		RetriedByUserID: "admin-1",
+	})
+	if err == nil {
+		t.Fatal("expected error retrying an approved tenant")
+	}
+	if !pkgerrors.Is(err, pkgerrors.ErrInvalidState) {
+		t.Errorf("expected InvalidState, got %v", err)
+	}
+}
+
+func TestRetryTenantMigrationHandler_NotFound(t *testing.T) {
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	h := NewRetryTenantMigrationHandler(tRepo, pub)
+	err := h.Handle(context.Background(), RetryTenantMigration{
+		TenantID:        "missing",
+		RetriedByUserID: "admin-1",
+	})
+	if err == nil || !pkgerrors.Is(err, pkgerrors.ErrNotFound) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestRetryTenantMigrationHandler_AlreadyProvisioning(t *testing.T) {
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	te, _ := tenant.NewTenant("user-1")
+	_ = te.StartProvisioning()
+	_ = tRepo.Save(context.Background(), te)
+
+	h := NewRetryTenantMigrationHandler(tRepo, pub)
+	if err := h.Handle(context.Background(), RetryTenantMigration{
+		TenantID:        te.ID(),
+		RetriedByUserID: "admin-1",
+	}); err != nil {
+		t.Fatalf("idempotent retry should succeed, got %v", err)
+	}
+	if pub.Count() != 1 {
+		t.Errorf("should re-publish once, got %d", pub.Count())
+	}
+}
+
+func TestRetryTenantMigrationHandler_PublishError(t *testing.T) {
+	tRepo := mocks.NewTenantRepository()
+	pub := mocks.NewEventPublisher()
+	pub.PublishFunc = func(ctx context.Context, topic string, payload interface{}) error {
+		return errors.New("nats down")
+	}
+	te, _ := tenant.NewTenant("user-1")
+	_ = te.StartProvisioning()
+	_ = te.MarkProvisioningFailed("x")
+	_ = tRepo.Save(context.Background(), te)
+
+	h := NewRetryTenantMigrationHandler(tRepo, pub)
+	err := h.Handle(context.Background(), RetryTenantMigration{
+		TenantID:        te.ID(),
+		RetriedByUserID: "admin-1",
+	})
+	if err == nil {
+		t.Fatal("expected error from publish")
+	}
+	// Tenant Save still happened — by design, the publish failure
+	// surfaces but the state machine moved.
+	if tRepo.Tenants[te.ID()].Status() != tenant.StatusProvisioning {
+		t.Errorf("tenant Save should have happened before publish")
+	}
+}

--- a/internal/application/command/reject_user.go
+++ b/internal/application/command/reject_user.go
@@ -1,0 +1,61 @@
+package command
+
+import (
+	"context"
+
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// RejectUser is the input command for RejectUserHandler.
+//
+// Rejects a still-pending user. Distinct from Suspend (which applies
+// to an already-approved user) — Reject emits user.rejected, never
+// touches the Tenant aggregate, and never provisions a tenant DB.
+// See duragraph-spec/api/platform.yaml § /api/admin/users/{user_id}/reject.
+type RejectUser struct {
+	UserID           string
+	RejectedByUserID string
+	Reason           string
+}
+
+// RejectUserHandler handles the RejectUser command.
+type RejectUserHandler struct {
+	userRepo user.Repository
+}
+
+// NewRejectUserHandler constructs a RejectUserHandler.
+func NewRejectUserHandler(userRepo user.Repository) *RejectUserHandler {
+	return &RejectUserHandler{userRepo: userRepo}
+}
+
+// Handle rejects the user. Self-rejection blocked by user.Reject.
+//
+// No tenant action: per the user.Reject docstring, rejection bypasses
+// tenant provisioning entirely. There is no Tenant aggregate to mutate
+// for a never-approved user (the bootstrap path is the only branch that
+// creates a Tenant aggregate before approval, and bootstrapped users
+// don't pass through Reject).
+func (h *RejectUserHandler) Handle(ctx context.Context, cmd RejectUser) error {
+	if cmd.UserID == "" {
+		return errors.InvalidInput("user_id", "user_id is required")
+	}
+	if cmd.RejectedByUserID == "" {
+		return errors.InvalidInput("rejected_by_user_id", "rejected_by_user_id is required")
+	}
+
+	u, err := h.userRepo.GetByID(ctx, cmd.UserID)
+	if err != nil {
+		return err
+	}
+
+	if err := u.Reject(cmd.RejectedByUserID, cmd.Reason); err != nil {
+		return err
+	}
+
+	if err := h.userRepo.Save(ctx, u); err != nil {
+		return errors.Internal("failed to save user", err)
+	}
+
+	return nil
+}

--- a/internal/application/command/resume_user.go
+++ b/internal/application/command/resume_user.go
@@ -1,0 +1,76 @@
+package command
+
+import (
+	"context"
+
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// ResumeUser is the input command for ResumeUserHandler.
+//
+// Reverses suspension. Only the User aggregate is mutated: the Tenant
+// aggregate has no Resume() method by design — the tenant state
+// machine treats Suspended as terminal at the aggregate level (see
+// internal/domain/tenant/status.go). Per duragraph-spec/auth/oauth.yml
+// the user-level resume is what restores access; the tenant DB and
+// NATS Account never went away (suspend keeps them intact, gating only
+// at the JWT/middleware path). So flipping the User row back to
+// approved is sufficient for the next OAuth callback to mint a JWT
+// with tenant_id populated again.
+//
+// Documented asymmetry: User has Resume; Tenant does not. The
+// admin UI surfaces only the user-level Resume; there is no "resume
+// tenant" endpoint. If a tenant ends up in suspended state with the
+// user still approved (operator manually fiddled with the DB, or
+// future suspend-tenant-only endpoint added) the only escape today is
+// a fresh tenant created via the bootstrap-recovery path of
+// ApproveUserHandler — out of scope for v0.
+type ResumeUser struct {
+	UserID          string
+	ResumedByUserID string
+}
+
+// ResumeUserHandler handles the ResumeUser command.
+type ResumeUserHandler struct {
+	userRepo user.Repository
+}
+
+// NewResumeUserHandler constructs a ResumeUserHandler.
+func NewResumeUserHandler(userRepo user.Repository) *ResumeUserHandler {
+	return &ResumeUserHandler{userRepo: userRepo}
+}
+
+// Handle transitions the user back to approved. user.Resume is the
+// only state-machine guard — it has no self-action guard (deliberate,
+// per the comment in internal/domain/user/user.go: a single-admin
+// deployment must be able to recover its own suspended account).
+//
+// Idempotency: a re-issued Resume on an already-approved user is a
+// no-op success.
+func (h *ResumeUserHandler) Handle(ctx context.Context, cmd ResumeUser) error {
+	if cmd.UserID == "" {
+		return errors.InvalidInput("user_id", "user_id is required")
+	}
+	if cmd.ResumedByUserID == "" {
+		return errors.InvalidInput("resumed_by_user_id", "resumed_by_user_id is required")
+	}
+
+	u, err := h.userRepo.GetByID(ctx, cmd.UserID)
+	if err != nil {
+		return err
+	}
+
+	if u.Status() == user.StatusApproved {
+		// Idempotent no-op.
+		return nil
+	}
+
+	if err := u.Resume(cmd.ResumedByUserID); err != nil {
+		return err
+	}
+	if err := h.userRepo.Save(ctx, u); err != nil {
+		return errors.Internal("failed to save user", err)
+	}
+	return nil
+}

--- a/internal/application/command/retry_tenant_migration.go
+++ b/internal/application/command/retry_tenant_migration.go
@@ -1,0 +1,102 @@
+package command
+
+import (
+	"context"
+	"time"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// RetryTenantMigration is the input command for
+// RetryTenantMigrationHandler.
+//
+// Used when a tenant's provisioning failed (CREATE DATABASE,
+// golang-migrate.Up, or NATS Account creation hit an error). The
+// tenant aggregate state machine permits provisioning_failed →
+// provisioning, which re-enters the same async workflow.
+type RetryTenantMigration struct {
+	TenantID        string
+	RetriedByUserID string
+}
+
+// RetryTenantMigrationHandler re-publishes tenant.provisioning for an
+// existing tenant. The platform-provisioner subscriber re-runs the
+// idempotent steps (CREATE DATABASE IF NOT EXISTS via the migrator's
+// pg_database existence check, golang-migrate Up swallowing
+// ErrNoChange, NATS Account creation — once that lands).
+type RetryTenantMigrationHandler struct {
+	tenantRepo tenant.Repository
+	publisher  EventPublisher
+}
+
+// NewRetryTenantMigrationHandler constructs a
+// RetryTenantMigrationHandler.
+func NewRetryTenantMigrationHandler(
+	tenantRepo tenant.Repository,
+	publisher EventPublisher,
+) *RetryTenantMigrationHandler {
+	return &RetryTenantMigrationHandler{
+		tenantRepo: tenantRepo,
+		publisher:  publisher,
+	}
+}
+
+// Handle transitions the tenant from provisioning_failed back to
+// provisioning and republishes tenant.provisioning to NATS.
+//
+// State machine: tenant.StartProvisioning is valid from both pending
+// AND provisioning_failed (per tenant/status.go). Other source states
+// surface InvalidState. Idempotency: a tenant already in provisioning
+// re-publishes the trigger only.
+//
+// RetriedByUserID is currently unused on the wire (the tenant
+// aggregate's StartProvisioning does not record an actor — only the
+// terminal Approve/Suspend events do). Captured for the audit log
+// projection (Wave 2) and for future enrichment of the
+// tenant.provisioning payload.
+func (h *RetryTenantMigrationHandler) Handle(ctx context.Context, cmd RetryTenantMigration) error {
+	if cmd.TenantID == "" {
+		return errors.InvalidInput("tenant_id", "tenant_id is required")
+	}
+	if cmd.RetriedByUserID == "" {
+		return errors.InvalidInput("retried_by_user_id", "retried_by_user_id is required")
+	}
+
+	t, err := h.tenantRepo.GetByID(ctx, cmd.TenantID)
+	if err != nil {
+		return err
+	}
+
+	// Idempotent re-publish if already provisioning.
+	if t.Status() == tenant.StatusProvisioning {
+		return h.publishProvisioning(ctx, t)
+	}
+
+	if err := t.StartProvisioning(); err != nil {
+		return err
+	}
+	if err := h.tenantRepo.Save(ctx, t); err != nil {
+		return errors.Internal("failed to save tenant", err)
+	}
+
+	return h.publishProvisioning(ctx, t)
+}
+
+// publishProvisioning emits the tenant.provisioning event for this
+// retry attempt. Mirrors ApproveUserHandler.publishProvisioning so the
+// subscriber sees a uniform payload regardless of which handler
+// originated it.
+func (h *RetryTenantMigrationHandler) publishProvisioning(ctx context.Context, t *tenant.Tenant) error {
+	if h.publisher == nil {
+		return nil
+	}
+	payload := tenant.TenantProvisioning{
+		TenantID:   t.ID(),
+		OccurredAt: time.Now(),
+	}
+	if err := h.publisher.Publish(ctx, TenantProvisioningTopic, payload); err != nil {
+		return errors.Internal("failed to publish tenant.provisioning", err)
+	}
+	return nil
+}

--- a/internal/application/command/retry_tenant_migration.go
+++ b/internal/application/command/retry_tenant_migration.go
@@ -31,11 +31,17 @@ type RetryTenantMigrationHandler struct {
 }
 
 // NewRetryTenantMigrationHandler constructs a
-// RetryTenantMigrationHandler.
+// RetryTenantMigrationHandler. Panics if publisher is nil — same
+// rationale as ApproveUserHandler: a misconfigured handler that
+// silently drops the trigger appears to succeed but never re-runs the
+// async workflow.
 func NewRetryTenantMigrationHandler(
 	tenantRepo tenant.Repository,
 	publisher EventPublisher,
 ) *RetryTenantMigrationHandler {
+	if publisher == nil {
+		panic("command.NewRetryTenantMigrationHandler: publisher must not be nil")
+	}
 	return &RetryTenantMigrationHandler{
 		tenantRepo: tenantRepo,
 		publisher:  publisher,
@@ -86,11 +92,8 @@ func (h *RetryTenantMigrationHandler) Handle(ctx context.Context, cmd RetryTenan
 // publishProvisioning emits the tenant.provisioning event for this
 // retry attempt. Mirrors ApproveUserHandler.publishProvisioning so the
 // subscriber sees a uniform payload regardless of which handler
-// originated it.
+// originated it. Constructor guarantees h.publisher is non-nil.
 func (h *RetryTenantMigrationHandler) publishProvisioning(ctx context.Context, t *tenant.Tenant) error {
-	if h.publisher == nil {
-		return nil
-	}
 	payload := tenant.TenantProvisioning{
 		TenantID:   t.ID(),
 		OccurredAt: time.Now(),

--- a/internal/application/command/suspend_user.go
+++ b/internal/application/command/suspend_user.go
@@ -1,0 +1,111 @@
+package command
+
+import (
+	"context"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// SuspendUser is the input command for SuspendUserHandler.
+//
+// Suspends an already-approved user. Per platform.yaml the tenant DB
+// and NATS Account remain intact; only API access is gated off via the
+// JWT/middleware path. Reversible via Resume.
+type SuspendUser struct {
+	UserID            string
+	SuspendedByUserID string
+	Reason            string
+}
+
+// SuspendUserHandler handles the SuspendUser command.
+//
+// Touches BOTH aggregates: User → suspended (state machine guard
+// approved → suspended in user.Suspend), Tenant → suspended (state
+// machine guard approved → suspended in tenant.Suspend). The tenant
+// state machine treats Suspended as terminal at the aggregate level —
+// see the comment block at the top of resume_user.go for the
+// asymmetry note that drops out of this design.
+type SuspendUserHandler struct {
+	userRepo   user.Repository
+	tenantRepo tenant.Repository
+}
+
+// NewSuspendUserHandler constructs a SuspendUserHandler.
+func NewSuspendUserHandler(userRepo user.Repository, tenantRepo tenant.Repository) *SuspendUserHandler {
+	return &SuspendUserHandler{userRepo: userRepo, tenantRepo: tenantRepo}
+}
+
+// Handle suspends the user and (best-effort) the tenant.
+//
+// Idempotency: a re-issued Suspend on an already-suspended user is a
+// no-op success — the OAuth callback's suspended branch and the admin
+// UI both rely on idempotent Suspend so a double-click can't surface a
+// 400 to the operator. This is enforced ahead of user.Suspend (which
+// returns InvalidState on suspended users).
+//
+// Atomicity: same caveat as ApproveUserHandler — no shared tx between
+// User and Tenant Save calls. We save user first, then tenant. If
+// tenant.Save fails the user is suspended but the tenant aggregate is
+// not. The retry semantics are: re-issuing Suspend is a no-op on the
+// user (idempotent short-circuit) but will progress the tenant on the
+// retry attempt — admin re-clicks Suspend.
+//
+// Tenant lookup: a user with no Tenant aggregate (rejection path, or
+// bootstrap edge cases) is suspended on the User side only; we do NOT
+// 404 on the missing tenant, because the user-side suspension is
+// already meaningful (the JWT middleware gates them off).
+func (h *SuspendUserHandler) Handle(ctx context.Context, cmd SuspendUser) error {
+	if cmd.UserID == "" {
+		return errors.InvalidInput("user_id", "user_id is required")
+	}
+	if cmd.SuspendedByUserID == "" {
+		return errors.InvalidInput("suspended_by_user_id", "suspended_by_user_id is required")
+	}
+
+	u, err := h.userRepo.GetByID(ctx, cmd.UserID)
+	if err != nil {
+		return err
+	}
+
+	if u.Status() == user.StatusSuspended {
+		// Idempotent no-op. Note: user.Status() == suspended could mean
+		// "suspended via Reject" (pending → suspended) or "suspended via
+		// Suspend" (approved → suspended). We do not attempt to
+		// distinguish — both end states are "API access denied", which
+		// is what the operator wants out of this endpoint.
+		return nil
+	}
+
+	if err := u.Suspend(cmd.SuspendedByUserID, cmd.Reason); err != nil {
+		return err
+	}
+	if err := h.userRepo.Save(ctx, u); err != nil {
+		return errors.Internal("failed to save user", err)
+	}
+
+	// Suspend the tenant if it exists and is approved. Other tenant
+	// states (pending / provisioning / failed / suspended) are not
+	// transitioned — only approved tenants can be suspended per the
+	// tenant state machine. A pending/provisioning tenant left dangling
+	// is harmless: the user's JWT path is already gated.
+	t, err := h.tenantRepo.GetByUserID(ctx, cmd.UserID)
+	if err != nil {
+		if errors.Is(err, errors.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if t.Status() != tenant.StatusApproved {
+		return nil
+	}
+	if err := t.Suspend(cmd.SuspendedByUserID, cmd.Reason); err != nil {
+		return err
+	}
+	if err := h.tenantRepo.Save(ctx, t); err != nil {
+		return errors.Internal("failed to save tenant", err)
+	}
+
+	return nil
+}

--- a/internal/domain/tenant/system_actor.go
+++ b/internal/domain/tenant/system_actor.go
@@ -1,0 +1,24 @@
+package tenant
+
+// SystemActorUserID is the sentinel approved_by_user_id passed to
+// tenant.Approve when the actor is the platform-provisioner subscriber
+// (i.e. the system itself, not a human admin).
+//
+// Why a sentinel and not the tenant's own user_id?
+//
+// The platform-provisioner subscriber has no human approver in scope —
+// it is a long-lived consumer that finishes the async provisioning
+// workflow kicked off by an admin's earlier ApproveUser command. The
+// audit log distinguishes "an admin approved" from "the system
+// finalized provisioning"; reusing the user's own ID would conflate
+// the two and surface a confusing "user X approved themselves" entry.
+// The all-zeros UUID is the conventional choice for "no actor" in
+// systems that still require a non-null actor column. Downstream
+// consumers (audit-log projector, admin UI activity feed) special-case
+// this value to render "system" instead of looking up a user row.
+//
+// Format note: the platform.users table has no row with this ID, and
+// the audit-log projection MUST NOT attempt a foreign-key join on
+// approved_by_user_id when this value appears. The Wave-2 audit-log
+// PR will add the corresponding rendering rule.
+const SystemActorUserID = "00000000-0000-0000-0000-000000000000"

--- a/internal/infrastructure/messaging/nats/jetstream_registry.go
+++ b/internal/infrastructure/messaging/nats/jetstream_registry.go
@@ -1,0 +1,39 @@
+// Package nats — jetstream_registry.go
+//
+// Small concurrent-safe map for stashing in-flight jetstream.Msg
+// values so the JetStreamSubscriber can route TermMessage() calls
+// back to the right server-side message. Separated into its own
+// file so the public-API file (jetstream_subscriber.go) stays
+// readable.
+package nats
+
+import (
+	"sync"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type jsRegistry struct {
+	mu sync.Mutex
+	m  map[string]jetstream.Msg
+}
+
+func newJSRegistry() *jsRegistry {
+	return &jsRegistry{m: make(map[string]jetstream.Msg)}
+}
+
+func (r *jsRegistry) put(uuid string, msg jetstream.Msg) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[uuid] = msg
+}
+
+func (r *jsRegistry) take(uuid string) (jetstream.Msg, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	msg, ok := r.m[uuid]
+	if ok {
+		delete(r.m, uuid)
+	}
+	return msg, ok
+}

--- a/internal/infrastructure/messaging/nats/jetstream_subscriber.go
+++ b/internal/infrastructure/messaging/nats/jetstream_subscriber.go
@@ -1,0 +1,253 @@
+// Package nats — jetstream_subscriber.go
+//
+// JetStreamSubscriber is a thin durable-consumer wrapper over the bare
+// nats.go JetStream API for use cases where the existing watermill
+// nats.Subscriber (plain core-NATS pub/sub) is not durable enough.
+//
+// Why a separate subscriber rather than extending the existing one?
+//   - The existing Subscriber wraps watermill-nats v2's plain-NATS
+//     subscriber. That stack offers no JetStream knobs (durable name,
+//     ack policy, filter subject) without a substantial refactor of
+//     all run/execution event consumers that currently depend on its
+//     gob-marshalling pub/sub semantics.
+//   - The publisher already declares the streams (publisher.go,
+//     ensureStreams) and publishes via watermill's GobMarshaler — so
+//     the on-the-wire payload inside the JetStream-stored message is
+//     a gob-encoded *message.Message. We reuse the matching
+//     GobMarshaler.Unmarshal here so producer/consumer formats stay
+//     coupled to one type.
+//
+// The subscriber binds to an existing stream + filter subject with a
+// durable consumer name (so server-side state survives reconnects and
+// broker restarts) and AckExplicit (so a process crash redelivers the
+// in-flight message). MaxDeliver bounds the redelivery loop on a
+// permanent failure (poison message).
+//
+// Output channel contract: each message is the watermill-decoded
+// *message.Message with Ack/Nack semantics wired to the underlying
+// JetStream Ack/Nak/Term. Callers MUST call exactly one of Ack(),
+// Nack(), or — for permanently-bad payloads — TermMessage(). Failing
+// to ack causes redelivery after AckWait.
+package nats
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	wnats "github.com/ThreeDotsLabs/watermill-nats/v2/pkg/nats"
+	"github.com/ThreeDotsLabs/watermill/message"
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// JetStreamSubscriberConfig configures a JetStreamSubscriber.
+type JetStreamSubscriberConfig struct {
+	// URL is the NATS server URL. Required.
+	URL string
+
+	// StreamName is the existing JetStream stream to bind to (e.g.
+	// "duragraph-events"). The subscriber does NOT create the stream;
+	// the publisher does that via ensureStreams.
+	StreamName string
+
+	// FilterSubject is the subject filter for the durable consumer
+	// (e.g. "duragraph.events.tenant.provisioning"). Must match a
+	// subject covered by the stream's subjects.
+	FilterSubject string
+
+	// Durable is the durable consumer name. Server-side state keyed
+	// off this name persists across reconnects + restarts.
+	Durable string
+
+	// MaxDeliver bounds redelivery attempts. After this many failed
+	// (Nak'd or AckWait-expired) deliveries the server stops
+	// redelivering. 0 means default (-1, unlimited).
+	MaxDeliver int
+
+	// AckWait is how long the server waits for an ack before
+	// redelivering. 0 means default (30s).
+	AckWait time.Duration
+}
+
+// JetStreamSubscriber is a durable JetStream consumer that decodes
+// watermill-format (gob) messages off a stream and exposes them as a
+// *message.Message channel.
+type JetStreamSubscriber struct {
+	cfg         JetStreamSubscriberConfig
+	conn        *natsgo.Conn
+	js          jetstream.JetStream
+	unmarshaler wnats.Unmarshaler
+}
+
+// NewJetStreamSubscriber connects to NATS and prepares (but does not
+// yet subscribe to) the durable consumer. Call SubscribeWithContext to
+// start receiving messages.
+func NewJetStreamSubscriber(cfg JetStreamSubscriberConfig) (*JetStreamSubscriber, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("jetstream subscriber: URL is required")
+	}
+	if cfg.StreamName == "" {
+		return nil, errors.New("jetstream subscriber: StreamName is required")
+	}
+	if cfg.FilterSubject == "" {
+		return nil, errors.New("jetstream subscriber: FilterSubject is required")
+	}
+	if cfg.Durable == "" {
+		return nil, errors.New("jetstream subscriber: Durable name is required")
+	}
+
+	conn, err := natsgo.Connect(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("jetstream subscriber: connect: %w", err)
+	}
+	js, err := jetstream.New(conn)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("jetstream subscriber: jetstream context: %w", err)
+	}
+	return &JetStreamSubscriber{
+		cfg:         cfg,
+		conn:        conn,
+		js:          js,
+		unmarshaler: wnats.GobMarshaler{},
+	}, nil
+}
+
+// SubscribeWithContext starts the durable consumer and returns a
+// channel of decoded messages. The channel closes when ctx is canceled.
+//
+// Each message's Ack/Nack call drives a JetStream Ack/Nak. Callers
+// that want to permanently drop a poisoned message should use
+// TermMessage(msg) below — Watermill's message.Message has no native
+// "term" so we expose a helper.
+func (s *JetStreamSubscriber) SubscribeWithContext(ctx context.Context) (<-chan *message.Message, error) {
+	consumer, err := s.js.CreateOrUpdateConsumer(ctx, s.cfg.StreamName, jetstream.ConsumerConfig{
+		Durable:       s.cfg.Durable,
+		FilterSubject: s.cfg.FilterSubject,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		MaxDeliver:    s.cfg.MaxDeliver,
+		AckWait:       s.cfg.AckWait,
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("jetstream subscriber: create/update consumer %q on %q: %w",
+			s.cfg.Durable, s.cfg.StreamName, err)
+	}
+
+	out := make(chan *message.Message)
+
+	consumeCtx, err := consumer.Consume(func(jsMsg jetstream.Msg) {
+		// Wrap the JetStream message into a watermill message.Message.
+		// Build the same shape watermill's GobMarshaler.Unmarshal
+		// expects: a *nats.Msg with the gob-encoded bytes as Data.
+		decoded, err := s.unmarshaler.Unmarshal(&natsgo.Msg{
+			Subject: jsMsg.Subject(),
+			Data:    jsMsg.Data(),
+		})
+		if err != nil {
+			// Bad payload — Term so the server stops redelivering.
+			_ = jsMsg.Term()
+			return
+		}
+
+		wmMsg := message.NewMessage(decoded.UUID, decoded.Payload)
+		wmMsg.Metadata = decoded.Metadata
+		wmMsg.SetContext(ctx)
+		// Stash the JetStream msg so TermMessage() can find it.
+		setJSMsg(wmMsg, jsMsg)
+
+		select {
+		case out <- wmMsg:
+		case <-ctx.Done():
+			_ = jsMsg.Nak()
+			return
+		}
+
+		// Wait for the consumer to ack/nack/term. Look up the
+		// registry on each branch so a TermMessage() call
+		// (which removes the entry) makes Ack/Nack here a no-op.
+		select {
+		case <-wmMsg.Acked():
+			if live, ok := jsMsgRegistry.take(wmMsg.UUID); ok {
+				_ = live.Ack()
+			}
+		case <-wmMsg.Nacked():
+			if live, ok := jsMsgRegistry.take(wmMsg.UUID); ok {
+				_ = live.Nak()
+			}
+		case <-ctx.Done():
+			// Caller never acked — let JS redeliver.
+			if live, ok := jsMsgRegistry.take(wmMsg.UUID); ok {
+				_ = live.Nak()
+			}
+		}
+	})
+	if err != nil {
+		close(out)
+		return nil, fmt.Errorf("jetstream subscriber: start consume: %w", err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		consumeCtx.Stop()
+		close(out)
+	}()
+
+	return out, nil
+}
+
+// Close drains and closes the underlying NATS connection. Safe to call
+// multiple times.
+func (s *JetStreamSubscriber) Close() error {
+	if s.conn == nil {
+		return nil
+	}
+	if err := s.conn.Drain(); err != nil {
+		return fmt.Errorf("jetstream subscriber: drain: %w", err)
+	}
+	return nil
+}
+
+// jsMsgKey is the metadata key under which we stash the underlying
+// jetstream.Msg. Read via TermMessage to escalate a poison-message ack
+// to a server-side Term (no further redelivery).
+const jsMsgMetadataKey = "_jetstream_msg_ptr_unsafe"
+
+// jsMsgRegistry maps watermill message UUIDs to their backing
+// jetstream.Msg. We can't put a pointer in metadata (string-only), so
+// we use a small in-memory side table keyed by UUID. Entries are
+// removed when the consumer Ack/Nack/Term-s the message.
+//
+// This is a low-traffic path (one tenant.provisioning event per
+// approval) so a sync.Map / coarse mutex is fine.
+var jsMsgRegistry = newJSRegistry()
+
+func setJSMsg(wmMsg *message.Message, jsMsg jetstream.Msg) {
+	jsMsgRegistry.put(wmMsg.UUID, jsMsg)
+	// Marker so TermMessage knows we have one.
+	wmMsg.Metadata.Set(jsMsgMetadataKey, "1")
+}
+
+// TermMessage signals JetStream to permanently stop redelivering this
+// message (poison-message escape hatch). Returns false if the message
+// did not originate from a JetStreamSubscriber.
+//
+// Callers must still call wmMsg.Ack() afterward to release the
+// consume-loop wait — the registry lookup will no-op (entry already
+// taken) so no double-ack reaches the server.
+func TermMessage(wmMsg *message.Message) bool {
+	if wmMsg == nil {
+		return false
+	}
+	if wmMsg.Metadata.Get(jsMsgMetadataKey) != "1" {
+		return false
+	}
+	jsMsg, ok := jsMsgRegistry.take(wmMsg.UUID)
+	if !ok {
+		return false
+	}
+	_ = jsMsg.Term()
+	return true
+}

--- a/internal/infrastructure/messaging/tenant_provisioner.go
+++ b/internal/infrastructure/messaging/tenant_provisioner.go
@@ -1,8 +1,9 @@
 // Package messaging — tenant_provisioner.go
 //
 // TenantProvisioner is the NATS subscriber side of the platform admin
-// orchestration loop. It listens for tenant.provisioning events emitted
-// by ApproveUserHandler / RetryTenantMigrationHandler and runs the
+// orchestration loop. It listens (as a JetStream durable consumer —
+// see DurableName below) for tenant.provisioning events emitted by
+// ApproveUserHandler / RetryTenantMigrationHandler and runs the
 // idempotent steps that turn a pending tenant into an approved one:
 //
 //  1. CREATE DATABASE (the migrator wraps this in a pg_database
@@ -19,32 +20,44 @@
 // tenant.approved / tenant.provisioning_failed events ride the same
 // (later) audit-log subscriber path as user lifecycle events.
 //
+// Durability:
+//
+// The subscriber is a JetStream durable consumer ("tenant-provisioner")
+// bound to the existing duragraph-events stream filtered on subject
+// duragraph.events.tenant.provisioning. Server-side state survives
+// broker restarts, so a message published while the engine is offline
+// is still delivered when the engine comes back. AckExplicit means a
+// process crash before ack causes JetStream to redeliver after AckWait.
+//
+// Ack policy inside handleMessage:
+//   - success / idempotent-noop / terminal-failure (tenant marked
+//     provisioning_failed and saved) → Ack. Redelivering would only
+//     re-run the idempotent migrator + observe the now-failed status
+//     and short-circuit; no useful retry.
+//   - malformed payload (extractTenantID fails) → Term. Garbage will
+//     never become valid; don't loop on it.
+//   - retryable error (load tenant DB hiccup, save-failed-tenant DB
+//     hiccup) → Nak. The same payload re-arrives after AckWait.
+//
 // Idempotency:
 //
 // A redelivered tenant.provisioning event for a tenant whose status is
-// no longer `provisioning` (because a previous delivery succeeded) is
-// acked-and-logged without action. Otherwise the state machine on
-// tenant.Approve would reject and we'd loop on a permanent error. See
-// processEvent below for the dispatch table.
+// no longer `provisioning` (because a previous delivery succeeded or
+// failed) is acked-and-logged without action. The dispatch table in
+// processEvent handles this — `approved` and `provisioning_failed`
+// are no-op branches.
 //
 // Bootstrap-already-approved short-circuit: when the OAuth bootstrap
 // path provisioned the tenant inline, the tenant is `approved` from
 // the start. If the admin then mistakenly double-approves (or some
 // other path emits tenant.provisioning for that tenant), the
 // subscriber must NOT re-run migrations or call tenant.Approve again.
-// Same dispatch table handles this — `approved` is the no-op branch.
-//
-// Ack semantics:
-//
-// Watermill messages are process-then-ack: we call msg.Ack() only
-// after the tenant Save succeeds (success or failure path). A panic
-// or unrecovered error before the ack causes redelivery; the
-// idempotent steps above make this safe.
 package messaging
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 
@@ -67,14 +80,12 @@ const TenantProvisioningTopic = command.TenantProvisioningTopic
 // provisioner needs. Keeping it as a small interface keeps the
 // subscriber unit-testable without spinning up a real Postgres.
 type TenantMigrator interface {
-	// ProvisionTenant performs CREATE DATABASE (idempotent) and applies
-	// all tenant migrations. Returns nil on success.
-	ProvisionTenant(ctx context.Context, tenantID string) error
-
-	// MigrateTenant returns the post-migration schema version for an
-	// already-existing tenant DB. Used to compute the version recorded
-	// on tenant.Approve.
-	MigrateTenant(ctx context.Context, tenantID string) (uint, error)
+	// ProvisionTenantWithVersion performs CREATE DATABASE (idempotent),
+	// applies all tenant migrations, and returns the resulting schema
+	// version in one round-trip. Used to record schema_version on
+	// tenant.Approve without a second migrate.Up() pass just to read
+	// the version table.
+	ProvisionTenantWithVersion(ctx context.Context, tenantID string) (uint, error)
 }
 
 // NATSAccountProvisioner is the operator-JWT wiring needed to create a
@@ -97,11 +108,30 @@ func (NoopNATSAccountProvisioner) ProvisionAccount(ctx context.Context, tenantID
 	return nil
 }
 
+// DurableName is the JetStream durable consumer name used by the
+// tenant provisioner. Server-side delivery state is keyed off this
+// name, so changing it would orphan in-flight events.
+const DurableName = "tenant-provisioner"
+
+// JetStreamStreamName is the JetStream stream the provisioner binds
+// to. The publisher's ensureStreams() declares this stream with
+// subjects "duragraph.events.>", which covers TenantProvisioningTopic.
+const JetStreamStreamName = "duragraph-events"
+
+// MessageSubscriber is the minimal subscribe surface the provisioner
+// needs. Both *nats.JetStreamSubscriber (production) and a test fake
+// satisfy it. We accept a no-arg SubscribeWithContext because the
+// JetStreamSubscriber is configured for one stream+filter at
+// construction time.
+type MessageSubscriber interface {
+	SubscribeWithContext(ctx context.Context) (<-chan *message.Message, error)
+}
+
 // TenantProvisioner is the NATS-driven worker that completes the
 // async tenant provisioning workflow. Construct with NewTenantProvisioner;
 // start with Run.
 type TenantProvisioner struct {
-	subscriber  *nats.Subscriber
+	subscriber  MessageSubscriber
 	tenantRepo  tenant.Repository
 	migrator    TenantMigrator
 	natsAccount NATSAccountProvisioner
@@ -111,9 +141,10 @@ type TenantProvisioner struct {
 // NewTenantProvisioner constructs a TenantProvisioner.
 //
 // natsAccount may be nil — the constructor substitutes
-// NoopNATSAccountProvisioner so callers don't have to care.
+// NoopNATSAccountProvisioner so callers don't have to care. subscriber
+// MAY be nil only in unit-test paths that drive processEvent directly.
 func NewTenantProvisioner(
-	subscriber *nats.Subscriber,
+	subscriber MessageSubscriber,
 	tenantRepo tenant.Repository,
 	migrator TenantMigrator,
 	natsAccount NATSAccountProvisioner,
@@ -134,17 +165,14 @@ func NewTenantProvisioner(
 	}
 }
 
-// Run subscribes to TenantProvisioningTopic and processes events until
-// ctx is canceled. Returns the context error on cancel; any subscribe
-// failure surfaces immediately.
-//
-// The Watermill subscriber returns one message channel per call to
-// SubscribeWithContext; we drain that channel in this goroutine, ack
-// or nack each message after processing, and return when the channel
-// closes (which happens when ctx is canceled and the subscriber's
-// internal goroutine closes the underlying NATS subscription).
+// Run subscribes via the configured subscriber and processes events
+// until ctx is canceled. Returns the context error on cancel; any
+// subscribe failure surfaces immediately.
 func (p *TenantProvisioner) Run(ctx context.Context) error {
-	ch, err := p.subscriber.SubscribeWithContext(ctx, TenantProvisioningTopic)
+	if p.subscriber == nil {
+		return fmt.Errorf("tenant provisioner: subscriber is nil")
+	}
+	ch, err := p.subscriber.SubscribeWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("subscribe %s: %w", TenantProvisioningTopic, err)
 	}
@@ -164,29 +192,64 @@ func (p *TenantProvisioner) Run(ctx context.Context) error {
 	}
 }
 
-// handleMessage processes one Watermill message. Always acks (no
-// nack) — the dispatch table inside processEvent classifies every
-// outcome (success, idempotent-noop, permanent-failure) as terminal,
-// and a NATS redelivery loop on a permanent failure would block the
-// stream forever. We log permanent failures; an operational follow-up
-// (Wave-2 audit log + dashboard) will make them visible to the admin.
+// handleMessage processes one message and routes the outcome to the
+// JetStream message API: success / non-retryable → Ack; malformed
+// payload → Term; transient infra error → Nak. See package header
+// "Ack policy" for the rationale.
+//
+// Classification of processEvent's return value:
+//   - errMalformedPayload: the bytes can't be parsed as a tenant.provisioning
+//     event. Term — redelivering garbage cannot make it parseable.
+//   - errTenantNotFound: payload referenced a non-existent tenant. Term —
+//     no future redelivery will conjure a row that isn't there.
+//   - any other non-nil error: transient infrastructure problem
+//     (DB connection blip, etc.). Nak — let JetStream redeliver.
+//   - nil: success or already-terminal (markFailed already persisted).
+//     Ack.
 func (p *TenantProvisioner) handleMessage(ctx context.Context, msg *message.Message) {
-	defer msg.Ack()
-	if err := p.processEvent(ctx, msg.Payload); err != nil {
-		p.logger.Printf("tenant_provisioner: process event failed: %v", err)
+	err := p.processEvent(ctx, msg.Payload)
+	switch {
+	case err == nil:
+		msg.Ack()
+	case errors.Is(err, errMalformedPayload), errors.Is(err, errTenantNotFound):
+		nats.TermMessage(msg) // best-effort; falls back to plain ack on non-JS subscribers
+		msg.Ack()
+	default:
+		// Transient — let JetStream redeliver after AckWait.
+		msg.Nack()
 	}
 }
 
+// errMalformedPayload / errTenantNotFound are sentinel errors used by
+// processEvent to communicate "do not retry this message" to
+// handleMessage. processEvent wraps them so callers see a useful
+// message; handleMessage uses errors.Is to classify.
+var (
+	errMalformedPayload = errors.New("tenant_provisioner: malformed payload")
+	errTenantNotFound   = errors.New("tenant_provisioner: tenant not found")
+)
+
 // processEvent unmarshals one tenant.provisioning event and runs the
-// dispatch table.
+// dispatch table. Returns nil on success or idempotent-noop. On
+// terminal failure inside runProvisioning the failure is persisted via
+// markFailed and processEvent returns nil — there is nothing to retry.
+// Returns non-nil only when the failure cause is transient (DB
+// connection blip on initial load) OR non-retryable (sentinel errors
+// errMalformedPayload / errTenantNotFound, which handleMessage maps to
+// Term).
 func (p *TenantProvisioner) processEvent(ctx context.Context, payload []byte) error {
 	tenantID, err := extractTenantID(payload)
 	if err != nil {
-		return fmt.Errorf("extract tenant_id: %w", err)
+		// Wrap with sentinel so handleMessage knows to Term.
+		return fmt.Errorf("%w: %v", errMalformedPayload, err)
 	}
 
 	t, err := p.tenantRepo.GetByID(ctx, tenantID)
 	if err != nil {
+		if pkgerrors.Is(err, pkgerrors.ErrNotFound) {
+			return fmt.Errorf("%w: %s", errTenantNotFound, tenantID)
+		}
+		// Transient — let handleMessage Nak.
 		return fmt.Errorf("load tenant %s: %w", tenantID, err)
 	}
 
@@ -215,21 +278,18 @@ func (p *TenantProvisioner) processEvent(ctx context.Context, payload []byte) er
 // runProvisioning is the work-doing branch: CREATE DATABASE + migrate
 // + NATS Account. On success → tenant.Approve. On failure →
 // tenant.MarkProvisioningFailed.
+//
+// Returns nil on both happy path AND terminal-failure-already-persisted
+// (markFailed succeeded). Returns non-nil only when the FAILURE PATH
+// itself failed to persist (state-machine guard fired, or Save failed)
+// — those are transient/exceptional and benefit from a redelivery.
 func (p *TenantProvisioner) runProvisioning(ctx context.Context, t *tenant.Tenant) error {
-	// CREATE DATABASE + migrate (each step is idempotent inside the
-	// migrator: pg_database existence check; golang-migrate
-	// ErrNoChange).
-	if err := p.migrator.ProvisionTenant(ctx, t.ID()); err != nil {
-		return p.markFailed(ctx, t, fmt.Sprintf("provision: %v", err))
-	}
-
-	// Read back the schema version. MigrateTenant after ProvisionTenant
-	// is the canonical way to ask "what version am I at" — golang-migrate
-	// has no separate read-only Version() helper that opens a fresh
-	// connection.
-	version, err := p.migrator.MigrateTenant(ctx, t.ID())
+	// CREATE DATABASE + migrate + read version, in one call. Each
+	// step is idempotent inside the migrator: pg_database existence
+	// check; golang-migrate swallows ErrNoChange.
+	version, err := p.migrator.ProvisionTenantWithVersion(ctx, t.ID())
 	if err != nil {
-		return p.markFailed(ctx, t, fmt.Sprintf("read schema version: %v", err))
+		return p.markFailed(ctx, t, fmt.Sprintf("provision: %v", err))
 	}
 
 	// NATS Account creation — stubbed today.
@@ -253,8 +313,11 @@ func (p *TenantProvisioner) runProvisioning(ctx context.Context, t *tenant.Tenan
 }
 
 // markFailed transitions the tenant to provisioning_failed and saves.
-// Returns the original failure reason wrapped — the caller logs it —
-// even if the Save succeeded, so the admin sees something happened.
+// Returns nil when the failure has been successfully persisted —
+// JetStream Acks (no useful redelivery; the next admin click goes
+// through retry-migration). Returns non-nil only if the failure-path
+// transition or save itself failed; those are exceptional and we
+// surface so handleMessage Naks.
 func (p *TenantProvisioner) markFailed(ctx context.Context, t *tenant.Tenant, reason string) error {
 	if mfErr := t.MarkProvisioningFailed(reason); mfErr != nil {
 		// State-machine guard fired; log and bail.
@@ -263,7 +326,8 @@ func (p *TenantProvisioner) markFailed(ctx context.Context, t *tenant.Tenant, re
 	if saveErr := p.tenantRepo.Save(ctx, t); saveErr != nil {
 		return fmt.Errorf("save failed-tenant %s: %w", t.ID(), saveErr)
 	}
-	return pkgerrors.Internal(fmt.Sprintf("tenant %s provisioning failed: %s", t.ID(), reason), nil)
+	p.logger.Printf("tenant_provisioner: tenant %s marked provisioning_failed: %s", t.ID(), reason)
+	return nil
 }
 
 // extractTenantID pulls the tenant_id field out of the JSON payload.

--- a/internal/infrastructure/messaging/tenant_provisioner.go
+++ b/internal/infrastructure/messaging/tenant_provisioner.go
@@ -1,0 +1,297 @@
+// Package messaging — tenant_provisioner.go
+//
+// TenantProvisioner is the NATS subscriber side of the platform admin
+// orchestration loop. It listens for tenant.provisioning events emitted
+// by ApproveUserHandler / RetryTenantMigrationHandler and runs the
+// idempotent steps that turn a pending tenant into an approved one:
+//
+//  1. CREATE DATABASE (the migrator wraps this in a pg_database
+//     existence check; safe to retry).
+//  2. golang-migrate Up (the migrator swallows ErrNoChange; safe to
+//     retry).
+//  3. NATS Account creation. Today this is a stubbed interface
+//     (NoopNATSAccountProvisioner) — the operator-JWT wiring is not yet
+//     in place; the real implementation lands in a follow-up PR.
+//
+// On success: tenant.Approve(SystemActorUserID, schemaVersion). On
+// failure: tenant.MarkProvisioningFailed(reason). Both terminal
+// transitions persist via the tenant repository, and the resulting
+// tenant.approved / tenant.provisioning_failed events ride the same
+// (later) audit-log subscriber path as user lifecycle events.
+//
+// Idempotency:
+//
+// A redelivered tenant.provisioning event for a tenant whose status is
+// no longer `provisioning` (because a previous delivery succeeded) is
+// acked-and-logged without action. Otherwise the state machine on
+// tenant.Approve would reject and we'd loop on a permanent error. See
+// processEvent below for the dispatch table.
+//
+// Bootstrap-already-approved short-circuit: when the OAuth bootstrap
+// path provisioned the tenant inline, the tenant is `approved` from
+// the start. If the admin then mistakenly double-approves (or some
+// other path emits tenant.provisioning for that tenant), the
+// subscriber must NOT re-run migrations or call tenant.Approve again.
+// Same dispatch table handles this — `approved` is the no-op branch.
+//
+// Ack semantics:
+//
+// Watermill messages are process-then-ack: we call msg.Ack() only
+// after the tenant Save succeeds (success or failure path). A panic
+// or unrecovered error before the ack causes redelivery; the
+// idempotent steps above make this safe.
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+
+	"github.com/duragraph/duragraph/internal/application/command"
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/infrastructure/messaging/nats"
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// TenantProvisioningTopic is the NATS subject the subscriber listens
+// on. Mirrors command.TenantProvisioningTopic so producer/consumer
+// stay in lockstep — see the constant's docstring there for the
+// rationale on why we don't use the bare `tenant.provisioning` subject
+// from the asyncapi spec.
+const TenantProvisioningTopic = command.TenantProvisioningTopic
+
+// TenantMigrator is the subset of the postgres.Migrator API the
+// provisioner needs. Keeping it as a small interface keeps the
+// subscriber unit-testable without spinning up a real Postgres.
+type TenantMigrator interface {
+	// ProvisionTenant performs CREATE DATABASE (idempotent) and applies
+	// all tenant migrations. Returns nil on success.
+	ProvisionTenant(ctx context.Context, tenantID string) error
+
+	// MigrateTenant returns the post-migration schema version for an
+	// already-existing tenant DB. Used to compute the version recorded
+	// on tenant.Approve.
+	MigrateTenant(ctx context.Context, tenantID string) (uint, error)
+}
+
+// NATSAccountProvisioner is the operator-JWT wiring needed to create a
+// per-tenant NATS Account. Today this is a stub (NoopNATSAccountProvisioner)
+// because the operator JWT mode is not yet wired into the engine — the
+// real implementation will land alongside the multi-account NATS
+// configuration. Defined as an interface so the follow-up PR can
+// substitute without changing TenantProvisioner.
+type NATSAccountProvisioner interface {
+	ProvisionAccount(ctx context.Context, tenantID string) error
+}
+
+// NoopNATSAccountProvisioner satisfies NATSAccountProvisioner without
+// performing any work. The default while operator-JWT wiring is
+// pending.
+type NoopNATSAccountProvisioner struct{}
+
+// ProvisionAccount is a no-op.
+func (NoopNATSAccountProvisioner) ProvisionAccount(ctx context.Context, tenantID string) error {
+	return nil
+}
+
+// TenantProvisioner is the NATS-driven worker that completes the
+// async tenant provisioning workflow. Construct with NewTenantProvisioner;
+// start with Run.
+type TenantProvisioner struct {
+	subscriber  *nats.Subscriber
+	tenantRepo  tenant.Repository
+	migrator    TenantMigrator
+	natsAccount NATSAccountProvisioner
+	logger      *log.Logger
+}
+
+// NewTenantProvisioner constructs a TenantProvisioner.
+//
+// natsAccount may be nil — the constructor substitutes
+// NoopNATSAccountProvisioner so callers don't have to care.
+func NewTenantProvisioner(
+	subscriber *nats.Subscriber,
+	tenantRepo tenant.Repository,
+	migrator TenantMigrator,
+	natsAccount NATSAccountProvisioner,
+	logger *log.Logger,
+) *TenantProvisioner {
+	if natsAccount == nil {
+		natsAccount = NoopNATSAccountProvisioner{}
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &TenantProvisioner{
+		subscriber:  subscriber,
+		tenantRepo:  tenantRepo,
+		migrator:    migrator,
+		natsAccount: natsAccount,
+		logger:      logger,
+	}
+}
+
+// Run subscribes to TenantProvisioningTopic and processes events until
+// ctx is canceled. Returns the context error on cancel; any subscribe
+// failure surfaces immediately.
+//
+// The Watermill subscriber returns one message channel per call to
+// SubscribeWithContext; we drain that channel in this goroutine, ack
+// or nack each message after processing, and return when the channel
+// closes (which happens when ctx is canceled and the subscriber's
+// internal goroutine closes the underlying NATS subscription).
+func (p *TenantProvisioner) Run(ctx context.Context) error {
+	ch, err := p.subscriber.SubscribeWithContext(ctx, TenantProvisioningTopic)
+	if err != nil {
+		return fmt.Errorf("subscribe %s: %w", TenantProvisioningTopic, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-ch:
+			if !ok {
+				// Channel closed (subscription torn down). Treat as a
+				// clean shutdown.
+				return ctx.Err()
+			}
+			p.handleMessage(ctx, msg)
+		}
+	}
+}
+
+// handleMessage processes one Watermill message. Always acks (no
+// nack) — the dispatch table inside processEvent classifies every
+// outcome (success, idempotent-noop, permanent-failure) as terminal,
+// and a NATS redelivery loop on a permanent failure would block the
+// stream forever. We log permanent failures; an operational follow-up
+// (Wave-2 audit log + dashboard) will make them visible to the admin.
+func (p *TenantProvisioner) handleMessage(ctx context.Context, msg *message.Message) {
+	defer msg.Ack()
+	if err := p.processEvent(ctx, msg.Payload); err != nil {
+		p.logger.Printf("tenant_provisioner: process event failed: %v", err)
+	}
+}
+
+// processEvent unmarshals one tenant.provisioning event and runs the
+// dispatch table.
+func (p *TenantProvisioner) processEvent(ctx context.Context, payload []byte) error {
+	tenantID, err := extractTenantID(payload)
+	if err != nil {
+		return fmt.Errorf("extract tenant_id: %w", err)
+	}
+
+	t, err := p.tenantRepo.GetByID(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("load tenant %s: %w", tenantID, err)
+	}
+
+	switch t.Status() {
+	case tenant.StatusProvisioning:
+		return p.runProvisioning(ctx, t)
+	case tenant.StatusApproved:
+		// Bootstrap-already-approved short-circuit (or duplicate
+		// delivery after a previous successful run). No work to do.
+		p.logger.Printf("tenant_provisioner: tenant %s already approved, skipping", tenantID)
+		return nil
+	case tenant.StatusProvisioningFailed:
+		// A previous attempt already terminated in failure. The retry
+		// endpoint moves the tenant back to provisioning before
+		// publishing a fresh event; if we're seeing failed here it
+		// means a stale redelivery — drop it.
+		p.logger.Printf("tenant_provisioner: tenant %s already failed; dropping stale event", tenantID)
+		return nil
+	default:
+		p.logger.Printf("tenant_provisioner: tenant %s in unexpected state %s; dropping event",
+			tenantID, t.Status())
+		return nil
+	}
+}
+
+// runProvisioning is the work-doing branch: CREATE DATABASE + migrate
+// + NATS Account. On success → tenant.Approve. On failure →
+// tenant.MarkProvisioningFailed.
+func (p *TenantProvisioner) runProvisioning(ctx context.Context, t *tenant.Tenant) error {
+	// CREATE DATABASE + migrate (each step is idempotent inside the
+	// migrator: pg_database existence check; golang-migrate
+	// ErrNoChange).
+	if err := p.migrator.ProvisionTenant(ctx, t.ID()); err != nil {
+		return p.markFailed(ctx, t, fmt.Sprintf("provision: %v", err))
+	}
+
+	// Read back the schema version. MigrateTenant after ProvisionTenant
+	// is the canonical way to ask "what version am I at" — golang-migrate
+	// has no separate read-only Version() helper that opens a fresh
+	// connection.
+	version, err := p.migrator.MigrateTenant(ctx, t.ID())
+	if err != nil {
+		return p.markFailed(ctx, t, fmt.Sprintf("read schema version: %v", err))
+	}
+
+	// NATS Account creation — stubbed today.
+	if err := p.natsAccount.ProvisionAccount(ctx, t.ID()); err != nil {
+		return p.markFailed(ctx, t, fmt.Sprintf("nats account: %v", err))
+	}
+
+	// Approve. SystemActorUserID is the conventional "no human actor"
+	// sentinel — see internal/domain/tenant/system_actor.go.
+	if err := t.Approve(tenant.SystemActorUserID, int(version)); err != nil {
+		// State-machine guard: only reachable if some racing actor
+		// already moved the tenant. Surface the inconsistency in logs;
+		// the next reconciliation tick will sort it out.
+		return fmt.Errorf("tenant.Approve(%s): %w", t.ID(), err)
+	}
+	if err := p.tenantRepo.Save(ctx, t); err != nil {
+		return fmt.Errorf("save approved tenant %s: %w", t.ID(), err)
+	}
+	p.logger.Printf("tenant_provisioner: tenant %s approved at schema_version=%d", t.ID(), version)
+	return nil
+}
+
+// markFailed transitions the tenant to provisioning_failed and saves.
+// Returns the original failure reason wrapped — the caller logs it —
+// even if the Save succeeded, so the admin sees something happened.
+func (p *TenantProvisioner) markFailed(ctx context.Context, t *tenant.Tenant, reason string) error {
+	if mfErr := t.MarkProvisioningFailed(reason); mfErr != nil {
+		// State-machine guard fired; log and bail.
+		return fmt.Errorf("mark_failed(%s): %w", t.ID(), mfErr)
+	}
+	if saveErr := p.tenantRepo.Save(ctx, t); saveErr != nil {
+		return fmt.Errorf("save failed-tenant %s: %w", t.ID(), saveErr)
+	}
+	return pkgerrors.Internal(fmt.Sprintf("tenant %s provisioning failed: %s", t.ID(), reason), nil)
+}
+
+// extractTenantID pulls the tenant_id field out of the JSON payload.
+// We accept two payload shapes for robustness:
+//
+//  1. The bare tenant.TenantProvisioning struct (what the command
+//     handlers publish today): {"tenant_id": "...", "occurred_at": ...}.
+//  2. The outbox-relay envelope (in case a future wiring switch routes
+//     these through the outbox): {"aggregate_id": "...", "payload": {...}}.
+//     The aggregate_id of a tenant event is the tenant_id by the
+//     domain.Event contract.
+//
+// Falling back through both keeps us forward-compatible if the
+// audit-log/outbox unification PR happens before the spec/impl
+// reconciliation PR.
+func extractTenantID(payload []byte) (string, error) {
+	var direct struct {
+		TenantID    string `json:"tenant_id"`
+		AggregateID string `json:"aggregate_id"`
+	}
+	if err := json.Unmarshal(payload, &direct); err != nil {
+		return "", fmt.Errorf("unmarshal payload: %w", err)
+	}
+	if direct.TenantID != "" {
+		return direct.TenantID, nil
+	}
+	if direct.AggregateID != "" {
+		return direct.AggregateID, nil
+	}
+	return "", fmt.Errorf("payload contains neither tenant_id nor aggregate_id")
+}

--- a/internal/infrastructure/messaging/tenant_provisioner_test.go
+++ b/internal/infrastructure/messaging/tenant_provisioner_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/duragraph/duragraph/internal/domain/tenant"
 	"github.com/duragraph/duragraph/internal/mocks"
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
 )
 
 // fakeMigrator implements TenantMigrator with adjustable hooks.
@@ -17,25 +18,19 @@ type fakeMigrator struct {
 	mu sync.Mutex
 
 	provisionCalls []string
-	migrateCalls   []string
 
 	provisionErr error
-	migrateErr   error
 	version      uint
 }
 
-func (f *fakeMigrator) ProvisionTenant(_ context.Context, tenantID string) error {
+func (f *fakeMigrator) ProvisionTenantWithVersion(_ context.Context, tenantID string) (uint, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.provisionCalls = append(f.provisionCalls, tenantID)
-	return f.provisionErr
-}
-
-func (f *fakeMigrator) MigrateTenant(_ context.Context, tenantID string) (uint, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.migrateCalls = append(f.migrateCalls, tenantID)
-	return f.version, f.migrateErr
+	if f.provisionErr != nil {
+		return 0, f.provisionErr
+	}
+	return f.version, nil
 }
 
 // fakeNATSAccount records calls; can be set to error.
@@ -59,7 +54,9 @@ type discardWriter struct{}
 
 func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
 
-// helper: persist a tenant in the given starting status.
+// helper: persist a tenant in the given starting status. Setup
+// transitions are checked with t.Fatalf so a state-machine guard
+// regression doesn't silently produce a tenant in the wrong state.
 func seedTenant(t *testing.T, repo *mocks.TenantRepository, status tenant.Status) *tenant.Tenant {
 	t.Helper()
 	te, err := tenant.NewTenant("user-1")
@@ -70,17 +67,33 @@ func seedTenant(t *testing.T, repo *mocks.TenantRepository, status tenant.Status
 	case tenant.StatusPending:
 		// already pending
 	case tenant.StatusProvisioning:
-		_ = te.StartProvisioning()
+		if err := te.StartProvisioning(); err != nil {
+			t.Fatalf("seed StartProvisioning: %v", err)
+		}
 	case tenant.StatusApproved:
-		_ = te.StartProvisioning()
-		_ = te.Approve("admin-1", 1)
+		if err := te.StartProvisioning(); err != nil {
+			t.Fatalf("seed StartProvisioning: %v", err)
+		}
+		if err := te.Approve("admin-1", 1); err != nil {
+			t.Fatalf("seed Approve: %v", err)
+		}
 	case tenant.StatusProvisioningFailed:
-		_ = te.StartProvisioning()
-		_ = te.MarkProvisioningFailed("test")
+		if err := te.StartProvisioning(); err != nil {
+			t.Fatalf("seed StartProvisioning: %v", err)
+		}
+		if err := te.MarkProvisioningFailed("test"); err != nil {
+			t.Fatalf("seed MarkProvisioningFailed: %v", err)
+		}
 	case tenant.StatusSuspended:
-		_ = te.StartProvisioning()
-		_ = te.Approve("admin-1", 1)
-		_ = te.Suspend("admin-2", "x")
+		if err := te.StartProvisioning(); err != nil {
+			t.Fatalf("seed StartProvisioning: %v", err)
+		}
+		if err := te.Approve("admin-1", 1); err != nil {
+			t.Fatalf("seed Approve: %v", err)
+		}
+		if err := te.Suspend("admin-2", "x"); err != nil {
+			t.Fatalf("seed Suspend: %v", err)
+		}
 	}
 	if err := repo.Save(context.Background(), te); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -95,6 +108,24 @@ func TestTenantProvisioner_Success(t *testing.T) {
 
 	te := seedTenant(t, repo, tenant.StatusProvisioning)
 
+	// Capture the events emitted by the SECOND Save (the
+	// approval). The seed's Save was already cleared by the mock's
+	// ClearEvents contract, so we install the SaveFunc only after
+	// seeding — otherwise we'd snapshot the seed's
+	// (provisioning_started) events, not the (approved) events we
+	// want to inspect.
+	var capturedEvents []eventbus.Event
+	repo.SaveFunc = func(_ context.Context, te *tenant.Tenant) error {
+		// Snapshot the events on this tenant BEFORE we clear them.
+		for _, ev := range te.Events() {
+			capturedEvents = append(capturedEvents, ev)
+		}
+		// Persist + clear, mirroring the default mock behavior.
+		repo.Tenants[te.ID()] = te
+		te.ClearEvents()
+		return nil
+	}
+
 	p := &TenantProvisioner{
 		tenantRepo:  repo,
 		migrator:    mig,
@@ -108,7 +139,7 @@ func TestTenantProvisioner_Success(t *testing.T) {
 	}
 
 	if len(mig.provisionCalls) != 1 || mig.provisionCalls[0] != te.ID() {
-		t.Errorf("expected ProvisionTenant called once with %s, got %v", te.ID(), mig.provisionCalls)
+		t.Errorf("expected ProvisionTenantWithVersion called once with %s, got %v", te.ID(), mig.provisionCalls)
 	}
 	if len(nats.calls) != 1 {
 		t.Errorf("expected NATS account provisioned once, got %d", len(nats.calls))
@@ -120,11 +151,30 @@ func TestTenantProvisioner_Success(t *testing.T) {
 	if saved.SchemaVersion() == nil || *saved.SchemaVersion() != 7 {
 		t.Errorf("expected schema version 7, got %v", saved.SchemaVersion())
 	}
-	// Must use the system-actor sentinel, NOT the user's own ID.
-	for _, ev := range saved.Events() {
-		// events were cleared by Save, so this loop is empty in
-		// practice. The actor check is implicit in not-erroring.
-		_ = ev
+
+	// Find the tenant.approved event; assert the actor is the
+	// system-actor sentinel (NOT the user's own ID). This protects
+	// the documented design choice that the subscriber's terminal
+	// transition is performed as the platform itself, not as any
+	// human admin.
+	var approved *tenant.TenantApproved
+	for _, ev := range capturedEvents {
+		if a, ok := ev.(tenant.TenantApproved); ok {
+			a := a
+			approved = &a
+			break
+		}
+	}
+	if approved == nil {
+		var types []string
+		for _, ev := range capturedEvents {
+			types = append(types, ev.EventType())
+		}
+		t.Fatalf("expected tenant.approved event captured; got types=%v", types)
+	}
+	if approved.ApprovedByUserID != tenant.SystemActorUserID {
+		t.Errorf("ApprovedByUserID = %q, want SystemActorUserID %q",
+			approved.ApprovedByUserID, tenant.SystemActorUserID)
 	}
 }
 
@@ -179,6 +229,10 @@ func TestTenantProvisioner_StaleEventOnFailedTenant(t *testing.T) {
 }
 
 func TestTenantProvisioner_ProvisionFailureMarksFailed(t *testing.T) {
+	// Terminal-failure-already-persisted: processEvent returns nil
+	// (so handleMessage Acks; redelivery would just no-op against
+	// the now-failed tenant). Verification is on the persisted
+	// state, not the return value.
 	repo := mocks.NewTenantRepository()
 	mig := &fakeMigrator{provisionErr: errors.New("create db: permission denied")}
 	te := seedTenant(t, repo, tenant.StatusProvisioning)
@@ -189,8 +243,8 @@ func TestTenantProvisioner_ProvisionFailureMarksFailed(t *testing.T) {
 		logger:     newSilentLogger(),
 	}
 	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
-	if err := p.processEvent(context.Background(), payload); err == nil {
-		t.Fatal("expected error from failed provisioning")
+	if err := p.processEvent(context.Background(), payload); err != nil {
+		t.Fatalf("terminal failure should return nil (already persisted): %v", err)
 	}
 	saved := repo.Tenants[te.ID()]
 	if saved.Status() != tenant.StatusProvisioningFailed {
@@ -214,8 +268,8 @@ func TestTenantProvisioner_NATSAccountFailureMarksFailed(t *testing.T) {
 		logger:      newSilentLogger(),
 	}
 	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
-	if err := p.processEvent(context.Background(), payload); err == nil {
-		t.Fatal("expected error from NATS account failure")
+	if err := p.processEvent(context.Background(), payload); err != nil {
+		t.Fatalf("terminal failure should return nil (already persisted): %v", err)
 	}
 	saved := repo.Tenants[te.ID()]
 	if saved.Status() != tenant.StatusProvisioningFailed {
@@ -224,6 +278,9 @@ func TestTenantProvisioner_NATSAccountFailureMarksFailed(t *testing.T) {
 }
 
 func TestTenantProvisioner_TenantNotFound(t *testing.T) {
+	// NotFound is non-retryable but distinct from a transient blip.
+	// processEvent wraps with errTenantNotFound so handleMessage
+	// classifies it as Term-able. Test asserts the sentinel.
 	repo := mocks.NewTenantRepository()
 	mig := &fakeMigrator{}
 	p := &TenantProvisioner{
@@ -232,8 +289,12 @@ func TestTenantProvisioner_TenantNotFound(t *testing.T) {
 		logger:     newSilentLogger(),
 	}
 	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: "nonexistent"})
-	if err := p.processEvent(context.Background(), payload); err == nil {
+	err := p.processEvent(context.Background(), payload)
+	if err == nil {
 		t.Fatal("expected error for missing tenant")
+	}
+	if !errors.Is(err, errTenantNotFound) {
+		t.Errorf("expected errTenantNotFound sentinel, got %v", err)
 	}
 }
 
@@ -259,6 +320,26 @@ func TestTenantProvisioner_ExtractTenantID_NoIDError(t *testing.T) {
 	payload := []byte(`{"foo":"bar"}`)
 	if _, err := extractTenantID(payload); err == nil {
 		t.Fatal("expected error when payload has no tenant_id or aggregate_id")
+	}
+}
+
+func TestTenantProvisioner_MalformedPayloadIsTermable(t *testing.T) {
+	// processEvent on garbage bytes should return an error wrapping
+	// errMalformedPayload so handleMessage routes it to Term (no
+	// further redelivery from JetStream).
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{}
+	p := &TenantProvisioner{
+		tenantRepo: repo,
+		migrator:   mig,
+		logger:     newSilentLogger(),
+	}
+	err := p.processEvent(context.Background(), []byte(`not-json`))
+	if err == nil {
+		t.Fatal("expected error from malformed payload")
+	}
+	if !errors.Is(err, errMalformedPayload) {
+		t.Errorf("expected errMalformedPayload sentinel, got %v", err)
 	}
 }
 

--- a/internal/infrastructure/messaging/tenant_provisioner_test.go
+++ b/internal/infrastructure/messaging/tenant_provisioner_test.go
@@ -1,0 +1,275 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"sync"
+	"testing"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/mocks"
+)
+
+// fakeMigrator implements TenantMigrator with adjustable hooks.
+type fakeMigrator struct {
+	mu sync.Mutex
+
+	provisionCalls []string
+	migrateCalls   []string
+
+	provisionErr error
+	migrateErr   error
+	version      uint
+}
+
+func (f *fakeMigrator) ProvisionTenant(_ context.Context, tenantID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.provisionCalls = append(f.provisionCalls, tenantID)
+	return f.provisionErr
+}
+
+func (f *fakeMigrator) MigrateTenant(_ context.Context, tenantID string) (uint, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.migrateCalls = append(f.migrateCalls, tenantID)
+	return f.version, f.migrateErr
+}
+
+// fakeNATSAccount records calls; can be set to error.
+type fakeNATSAccount struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeNATSAccount) ProvisionAccount(_ context.Context, tenantID string) error {
+	f.calls = append(f.calls, tenantID)
+	return f.err
+}
+
+func newSilentLogger() *log.Logger {
+	// Discard log output during tests — not part of the assertion
+	// surface.
+	return log.New(discardWriter{}, "", 0)
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// helper: persist a tenant in the given starting status.
+func seedTenant(t *testing.T, repo *mocks.TenantRepository, status tenant.Status) *tenant.Tenant {
+	t.Helper()
+	te, err := tenant.NewTenant("user-1")
+	if err != nil {
+		t.Fatalf("NewTenant: %v", err)
+	}
+	switch status {
+	case tenant.StatusPending:
+		// already pending
+	case tenant.StatusProvisioning:
+		_ = te.StartProvisioning()
+	case tenant.StatusApproved:
+		_ = te.StartProvisioning()
+		_ = te.Approve("admin-1", 1)
+	case tenant.StatusProvisioningFailed:
+		_ = te.StartProvisioning()
+		_ = te.MarkProvisioningFailed("test")
+	case tenant.StatusSuspended:
+		_ = te.StartProvisioning()
+		_ = te.Approve("admin-1", 1)
+		_ = te.Suspend("admin-2", "x")
+	}
+	if err := repo.Save(context.Background(), te); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return te
+}
+
+func TestTenantProvisioner_Success(t *testing.T) {
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{version: 7}
+	nats := &fakeNATSAccount{}
+
+	te := seedTenant(t, repo, tenant.StatusProvisioning)
+
+	p := &TenantProvisioner{
+		tenantRepo:  repo,
+		migrator:    mig,
+		natsAccount: nats,
+		logger:      newSilentLogger(),
+	}
+
+	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
+	if err := p.processEvent(context.Background(), payload); err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+
+	if len(mig.provisionCalls) != 1 || mig.provisionCalls[0] != te.ID() {
+		t.Errorf("expected ProvisionTenant called once with %s, got %v", te.ID(), mig.provisionCalls)
+	}
+	if len(nats.calls) != 1 {
+		t.Errorf("expected NATS account provisioned once, got %d", len(nats.calls))
+	}
+	saved := repo.Tenants[te.ID()]
+	if saved.Status() != tenant.StatusApproved {
+		t.Errorf("expected approved, got %s", saved.Status())
+	}
+	if saved.SchemaVersion() == nil || *saved.SchemaVersion() != 7 {
+		t.Errorf("expected schema version 7, got %v", saved.SchemaVersion())
+	}
+	// Must use the system-actor sentinel, NOT the user's own ID.
+	for _, ev := range saved.Events() {
+		// events were cleared by Save, so this loop is empty in
+		// practice. The actor check is implicit in not-erroring.
+		_ = ev
+	}
+}
+
+func TestTenantProvisioner_BootstrapAlreadyApproved(t *testing.T) {
+	// Bootstrap-already-approved short-circuit: tenant in `approved`
+	// receives a tenant.provisioning event. No migrator call, no Save.
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{}
+	nats := &fakeNATSAccount{}
+	te := seedTenant(t, repo, tenant.StatusApproved)
+
+	p := &TenantProvisioner{
+		tenantRepo:  repo,
+		migrator:    mig,
+		natsAccount: nats,
+		logger:      newSilentLogger(),
+	}
+	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
+	if err := p.processEvent(context.Background(), payload); err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+	if len(mig.provisionCalls) != 0 {
+		t.Errorf("must not call migrator on already-approved tenant: %v", mig.provisionCalls)
+	}
+	if len(nats.calls) != 0 {
+		t.Errorf("must not call NATS account: %v", nats.calls)
+	}
+	if repo.Tenants[te.ID()].Status() != tenant.StatusApproved {
+		t.Errorf("status must remain approved")
+	}
+}
+
+func TestTenantProvisioner_StaleEventOnFailedTenant(t *testing.T) {
+	// Stale redelivery for a tenant in provisioning_failed state — drop
+	// silently.
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{}
+	te := seedTenant(t, repo, tenant.StatusProvisioningFailed)
+
+	p := &TenantProvisioner{
+		tenantRepo: repo,
+		migrator:   mig,
+		logger:     newSilentLogger(),
+	}
+	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
+	if err := p.processEvent(context.Background(), payload); err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+	if len(mig.provisionCalls) != 0 {
+		t.Errorf("must not run migrator on failed tenant")
+	}
+}
+
+func TestTenantProvisioner_ProvisionFailureMarksFailed(t *testing.T) {
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{provisionErr: errors.New("create db: permission denied")}
+	te := seedTenant(t, repo, tenant.StatusProvisioning)
+
+	p := &TenantProvisioner{
+		tenantRepo: repo,
+		migrator:   mig,
+		logger:     newSilentLogger(),
+	}
+	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
+	if err := p.processEvent(context.Background(), payload); err == nil {
+		t.Fatal("expected error from failed provisioning")
+	}
+	saved := repo.Tenants[te.ID()]
+	if saved.Status() != tenant.StatusProvisioningFailed {
+		t.Errorf("expected provisioning_failed, got %s", saved.Status())
+	}
+	if saved.FailureReason() == "" {
+		t.Errorf("failure reason should be populated")
+	}
+}
+
+func TestTenantProvisioner_NATSAccountFailureMarksFailed(t *testing.T) {
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{version: 3}
+	nats := &fakeNATSAccount{err: errors.New("operator jwt invalid")}
+	te := seedTenant(t, repo, tenant.StatusProvisioning)
+
+	p := &TenantProvisioner{
+		tenantRepo:  repo,
+		migrator:    mig,
+		natsAccount: nats,
+		logger:      newSilentLogger(),
+	}
+	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: te.ID()})
+	if err := p.processEvent(context.Background(), payload); err == nil {
+		t.Fatal("expected error from NATS account failure")
+	}
+	saved := repo.Tenants[te.ID()]
+	if saved.Status() != tenant.StatusProvisioningFailed {
+		t.Errorf("expected provisioning_failed, got %s", saved.Status())
+	}
+}
+
+func TestTenantProvisioner_TenantNotFound(t *testing.T) {
+	repo := mocks.NewTenantRepository()
+	mig := &fakeMigrator{}
+	p := &TenantProvisioner{
+		tenantRepo: repo,
+		migrator:   mig,
+		logger:     newSilentLogger(),
+	}
+	payload, _ := json.Marshal(tenant.TenantProvisioning{TenantID: "nonexistent"})
+	if err := p.processEvent(context.Background(), payload); err == nil {
+		t.Fatal("expected error for missing tenant")
+	}
+}
+
+func TestTenantProvisioner_ExtractTenantID_AggregateIDFallback(t *testing.T) {
+	// Outbox-envelope shape: {aggregate_id: "..."}.
+	envelope := map[string]interface{}{
+		"aggregate_id":   "tenant-123",
+		"aggregate_type": "tenant",
+		"event_type":     "tenant.provisioning",
+		"payload":        map[string]interface{}{},
+	}
+	payload, _ := json.Marshal(envelope)
+	id, err := extractTenantID(payload)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if id != "tenant-123" {
+		t.Errorf("expected aggregate_id fallback, got %q", id)
+	}
+}
+
+func TestTenantProvisioner_ExtractTenantID_NoIDError(t *testing.T) {
+	payload := []byte(`{"foo":"bar"}`)
+	if _, err := extractTenantID(payload); err == nil {
+		t.Fatal("expected error when payload has no tenant_id or aggregate_id")
+	}
+}
+
+func TestTenantProvisioner_NoopNATSAccountIsDefault(t *testing.T) {
+	// Constructor must substitute Noop when caller passes nil so a
+	// zero-config wiring doesn't panic.
+	p := NewTenantProvisioner(nil, nil, nil, nil, nil)
+	if p.natsAccount == nil {
+		t.Fatal("constructor must default natsAccount")
+	}
+	if _, ok := p.natsAccount.(NoopNATSAccountProvisioner); !ok {
+		t.Errorf("expected NoopNATSAccountProvisioner default")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migrator.go
+++ b/internal/infrastructure/persistence/postgres/migrator.go
@@ -291,22 +291,36 @@ func (m *Migrator) MigrateMainDB(ctx context.Context, dbName string) error {
 //
 // tenantID must be a UUID string; the DB name is derived via
 // tenant.DBName (which validates the UUID).
+//
+// Discards the resulting schema version; callers that need it should use
+// ProvisionTenantWithVersion instead (avoids a second migrate.Up()
+// round-trip just to read the version table).
 func (m *Migrator) ProvisionTenant(ctx context.Context, tenantID string) error {
+	_, err := m.ProvisionTenantWithVersion(ctx, tenantID)
+	return err
+}
+
+// ProvisionTenantWithVersion is ProvisionTenant that also returns the
+// resulting schema version, avoiding a second MigrateTenant call just to
+// read the version. Used by the tenant_provisioner subscriber where the
+// version is recorded on tenant.Approve.
+func (m *Migrator) ProvisionTenantWithVersion(ctx context.Context, tenantID string) (uint, error) {
 	dbName, err := tenant.DBName(tenantID)
 	if err != nil {
-		return fmt.Errorf("provision tenant: %w", err)
+		return 0, fmt.Errorf("provision tenant: %w", err)
 	}
 	if err := tenant.ValidateDBName(dbName); err != nil {
 		// Defensive: DBName + ValidateDBName should always agree.
-		return fmt.Errorf("provision tenant: derived db name failed validation: %w", err)
+		return 0, fmt.Errorf("provision tenant: derived db name failed validation: %w", err)
 	}
 	if err := m.ensureDatabase(ctx, dbName); err != nil {
-		return fmt.Errorf("provision tenant %s: %w", tenantID, err)
+		return 0, fmt.Errorf("provision tenant %s: %w", tenantID, err)
 	}
-	if _, err := m.MigrateTenant(ctx, tenantID); err != nil {
-		return fmt.Errorf("provision tenant %s: migrate: %w", tenantID, err)
+	version, err := m.MigrateTenant(ctx, tenantID)
+	if err != nil {
+		return 0, fmt.Errorf("provision tenant %s: migrate: %w", tenantID, err)
 	}
-	return nil
+	return version, nil
 }
 
 // MigrateTenant runs tenant migrations against an existing tenant DB

--- a/internal/mocks/event_publisher.go
+++ b/internal/mocks/event_publisher.go
@@ -1,0 +1,47 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+)
+
+// PublishedEvent is one captured publish() call in the EventPublisher
+// recorder.
+type PublishedEvent struct {
+	Topic   string
+	Payload interface{}
+}
+
+// EventPublisher is a recorder that satisfies the
+// command.EventPublisher interface. Stores every Publish() call for
+// test assertions; an optional Func override lets a test inject
+// failure.
+type EventPublisher struct {
+	mu          sync.Mutex
+	Events      []PublishedEvent
+	PublishFunc func(ctx context.Context, topic string, payload interface{}) error
+}
+
+// NewEventPublisher constructs a fresh recorder.
+func NewEventPublisher() *EventPublisher {
+	return &EventPublisher{Events: make([]PublishedEvent, 0)}
+}
+
+// Publish records the call and returns the result of PublishFunc if
+// set, else nil.
+func (p *EventPublisher) Publish(ctx context.Context, topic string, payload interface{}) error {
+	p.mu.Lock()
+	p.Events = append(p.Events, PublishedEvent{Topic: topic, Payload: payload})
+	p.mu.Unlock()
+	if p.PublishFunc != nil {
+		return p.PublishFunc(ctx, topic, payload)
+	}
+	return nil
+}
+
+// Count returns how many Publish() calls have been recorded.
+func (p *EventPublisher) Count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.Events)
+}

--- a/internal/mocks/tenant_repo.go
+++ b/internal/mocks/tenant_repo.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/duragraph/duragraph/internal/domain/tenant"
@@ -33,7 +34,8 @@ func NewTenantRepository() *TenantRepository {
 }
 
 // Save stores t under both ID and user_id indexes. Func override takes
-// precedence.
+// precedence. Mirrors the postgres repository's contract of clearing
+// emitted domain events after persistence.
 func (m *TenantRepository) Save(ctx context.Context, t *tenant.Tenant) error {
 	if m.SaveFunc != nil {
 		return m.SaveFunc(ctx, t)
@@ -42,6 +44,7 @@ func (m *TenantRepository) Save(ctx context.Context, t *tenant.Tenant) error {
 	defer m.mu.Unlock()
 	m.Tenants[t.ID()] = t
 	m.tenantsByUser[t.UserID()] = t
+	t.ClearEvents()
 	return nil
 }
 
@@ -74,6 +77,9 @@ func (m *TenantRepository) GetByUserID(ctx context.Context, userID string) (*ten
 }
 
 // ListByStatus returns tenants matching status with pagination.
+// Results are sorted by CreatedAt ascending (ID as tiebreaker) for
+// deterministic behavior — the postgres repo's SELECT uses ORDER BY,
+// so callers expect a stable order.
 func (m *TenantRepository) ListByStatus(ctx context.Context, status tenant.Status, limit, offset int) ([]*tenant.Tenant, error) {
 	if m.ListByStatusFunc != nil {
 		return m.ListByStatusFunc(ctx, status, limit, offset)
@@ -86,6 +92,12 @@ func (m *TenantRepository) ListByStatus(ctx context.Context, status tenant.Statu
 			out = append(out, t)
 		}
 	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedAt().Equal(out[j].CreatedAt()) {
+			return out[i].ID() < out[j].ID()
+		}
+		return out[i].CreatedAt().Before(out[j].CreatedAt())
+	})
 	if offset >= len(out) {
 		return []*tenant.Tenant{}, nil
 	}

--- a/internal/mocks/tenant_repo.go
+++ b/internal/mocks/tenant_repo.go
@@ -1,0 +1,97 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// TenantRepository is an in-memory mock of tenant.Repository for
+// command handler / subscriber unit tests.
+type TenantRepository struct {
+	mu      sync.RWMutex
+	Tenants map[string]*tenant.Tenant
+
+	// Index by user_id for GetByUserID (1:1 with tenant.id).
+	tenantsByUser map[string]*tenant.Tenant
+
+	SaveFunc         func(ctx context.Context, t *tenant.Tenant) error
+	GetByIDFunc      func(ctx context.Context, id string) (*tenant.Tenant, error)
+	GetByUserIDFunc  func(ctx context.Context, userID string) (*tenant.Tenant, error)
+	ListByStatusFunc func(ctx context.Context, status tenant.Status, limit, offset int) ([]*tenant.Tenant, error)
+}
+
+// NewTenantRepository constructs an empty in-memory TenantRepository
+// mock.
+func NewTenantRepository() *TenantRepository {
+	return &TenantRepository{
+		Tenants:       make(map[string]*tenant.Tenant),
+		tenantsByUser: make(map[string]*tenant.Tenant),
+	}
+}
+
+// Save stores t under both ID and user_id indexes. Func override takes
+// precedence.
+func (m *TenantRepository) Save(ctx context.Context, t *tenant.Tenant) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, t)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Tenants[t.ID()] = t
+	m.tenantsByUser[t.UserID()] = t
+	return nil
+}
+
+// GetByID returns the tenant with the given ID or NotFound.
+func (m *TenantRepository) GetByID(ctx context.Context, id string) (*tenant.Tenant, error) {
+	if m.GetByIDFunc != nil {
+		return m.GetByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, ok := m.Tenants[id]
+	if !ok {
+		return nil, errors.NotFound("tenant", id)
+	}
+	return t, nil
+}
+
+// GetByUserID returns the tenant for the given user_id or NotFound.
+func (m *TenantRepository) GetByUserID(ctx context.Context, userID string) (*tenant.Tenant, error) {
+	if m.GetByUserIDFunc != nil {
+		return m.GetByUserIDFunc(ctx, userID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, ok := m.tenantsByUser[userID]
+	if !ok {
+		return nil, errors.NotFound("tenant for user", userID)
+	}
+	return t, nil
+}
+
+// ListByStatus returns tenants matching status with pagination.
+func (m *TenantRepository) ListByStatus(ctx context.Context, status tenant.Status, limit, offset int) ([]*tenant.Tenant, error) {
+	if m.ListByStatusFunc != nil {
+		return m.ListByStatusFunc(ctx, status, limit, offset)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*tenant.Tenant, 0)
+	for _, t := range m.Tenants {
+		if t.Status() == status {
+			out = append(out, t)
+		}
+	}
+	if offset >= len(out) {
+		return []*tenant.Tenant{}, nil
+	}
+	out = out[offset:]
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
+	}
+	return out, nil
+}

--- a/internal/mocks/user_repo.go
+++ b/internal/mocks/user_repo.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/duragraph/duragraph/internal/domain/user"
@@ -34,7 +35,10 @@ func NewUserRepository() *UserRepository {
 }
 
 // Save stores u under both ID and (provider, oauth_id) indexes. Func
-// override takes precedence.
+// override takes precedence. Mirrors the postgres repository's contract
+// of clearing emitted domain events after persistence — without this,
+// tests that snapshot Events() at a different point in the flow can
+// double-count.
 func (m *UserRepository) Save(ctx context.Context, u *user.User) error {
 	if m.SaveFunc != nil {
 		return m.SaveFunc(ctx, u)
@@ -43,6 +47,7 @@ func (m *UserRepository) Save(ctx context.Context, u *user.User) error {
 	defer m.mu.Unlock()
 	m.Users[u.ID()] = u
 	m.usersByOAuth[u.OAuthProvider()+"/"+u.OAuthID()] = u
+	u.ClearEvents()
 	return nil
 }
 
@@ -74,7 +79,11 @@ func (m *UserRepository) GetByOAuth(ctx context.Context, provider, oauthID strin
 	return u, nil
 }
 
-// ListByStatus returns users matching status with pagination.
+// ListByStatus returns users matching status with pagination. Results
+// are sorted by CreatedAt ascending (ID as tiebreaker) for
+// deterministic behavior — the postgres repo uses ORDER BY in its
+// SELECT, so without sorting here a test that compares results
+// position-by-position would be flaky against the map iteration order.
 func (m *UserRepository) ListByStatus(ctx context.Context, status user.Status, limit, offset int) ([]*user.User, error) {
 	if m.ListByStatusFunc != nil {
 		return m.ListByStatusFunc(ctx, status, limit, offset)
@@ -87,6 +96,12 @@ func (m *UserRepository) ListByStatus(ctx context.Context, status user.Status, l
 			out = append(out, u)
 		}
 	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedAt().Equal(out[j].CreatedAt()) {
+			return out[i].ID() < out[j].ID()
+		}
+		return out[i].CreatedAt().Before(out[j].CreatedAt())
+	})
 	if offset >= len(out) {
 		return []*user.User{}, nil
 	}

--- a/internal/mocks/user_repo.go
+++ b/internal/mocks/user_repo.go
@@ -1,0 +1,108 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// UserRepository is an in-memory mock of user.Repository for command
+// handler unit tests. Each Func override hook lets a test inject
+// failure / latency without subclassing.
+type UserRepository struct {
+	mu    sync.RWMutex
+	Users map[string]*user.User
+
+	// Index by (oauth_provider, oauth_id) for GetByOAuth.
+	usersByOAuth map[string]*user.User
+
+	SaveFunc         func(ctx context.Context, u *user.User) error
+	GetByIDFunc      func(ctx context.Context, id string) (*user.User, error)
+	GetByOAuthFunc   func(ctx context.Context, provider, oauthID string) (*user.User, error)
+	ListByStatusFunc func(ctx context.Context, status user.Status, limit, offset int) ([]*user.User, error)
+	CountAllFunc     func(ctx context.Context) (int, error)
+}
+
+// NewUserRepository constructs an empty in-memory UserRepository mock.
+func NewUserRepository() *UserRepository {
+	return &UserRepository{
+		Users:        make(map[string]*user.User),
+		usersByOAuth: make(map[string]*user.User),
+	}
+}
+
+// Save stores u under both ID and (provider, oauth_id) indexes. Func
+// override takes precedence.
+func (m *UserRepository) Save(ctx context.Context, u *user.User) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(ctx, u)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Users[u.ID()] = u
+	m.usersByOAuth[u.OAuthProvider()+"/"+u.OAuthID()] = u
+	return nil
+}
+
+// GetByID returns the user with the given ID or NotFound.
+func (m *UserRepository) GetByID(ctx context.Context, id string) (*user.User, error) {
+	if m.GetByIDFunc != nil {
+		return m.GetByIDFunc(ctx, id)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	u, ok := m.Users[id]
+	if !ok {
+		return nil, errors.NotFound("user", id)
+	}
+	return u, nil
+}
+
+// GetByOAuth returns the user with the given (provider, oauth_id) pair.
+func (m *UserRepository) GetByOAuth(ctx context.Context, provider, oauthID string) (*user.User, error) {
+	if m.GetByOAuthFunc != nil {
+		return m.GetByOAuthFunc(ctx, provider, oauthID)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	u, ok := m.usersByOAuth[provider+"/"+oauthID]
+	if !ok {
+		return nil, errors.NotFound("user", provider+"/"+oauthID)
+	}
+	return u, nil
+}
+
+// ListByStatus returns users matching status with pagination.
+func (m *UserRepository) ListByStatus(ctx context.Context, status user.Status, limit, offset int) ([]*user.User, error) {
+	if m.ListByStatusFunc != nil {
+		return m.ListByStatusFunc(ctx, status, limit, offset)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*user.User, 0)
+	for _, u := range m.Users {
+		if u.Status() == status {
+			out = append(out, u)
+		}
+	}
+	if offset >= len(out) {
+		return []*user.User{}, nil
+	}
+	out = out[offset:]
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// CountAll returns the total user count. Used by the bootstrap branch.
+func (m *UserRepository) CountAll(ctx context.Context) (int, error) {
+	if m.CountAllFunc != nil {
+		return m.CountAllFunc(ctx)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.Users), nil
+}


### PR DESCRIPTION
## Summary

Wave 1 multi-tenant rollout — adds the platform admin command handlers and the async tenant provisioner that completes the workflow they kick off.

- **Five command handlers** (`internal/application/command/`): `ApproveUser`, `RejectUser`, `SuspendUser`, `ResumeUser`, `RetryTenantMigration`. Each uses the User/Tenant aggregates' existing state machines (PRs #147, #148) and the User/Tenant repositories from PR #152.
- **Tenant provisioner subscriber** (`internal/infrastructure/messaging/tenant_provisioner.go`): listens on `duragraph.events.tenant.provisioning`, runs `Migrator.ProvisionTenant` + `MigrateTenant`, then either calls `tenant.Approve(SystemActorUserID, schemaVersion)` on success or `MarkProvisioningFailed` on error. Bootstrap-already-approved + stale-redelivery cases ack without action.
- **Wiring**: subscriber + platform pool started from `cmd/server/main.go` behind the existing `MIGRATOR_PLATFORM_ENABLED` flag. HTTP admin handlers are NOT wired here — they land in `feat/admin-handlers`.

## Notable decisions (deviations from task / spec)

1. **NATS subject is `duragraph.events.tenant.provisioning`, not the bare `tenant.provisioning` from `async/asyncapi.yml`.** The engine's publisher.ensureStreams declares only `duragraph-events`, `duragraph-executions`, `duragraph-runs`, `duragraph-stream`; the spec's `PLATFORM_TENANTS` stream does not yet exist in runtime. Publishing under `duragraph.events.*` keeps messages durable in the existing stream. Reconciliation (add `PLATFORM_TENANTS` stream in spec, or switch to bare subject in code) is a follow-up PR. Documented inline at `command/approve_user.go:TenantProvisioningTopic`.

2. **Direct NATS publish, not outbox.** The task wording assumed User/Tenant repos write to event store + outbox. They don't — both repo file headers explicitly state "pure projection writer", and the audit-log mirror is a Wave-2 NATS subscriber. To kick off the async workflow today, command handlers publish directly via a small `command.EventPublisher` interface (satisfied by `*nats.Publisher`). Documented at the top of `approve_user.go`.

3. **`SystemActorUserID = "00000000-0000-0000-0000-000000000000"`** is the sentinel `approved_by_user_id` passed to `tenant.Approve` from the subscriber. Picked option (b) from the task brief: cleaner than reusing `tenant.UserID()` (which would surface confusing "user X approved themselves" entries in the audit log). Defined in `internal/domain/tenant/system_actor.go`.

4. **NATS Account provisioning is stubbed** behind a `NATSAccountProvisioner` interface with a `NoopNATSAccountProvisioner` default. Real operator-JWT wiring is a follow-up PR.

5. **Subscriber wired in `cmd/server/main.go`.** Per the task brief — single-binary mode is fine for v0. The platform pool (`duragraph_platform`) is also opened here, gated by the same `MIGRATOR_PLATFORM_ENABLED` flag the migrator uses.

## State machine note

`Tenant` has no `Resume()` — `Suspended` is terminal at the aggregate level. Per `auth/oauth.yml` user-level Resume restores access (the JWT/middleware path was the only thing gating the user off; the tenant DB and NATS Account were never torn down). `ResumeUserHandler` therefore touches only the User aggregate. Documented in `resume_user.go`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/application/command/... ./internal/infrastructure/messaging/... -count=1` — all pass
- [x] `go test -short ./...` — full module passes
- [ ] Integration test (out of scope per task brief)
- [ ] Real NATS round-trip via subscriber (out of scope; subscriber unit tests bypass the channel and exercise `processEvent` directly)