### PR TITLE
docs: cross-reference Platform Mode docs from RUNBOOK

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,6 +2,13 @@
 
 Complete guide for running and managing the DuraGraph application.
 
+> **Multi-tenant deployment?** This runbook covers single-tenant operation.
+> For Platform Mode (multi-tenant SaaS with OAuth, admin UI, per-tenant
+> databases), see the
+> [Platform Mode section in the deployment docs](https://duragraph.ai/docs/ops/deployment/#platform-mode-multi-tenant)
+> — covers `MIGRATOR_PLATFORM_ENABLED`, OAuth provider setup, and the
+> first-user bootstrap flow.
+
 ## Table of Contents
 
 1. [Prerequisites](#prerequisites)


### PR DESCRIPTION
## Summary

- Adds a callout near the top of `RUNBOOK.md` pointing operators running multi-tenant Platform Mode to the new deployment docs section
- Single-tenant operation continues to be the runbook's primary focus

## Why

The `Platform Mode` deployment doc (Duragraph/duragraph-docs#12, merged) covers `MIGRATOR_PLATFORM_ENABLED`, OAuth provider setup, secret generation, and the first-user bootstrap flow. RUNBOOK previously had no signal that this mode existed — operators looking up "how to run Duragraph" would miss it entirely.

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] Link resolves once docs site updates (3ba6cf8 already on main of duragraph-docs)