### PR TITLE
feat: wire OAuth handlers + add /api/platform/me

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/duragraph/duragraph/internal/infrastructure/http/dashboard"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/handlers"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/handlers/admin"
+	authhandler "github.com/duragraph/duragraph/internal/infrastructure/http/handlers/auth"
+	platformhandler "github.com/duragraph/duragraph/internal/infrastructure/http/handlers/platform"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/middleware"
 	"github.com/duragraph/duragraph/internal/infrastructure/mcp"
 	"github.com/duragraph/duragraph/internal/infrastructure/messaging"
@@ -240,7 +242,35 @@ func main() {
 	// registered. Stays nil in single-tenant deployments — the route
 	// registration site checks for nil and skips mounting handlers,
 	// preserving the empty-group fail-safe (404 on /api/admin/*).
+	//
+	// oauthHandler and platformHandler follow the same pattern: built
+	// inside the platformEnabled block (their dependencies — userRepo,
+	// tenantRepo, platformPool — only exist there), consumed downstream
+	// where /api/auth/* and /api/platform/* are registered. nil in
+	// single-tenant deployments → those routes simply aren't mounted.
 	var adminHandler *admin.Handler
+	var oauthHandler *authhandler.Handler
+	var platformHandler *platformhandler.Handler
+
+	// JWT verifier: shared between TenantMiddleware (when AUTH_ENABLED)
+	// and the OAuth handler's /api/auth/refresh endpoint (when
+	// MIGRATOR_PLATFORM_ENABLED). Hoisted out of the AUTH_ENABLED branch
+	// so the OAuth handler can depend on it without forcing the two
+	// flags to be coupled at the type level. JWT_SECRET drives both —
+	// they MUST share the same secret so refresh round-trips a token
+	// the middleware will accept on the next request.
+	var verifier *auth.Verifier
+	if os.Getenv("AUTH_ENABLED") == "true" || platformEnabled {
+		jwtSecret := os.Getenv("JWT_SECRET")
+		if jwtSecret == "" {
+			jwtSecret = "default-secret-change-in-production"
+		}
+		v, err := auth.NewVerifier([]byte(jwtSecret))
+		if err != nil {
+			log.Fatalf("failed to construct JWT verifier: %v", err)
+		}
+		verifier = v
+	}
 
 	if platformEnabled {
 		platformConfig := postgres.Config{
@@ -294,6 +324,82 @@ func main() {
 			retryMigrationCmd,
 			metricsBackend,
 		)
+
+		// OAuth handler wiring.
+		//
+		// PLATFORM_BASE_URL is the externally-facing URL of this engine
+		// (e.g. https://platform.duragraph.ai). It feeds three things:
+		//   (1) the goth provider redirect URLs ("<base>/api/auth/<p>/callback");
+		//   (2) the cookie-logout CSRF same-origin check (auth.Config.BaseURL);
+		//   (3) the CookieSecure flag (https → true, http → false).
+		// Required when MIGRATOR_PLATFORM_ENABLED — fail fast at startup
+		// rather than 500ing on first /api/auth/<provider>/login.
+		platformBaseURL := os.Getenv("PLATFORM_BASE_URL")
+		if platformBaseURL == "" {
+			log.Fatal("PLATFORM_BASE_URL is required when MIGRATOR_PLATFORM_ENABLED=true")
+		}
+		// CookieSecure derived from the base-URL scheme: production runs
+		// behind Traefik with https, dev runs plain http. Lower-case for
+		// case-insensitive scheme match — RFC 3986 says scheme is
+		// case-insensitive and we control the env var, but be lenient.
+		cookieSecure := strings.HasPrefix(strings.ToLower(platformBaseURL), "https://")
+
+		// OAUTH_SESSION_SECRET keys the gorilla/sessions cookie store
+		// goth uses to hold the OAuth state token between /login and
+		// /callback. Required + ≥32 bytes; ConfigureProviders enforces
+		// the length floor and rejects misconfigured deployments at
+		// startup.
+		oauthSessionSecret := os.Getenv("OAUTH_SESSION_SECRET")
+		if oauthSessionSecret == "" {
+			log.Fatal("OAUTH_SESSION_SECRET is required when MIGRATOR_PLATFORM_ENABLED=true")
+		}
+
+		if err := authhandler.ConfigureProviders(authhandler.ProviderConfig{
+			BaseURL:            platformBaseURL,
+			GoogleClientID:     os.Getenv("OAUTH_GOOGLE_CLIENT_ID"),
+			GoogleClientSecret: os.Getenv("OAUTH_GOOGLE_CLIENT_SECRET"),
+			GitHubClientID:     os.Getenv("OAUTH_GITHUB_CLIENT_ID"),
+			GitHubClientSecret: os.Getenv("OAUTH_GITHUB_CLIENT_SECRET"),
+			SessionSecret:      oauthSessionSecret,
+			CookieSecure:       cookieSecure,
+		}); err != nil {
+			log.Fatalf("OAuth provider configuration failed: %v", err)
+		}
+
+		// JWT_SECRET (with the verifier's default fallback) drives BOTH
+		// the verifier hoisted above AND the OAuth handler's
+		// IssueJWT/Refresh round-trip. Must be the same bytes — a
+		// refresh-issued token has to verify against the middleware's
+		// secret on the next request.
+		oauthJWTSecret := os.Getenv("JWT_SECRET")
+		if oauthJWTSecret == "" {
+			oauthJWTSecret = "default-secret-change-in-production"
+		}
+
+		oh, err := authhandler.NewHandler(
+			userRepo,
+			tenantRepo,
+			migrator,
+			verifier,
+			authhandler.NewGothExchanger(),
+			authhandler.NewPoolBootstrapLocker(platformPool),
+			authhandler.Config{
+				SessionTTL:   24 * time.Hour,
+				BaseURL:      platformBaseURL,
+				CookieDomain: os.Getenv("PLATFORM_COOKIE_DOMAIN"), // empty = host-only
+				CookieSecure: cookieSecure,
+				JWTSecret:    []byte(oauthJWTSecret),
+			},
+		)
+		if err != nil {
+			log.Fatalf("failed to construct OAuth handler: %v", err)
+		}
+		oauthHandler = oh
+
+		// /api/platform/me handler. Same lifetime + nil-fallback rules
+		// as oauthHandler — only constructed in platform mode.
+		platformHandler = platformhandler.NewHandler(userRepo, tenantRepo)
+		fmt.Println("✅ OAuth + /api/platform/me handlers constructed")
 
 		// Tenant provisioner subscriber. Uses a JetStream durable
 		// consumer (durable name "tenant-provisioner") bound to the
@@ -627,28 +733,22 @@ func main() {
 	// Public/auth-only routes (/health, /metrics, /api/auth/*) bypass
 	// TenantMiddleware via Echo's per-route middleware semantics: they
 	// are registered on the bare *echo.Echo (not under a group with
-	// TenantMiddleware applied). Future /api/auth/login, /callback,
-	// /logout endpoints will live alongside /health below.
+	// TenantMiddleware applied). The /api/auth/{provider}/login,
+	// /callback, /logout, /refresh endpoints are wired below where
+	// oauthHandler is registered (only when MIGRATOR_PLATFORM_ENABLED).
 	//
 	// Backwards compat: when AUTH_ENABLED=false (the default), no auth
 	// middleware runs at all. Existing single-tenant deployments keep
 	// working unchanged. This gate is intentionally NOT tied to
 	// MIGRATOR_PLATFORM_ENABLED — middleware applies whether or not
 	// the multi-tenant migrator is active. The two flags are
-	// orthogonal: AUTH_ENABLED gates JWT verification, the migrator
-	// flag gates platform-DB provisioning.
+	// orthogonal: AUTH_ENABLED gates JWT verification on /api/v1, the
+	// migrator flag gates platform-DB provisioning + the platform
+	// admin/auth/me endpoints. The verifier itself is hoisted above
+	// (constructed when EITHER flag is on) because the OAuth handler
+	// needs it for /api/auth/refresh.
 	authEnabled := os.Getenv("AUTH_ENABLED") == "true"
-	var verifier *auth.Verifier
 	if authEnabled {
-		jwtSecret := os.Getenv("JWT_SECRET")
-		if jwtSecret == "" {
-			jwtSecret = "default-secret-change-in-production"
-		}
-		v, err := auth.NewVerifier([]byte(jwtSecret))
-		if err != nil {
-			log.Fatalf("failed to construct JWT verifier: %v", err)
-		}
-		verifier = v
 		fmt.Println("✅ Authentication enabled (TenantMiddleware)")
 	}
 
@@ -666,6 +766,21 @@ func main() {
 	// System endpoints (LangGraph compatible)
 	e.GET("/ok", systemHandler.Ok)
 	e.GET("/info", systemHandler.Info)
+
+	// OAuth routes — public by design. /login and /callback handle the
+	// 3-leg OAuth dance themselves (state cookie via gothic, Origin
+	// check on cookie-logout, JWT verification on /refresh). Mount on
+	// the bare *echo.Echo BEFORE the /api/v1 group so TenantMiddleware
+	// is never accidentally applied to them. Single-DB / non-platform
+	// deployments leave oauthHandler == nil and these routes simply
+	// don't exist.
+	if oauthHandler != nil {
+		e.GET("/api/auth/:provider/login", oauthHandler.Login)
+		e.GET("/api/auth/:provider/callback", oauthHandler.Callback)
+		e.POST("/api/auth/logout", oauthHandler.Logout)
+		e.POST("/api/auth/refresh", oauthHandler.Refresh)
+		fmt.Println("✅ OAuth routes registered (/api/auth/{provider}/login,callback + /api/auth/logout,refresh)")
+	}
 
 	// API routes.
 	//
@@ -807,6 +922,29 @@ func main() {
 			adminHandler.Register(adminGroup)
 			fmt.Println("✅ Admin HTTP handlers registered at /api/admin/*")
 		}
+	}
+
+	// Platform self-service route group (/api/platform/*).
+	//
+	// Middleware chain is just TenantMiddleware — pending users (valid
+	// token, no tenant_id) need /api/platform/me to render their
+	// "awaiting approval" state, so we deliberately DON'T apply
+	// RequireTenant here. The endpoint itself returns 401 on missing
+	// user_id as defence-in-depth.
+	//
+	// Independent of AUTH_ENABLED: a deployment running in platform
+	// mode (MIGRATOR_PLATFORM_ENABLED=true) needs TenantMiddleware on
+	// /api/platform even when AUTH_ENABLED=false (the two flags are
+	// orthogonal — see the auth comment block above). Gating on
+	// platformHandler != nil is sufficient because platformHandler is
+	// constructed inside the same platformEnabled block as the
+	// verifier, so non-nil platformHandler implies non-nil verifier.
+	if platformHandler != nil {
+		platformGroup := e.Group("/api/platform",
+			middleware.TenantMiddleware(verifier),
+		)
+		platformHandler.Register(platformGroup)
+		fmt.Println("✅ Platform handlers registered at /api/platform/*")
 	}
 
 	// Embedded React dashboard. Must be registered after API routes so Echo's

--- a/internal/infrastructure/http/handlers/platform/me.go
+++ b/internal/infrastructure/http/handlers/platform/me.go
@@ -1,0 +1,174 @@
+// Package platform implements the self-service platform HTTP handlers
+// under /api/platform/*. The contract lives in
+// duragraph-spec/api/platform.yaml (Platform section) and
+// duragraph-spec/auth/oauth.yml § /api/platform/me.
+//
+// Auth chain: each /api/platform/* request is gated by TenantMiddleware
+// (NOT RequireTenant — pending users have valid JWTs with tenant_id=""
+// and need to reach /me to render the awaiting-approval page). By the
+// time a Handler method runs, the request context carries a verified
+// user_id; tenant_id may or may not be present depending on the user's
+// approval status.
+//
+// Spec field-name note: the canonical "me" response shape uses
+// `user_id`, matching auth/oauth.yml § /api/platform/me.response_body_shape.
+// api/platform.yaml's User schema names the same field `id` — that's a
+// known divergence between the two spec files. Wave 1 wiring honours
+// the explicit response_body_shape in oauth.yml; reconciliation is a
+// future spec PR. Don't "fix" the JSON tag here without coordinating.
+package platform
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/domain/user"
+	"github.com/duragraph/duragraph/internal/infrastructure/http/middleware"
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// Handler is the HTTP layer for /api/platform/*. All dependencies are
+// required; passing nil panics at construction time (matching the
+// admin.NewHandler convention — fail fast at startup rather than lazy
+// nil-deref on first request).
+type Handler struct {
+	userRepo   user.Repository
+	tenantRepo tenant.Repository
+}
+
+// NewHandler constructs a Handler. The user and tenant repos must both
+// be non-nil; passing nil panics. We follow the admin handler's
+// fail-fast convention here rather than returning an error because
+// these dependencies are wired exactly once at startup from main.go,
+// where a panic surfaces as a startup-time crash that's easier to
+// diagnose than a deferred 500 on first /me hit.
+func NewHandler(userRepo user.Repository, tenantRepo tenant.Repository) *Handler {
+	if userRepo == nil {
+		panic("platform.NewHandler: userRepo must not be nil")
+	}
+	if tenantRepo == nil {
+		panic("platform.NewHandler: tenantRepo must not be nil")
+	}
+	return &Handler{
+		userRepo:   userRepo,
+		tenantRepo: tenantRepo,
+	}
+}
+
+// Register mounts the platform routes under the given Echo group. The
+// caller is responsible for applying TenantMiddleware to the group
+// BEFORE calling Register; the handler does not re-apply it.
+func (h *Handler) Register(g *echo.Group) {
+	g.GET("/me", h.Me)
+}
+
+// MeResponse mirrors the response_body_shape declared in
+// duragraph-spec/auth/oauth.yml § /api/platform/me. TenantID is a
+// pointer because pending users have no tenant — the spec models that
+// as nullable, which JSON-omits to `null` (not a missing field).
+type MeResponse struct {
+	UserID    string    `json:"user_id"`
+	Email     string    `json:"email"`
+	Role      string    `json:"role"`
+	Status    string    `json:"status"`
+	TenantID  *string   `json:"tenant_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// errorResponse is the canonical error envelope used elsewhere in the
+// platform-namespace handlers. Local copy rather than importing
+// admin/dto's ErrorResponse to keep the platform package free of
+// admin-specific imports — the JSON shape on the wire is identical.
+type errorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message,omitempty"`
+}
+
+// Me handles GET /api/platform/me.
+//
+// Returns the currently authenticated user's identity + status +
+// (optional) tenant_id. Responds 401 in two failure modes:
+//
+//   - No user_id in the request context. TenantMiddleware is supposed
+//     to populate this on every authenticated request; absence here
+//     means either the middleware wasn't applied (route mis-wired) or
+//     the request had no token. Defense-in-depth: 401 on either path.
+//
+//   - User row not found. The token references a user the platform
+//     no longer has a record of (e.g. an admin deleted the row mid-
+//     session). Treat as logged-out: 401, prompting the dashboard to
+//     clear its cookie and route to /login.
+//
+// The tenant lookup is best-effort: a NotFound error for an approved
+// user yields tenant_id=null in the response (data-invariant violation,
+// but logging it is more useful than 500ing — the dashboard's pending/
+// suspended pages render fine without a tenant_id, and a 500 would
+// block the user from logging out).
+func (h *Handler) Me(c echo.Context) error {
+	userID, ok := middleware.UserIDFromCtx(c)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, errorResponse{
+			Error:   "unauthorized",
+			Message: "missing authenticated user",
+		})
+	}
+
+	ctx := c.Request().Context()
+
+	u, err := h.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, pkgerrors.ErrNotFound) {
+			// Token references a nonexistent user — treat as
+			// logged-out per the spec's "401 when neither
+			// [cookie nor bearer] is present or valid".
+			return c.JSON(http.StatusUnauthorized, errorResponse{
+				Error:   "unauthorized",
+				Message: "user not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, errorResponse{
+			Error:   "internal_error",
+			Message: "failed to look up user",
+		})
+	}
+
+	resp := MeResponse{
+		UserID:    u.ID(),
+		Email:     u.Email(),
+		Role:      string(u.Role()),
+		Status:    string(u.Status()),
+		TenantID:  h.lookupTenantID(ctx, u),
+		CreatedAt: u.CreatedAt(),
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// lookupTenantID returns a non-nil tenant_id only for approved users
+// with an existing tenant row. Pending and suspended users — and any
+// approved user whose tenant lookup fails — get nil (rendered as JSON
+// null). Errors are logged but not surfaced to the client; /me must
+// stay reachable for pending users and shouldn't 500 on a transient
+// platform-DB blip during tenant lookup.
+func (h *Handler) lookupTenantID(ctx context.Context, u *user.User) *string {
+	if u.Status() != user.StatusApproved {
+		return nil
+	}
+	t, err := h.tenantRepo.GetByUserID(ctx, u.ID())
+	if err != nil {
+		// Don't fail the endpoint. Approved-without-tenant is a
+		// data-invariant violation (admin approval is meant to
+		// provision atomically) but the dashboard renders fine with
+		// a null tenant_id — the user can still log out. Log so the
+		// case is diagnosable post-hoc.
+		log.Printf("platform/me: tenant lookup failed for approved user %s: %v", u.ID(), err)
+		return nil
+	}
+	id := t.ID()
+	return &id
+}

--- a/internal/infrastructure/http/handlers/platform/me_test.go
+++ b/internal/infrastructure/http/handlers/platform/me_test.go
@@ -1,0 +1,379 @@
+// Tests for the /api/platform/me handler. Mirrors the hand-rolled-stub
+// pattern from internal/infrastructure/http/handlers/auth (no testify):
+// each test wires a stubUserRepo / stubTenantRepo with the closure
+// behaviour it cares about and seeds the request context's
+// `platform.user_id` directly (matching admin/handler_test.go's pattern,
+// since TenantMiddleware doesn't run in unit tests).
+
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/domain/user"
+	pkgerrors "github.com/duragraph/duragraph/internal/pkg/errors"
+)
+
+// ctxKeyPlatformUserID mirrors middleware.ctxKeyPlatformUserID. The
+// middleware accessor is `UserIDFromCtx` (read-only) and the writer
+// `withUserID` is unexported — tests in this package have to seed the
+// raw key, exactly the pattern admin/handler_test.go uses. Keep the
+// constant in sync with internal/infrastructure/http/middleware/ctxkeys.go.
+const ctxKeyPlatformUserID = "platform.user_id"
+
+// ---- stubs ---------------------------------------------------------------
+
+type stubUserRepo struct {
+	getByIDFn func(ctx context.Context, id string) (*user.User, error)
+}
+
+func (r *stubUserRepo) Save(_ context.Context, _ *user.User) error { return nil }
+func (r *stubUserRepo) GetByID(ctx context.Context, id string) (*user.User, error) {
+	if r.getByIDFn != nil {
+		return r.getByIDFn(ctx, id)
+	}
+	return nil, pkgerrors.NotFound("user", id)
+}
+func (r *stubUserRepo) GetByOAuth(_ context.Context, provider, oauthID string) (*user.User, error) {
+	return nil, pkgerrors.NotFound("user", provider+"/"+oauthID)
+}
+func (r *stubUserRepo) ListByStatus(_ context.Context, _ user.Status, _, _ int) ([]*user.User, error) {
+	return nil, nil
+}
+func (r *stubUserRepo) List(_ context.Context, _ *user.Status, _, _ int) ([]*user.User, error) {
+	return nil, nil
+}
+func (r *stubUserRepo) CountByStatus(_ context.Context, _ *user.Status) (int, error) {
+	return 0, nil
+}
+func (r *stubUserRepo) CountAll(_ context.Context) (int, error) { return 0, nil }
+
+type stubTenantRepo struct {
+	getByUserIDFn func(ctx context.Context, userID string) (*tenant.Tenant, error)
+}
+
+func (r *stubTenantRepo) Save(_ context.Context, _ *tenant.Tenant) error { return nil }
+func (r *stubTenantRepo) GetByID(_ context.Context, id string) (*tenant.Tenant, error) {
+	return nil, pkgerrors.NotFound("tenant", id)
+}
+func (r *stubTenantRepo) GetByUserID(ctx context.Context, userID string) (*tenant.Tenant, error) {
+	if r.getByUserIDFn != nil {
+		return r.getByUserIDFn(ctx, userID)
+	}
+	return nil, pkgerrors.NotFound("tenant for user", userID)
+}
+func (r *stubTenantRepo) ListByStatus(_ context.Context, _ tenant.Status, _, _ int) ([]*tenant.Tenant, error) {
+	return nil, nil
+}
+
+// ---- helpers -------------------------------------------------------------
+
+func newCtx(t *testing.T, userID string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/platform/me", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if userID != "" {
+		c.Set(ctxKeyPlatformUserID, userID)
+	}
+	return c, rec
+}
+
+func decodeMe(t *testing.T, rec *httptest.ResponseRecorder) MeResponse {
+	t.Helper()
+	var resp MeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal MeResponse: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+// ---- tests ---------------------------------------------------------------
+
+// 401 when no user_id is present in the request context. Defence-in-
+// depth — TenantMiddleware should always set it; absence means the
+// route was mis-wired or token verification was bypassed.
+func TestMe_NoUserID_401(t *testing.T) {
+	h := NewHandler(&stubUserRepo{}, &stubTenantRepo{})
+
+	c, rec := newCtx(t, "")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// 401 when the user_id refers to a row that no longer exists (e.g.
+// admin deleted the user mid-session). Treat as logged-out per the
+// spec rather than 404 — the dashboard should clear its cookie.
+func TestMe_UserNotFound_401(t *testing.T) {
+	h := NewHandler(
+		&stubUserRepo{
+			getByIDFn: func(_ context.Context, _ string) (*user.User, error) {
+				return nil, pkgerrors.NotFound("user", "missing")
+			},
+		},
+		&stubTenantRepo{},
+	)
+
+	c, rec := newCtx(t, "missing")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// 500 on unexpected user-repo errors (DB connection failure, etc.).
+// Distinguished from 401-NotFound because the request is otherwise
+// well-formed; surfacing 500 helps the dashboard distinguish "your
+// session is bad, log out" from "the platform is having a bad day".
+func TestMe_UserRepoError_500(t *testing.T) {
+	h := NewHandler(
+		&stubUserRepo{
+			getByIDFn: func(_ context.Context, _ string) (*user.User, error) {
+				return nil, errors.New("db dead")
+			},
+		},
+		&stubTenantRepo{},
+	)
+
+	c, rec := newCtx(t, "user-1")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// Pending user → 200 with tenant_id=null. The tenant repo is NOT
+// consulted because the user is pre-approval.
+func TestMe_PendingUser_200_NullTenant(t *testing.T) {
+	pending := user.ReconstructFromData(user.UserData{
+		ID:            "user-pending",
+		Email:         "alice@example.com",
+		OAuthProvider: "google",
+		OAuthID:       "google-sub-1",
+		Role:          string(user.RoleUser),
+		Status:        string(user.StatusPending),
+		CreatedAt:     time.Now().UTC().Truncate(time.Second),
+		UpdatedAt:     time.Now().UTC().Truncate(time.Second),
+	})
+
+	tenantCalls := 0
+	h := NewHandler(
+		&stubUserRepo{
+			getByIDFn: func(_ context.Context, _ string) (*user.User, error) {
+				return pending, nil
+			},
+		},
+		&stubTenantRepo{
+			getByUserIDFn: func(_ context.Context, _ string) (*tenant.Tenant, error) {
+				tenantCalls++
+				return nil, pkgerrors.NotFound("tenant", "")
+			},
+		},
+	)
+
+	c, rec := newCtx(t, "user-pending")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	resp := decodeMe(t, rec)
+	if resp.UserID != "user-pending" {
+		t.Errorf("user_id: want user-pending, got %q", resp.UserID)
+	}
+	if resp.Status != "pending" {
+		t.Errorf("status: want pending, got %q", resp.Status)
+	}
+	if resp.TenantID != nil {
+		t.Errorf("tenant_id: want nil, got %v", *resp.TenantID)
+	}
+	if tenantCalls != 0 {
+		t.Errorf("tenant repo should not be consulted for pending users; got %d calls", tenantCalls)
+	}
+}
+
+// Approved user with a tenant row → 200 with tenant_id populated.
+func TestMe_ApprovedUser_200_PopulatedTenant(t *testing.T) {
+	approved := user.ReconstructFromData(user.UserData{
+		ID:            "user-approved",
+		Email:         "bob@example.com",
+		OAuthProvider: "github",
+		OAuthID:       "github-sub-2",
+		Role:          string(user.RoleAdmin),
+		Status:        string(user.StatusApproved),
+		CreatedAt:     time.Now().UTC().Truncate(time.Second),
+		UpdatedAt:     time.Now().UTC().Truncate(time.Second),
+	})
+	approvedTenant := tenant.ReconstructFromData(tenant.TenantData{
+		ID:        "11111111-1111-1111-1111-111111111111",
+		UserID:    "user-approved",
+		DBName:    "tenant_11111111111111111111111111111111",
+		Status:    string(tenant.StatusApproved),
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		UpdatedAt: time.Now().UTC().Truncate(time.Second),
+	})
+
+	h := NewHandler(
+		&stubUserRepo{
+			getByIDFn: func(_ context.Context, _ string) (*user.User, error) {
+				return approved, nil
+			},
+		},
+		&stubTenantRepo{
+			getByUserIDFn: func(_ context.Context, _ string) (*tenant.Tenant, error) {
+				return approvedTenant, nil
+			},
+		},
+	)
+
+	c, rec := newCtx(t, "user-approved")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	resp := decodeMe(t, rec)
+	if resp.Status != "approved" {
+		t.Errorf("status: want approved, got %q", resp.Status)
+	}
+	if resp.Role != "admin" {
+		t.Errorf("role: want admin, got %q", resp.Role)
+	}
+	if resp.TenantID == nil {
+		t.Fatal("tenant_id: want populated, got nil")
+	}
+	if *resp.TenantID != approvedTenant.ID() {
+		t.Errorf("tenant_id: want %s, got %s", approvedTenant.ID(), *resp.TenantID)
+	}
+}
+
+// Approved user but the tenant lookup blew up — fall back to nil
+// tenant_id rather than 500. Documented behaviour: the dashboard's
+// logout flow shouldn't be blocked on a transient platform-DB error.
+func TestMe_ApprovedUser_TenantLookupError_NullTenant(t *testing.T) {
+	approved := user.ReconstructFromData(user.UserData{
+		ID:            "user-approved",
+		Email:         "bob@example.com",
+		OAuthProvider: "github",
+		OAuthID:       "github-sub-2",
+		Role:          string(user.RoleUser),
+		Status:        string(user.StatusApproved),
+		CreatedAt:     time.Now().UTC().Truncate(time.Second),
+		UpdatedAt:     time.Now().UTC().Truncate(time.Second),
+	})
+
+	h := NewHandler(
+		&stubUserRepo{
+			getByIDFn: func(_ context.Context, _ string) (*user.User, error) {
+				return approved, nil
+			},
+		},
+		&stubTenantRepo{
+			getByUserIDFn: func(_ context.Context, _ string) (*tenant.Tenant, error) {
+				return nil, errors.New("platform DB unavailable")
+			},
+		},
+	)
+
+	c, rec := newCtx(t, "user-approved")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	resp := decodeMe(t, rec)
+	if resp.TenantID != nil {
+		t.Errorf("tenant_id: want nil on tenant-lookup error, got %v", *resp.TenantID)
+	}
+}
+
+// Suspended user → 200 with tenant_id=null. Dashboard renders a
+// suspended-state page; tenant repo is not consulted.
+func TestMe_SuspendedUser_200_NullTenant(t *testing.T) {
+	suspended := user.ReconstructFromData(user.UserData{
+		ID:            "user-suspended",
+		Email:         "carol@example.com",
+		OAuthProvider: "google",
+		OAuthID:       "google-sub-3",
+		Role:          string(user.RoleUser),
+		Status:        string(user.StatusSuspended),
+		CreatedAt:     time.Now().UTC().Truncate(time.Second),
+		UpdatedAt:     time.Now().UTC().Truncate(time.Second),
+	})
+
+	tenantCalls := 0
+	h := NewHandler(
+		&stubUserRepo{
+			getByIDFn: func(_ context.Context, _ string) (*user.User, error) {
+				return suspended, nil
+			},
+		},
+		&stubTenantRepo{
+			getByUserIDFn: func(_ context.Context, _ string) (*tenant.Tenant, error) {
+				tenantCalls++
+				return nil, nil
+			},
+		},
+	)
+
+	c, rec := newCtx(t, "user-suspended")
+	if err := h.Me(c); err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	resp := decodeMe(t, rec)
+	if resp.Status != "suspended" {
+		t.Errorf("status: want suspended, got %q", resp.Status)
+	}
+	if resp.TenantID != nil {
+		t.Errorf("tenant_id: want nil, got %v", *resp.TenantID)
+	}
+	if tenantCalls != 0 {
+		t.Errorf("tenant repo should not be consulted for suspended users; got %d calls", tenantCalls)
+	}
+}
+
+// Constructor panics on nil deps — fail-fast convention shared with
+// admin.NewHandler. Catching this at startup beats deferred 500s.
+func TestNewHandler_PanicsOnNil(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"nil userRepo", func() { NewHandler(nil, &stubTenantRepo{}) }},
+		{"nil tenantRepo", func() { NewHandler(&stubUserRepo{}, nil) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got none")
+				}
+			}()
+			tc.fn()
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Wave 1 final wiring PR. Connects the OAuth handlers from #154 into `cmd/server/main.go` and adds the small `/api/platform/me` endpoint the dashboard's awaiting-approval page depends on.

## What's wired

Gated on `MIGRATOR_PLATFORM_ENABLED=true`:

| Method | Path | Handler |
|--------|------|---------|
| GET    | `/api/auth/{provider}/login`    | `oauthHandler.Login` |
| GET    | `/api/auth/{provider}/callback` | `oauthHandler.Callback` |
| POST   | `/api/auth/logout`              | `oauthHandler.Logout` |
| POST   | `/api/auth/refresh`             | `oauthHandler.Refresh` |
| GET    | `/api/platform/me`              | `platformHandler.Me` |

OAuth routes mount on the bare `*echo.Echo` before `/api/v1` so `TenantMiddleware` never accidentally applies. `/api/platform/me` mounts on its own group with `TenantMiddleware` (NOT `RequireTenant` -- pending users with `tenant_id=""` still need `/me`).

## Structural change: verifier hoisting

The JWT `*auth.Verifier` was previously built only inside the `AUTH_ENABLED` branch. The OAuth handler needs it for `/api/auth/refresh`, so I hoisted construction to fire when `AUTH_ENABLED || MIGRATOR_PLATFORM_ENABLED`. Same `JWT_SECRET` (with the existing `default-secret-change-in-production` fallback) drives both verifier and `auth.Config.JWTSecret`, so a token issued by `/refresh` verifies on the next middleware-gated request.

The two flags remain orthogonal at every other site (TenantMiddleware on `/api/v1` is still gated only on `AUTH_ENABLED`; admin route group registration unchanged).

## New package: `internal/infrastructure/http/handlers/platform`

Hand-rolled stub repos, matching the auth + admin handler test conventions (no testify). Tests cover:

- 401 when no `user_id` in ctx (defense-in-depth -- `TenantMiddleware` should always set it)
- 401 when user row not found (token references deleted user -> treat as logged out)
- 500 on unexpected user-repo errors
- 200 pending user with `tenant_id=null`
- 200 approved user with `tenant_id` populated
- 200 suspended user with `tenant_id=null`
- 200 approved-but-tenant-lookup-failed -- `tenant_id=null` with stderr log (don't 500 on transient platform-DB blips)
- Constructor panics on nil deps (matches `admin.NewHandler` convention)

Spec note: the response field name is `user_id` per `auth/oauth.yml § /api/platform/me.response_body_shape`. `api/platform.yaml § schemas.User` names the same field `id` -- a known divergence between the two spec files. Honouring the explicit response_body_shape in oauth.yml; reconciliation is a future spec PR. Documented in the handler.

## Required env vars for platform mode

When `MIGRATOR_PLATFORM_ENABLED=true`:

- `PLATFORM_BASE_URL` -- required; externally-facing URL (e.g. `https://platform.duragraph.ai`). `https` scheme -> `CookieSecure=true`.
- `OAUTH_SESSION_SECRET` -- required; >=32 bytes (`ConfigureProviders` rejects shorter values at startup).
- `OAUTH_GOOGLE_CLIENT_ID` + `OAUTH_GOOGLE_CLIENT_SECRET` and/or `OAUTH_GITHUB_CLIENT_ID` + `OAUTH_GITHUB_CLIENT_SECRET` -- at least one provider pair must be set (`ConfigureProviders` enforces this).
- `PLATFORM_COOKIE_DOMAIN` -- optional; empty = host-only cookie.
- `JWT_SECRET` -- shared with the verifier; existing var. Must be the same bytes for refresh round-trips to succeed.

Single-DB / non-platform deployments (`MIGRATOR_PLATFORM_ENABLED` unset) leave `oauthHandler` and `platformHandler` nil and skip route registration entirely -- backwards-compatible.

## Test plan

- [x] `go build ./...` -- clean
- [x] `go test -short ./...` -- all packages pass
- [x] `go test ./internal/infrastructure/http/handlers/auth/... ./internal/infrastructure/http/handlers/platform/... ./internal/infrastructure/http/middleware/... -count=1` -- targeted suites pass
- [ ] Smoke against a real platform-mode deployment: confirm `/api/auth/google/login` redirects, callback issues a session cookie, `/api/platform/me` returns 200 with a JWT cookie present
- [ ] Confirm `/api/auth/refresh` round-trips a token that subsequently passes `TenantMiddleware` on `/api/v1/*`