### PR TITLE
feat: add tenant_id labels to metrics + register assistants/threads gauges

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -548,10 +548,10 @@ func main() {
 	createRunHandler := command.NewCreateRunHandler(runRepo)
 	submitToolOutputsHandler := command.NewSubmitToolOutputsHandler(runRepo, interruptRepo)
 	deleteRunHandler := command.NewDeleteRunHandler(runRepo)
-	createAssistantHandler := command.NewCreateAssistantHandler(assistantRepo)
+	createAssistantHandler := command.NewCreateAssistantHandler(assistantRepo, metrics)
 	updateAssistantHandler := command.NewUpdateAssistantHandler(assistantRepo)
-	deleteAssistantHandler := command.NewDeleteAssistantHandler(assistantRepo)
-	createThreadHandler := command.NewCreateThreadHandler(threadRepo)
+	deleteAssistantHandler := command.NewDeleteAssistantHandler(assistantRepo, metrics)
+	createThreadHandler := command.NewCreateThreadHandler(threadRepo, metrics)
 	updateThreadHandler := command.NewUpdateThreadHandler(threadRepo)
 	addMessageHandler := command.NewAddMessageHandler(threadRepo)
 
@@ -566,7 +566,7 @@ func main() {
 	listThreadsHandler := query.NewListThreadsHandler(threadRepo)
 	searchThreadsHandler := query.NewSearchThreadsHandler(threadRepo)
 	countThreadsHandler := query.NewCountThreadsHandler(threadRepo)
-	deleteThreadHandler := command.NewDeleteThreadHandler(threadRepo)
+	deleteThreadHandler := command.NewDeleteThreadHandler(threadRepo, metrics)
 
 	// Initialize checkpoint handlers
 	getThreadStateHandler := query.NewGetThreadStateHandler(checkpointRepo)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -272,6 +272,23 @@ func main() {
 		verifier = v
 	}
 
+	// Initialize Prometheus metrics. Hoisted above the platformEnabled
+	// block so the per-tenant gauge bootstrap (bootstrapTenantMetrics)
+	// can seed AssistantsTotal/ThreadsTotal from the DB at startup —
+	// otherwise those gauges start at 0 on every restart and the first
+	// delete after restart can produce a negative value.
+	metrics := monitoring.NewMetrics("duragraph")
+
+	// Register DB pool collectors for Prometheus
+	writePoolCollector := monitoring.NewDBPoolCollector(pools.Write, "duragraph", "write")
+	prometheus.MustRegister(writePoolCollector)
+	if pools.Read != pools.Write {
+		readPoolCollector := monitoring.NewDBPoolCollector(pools.Read, "duragraph", "read")
+		prometheus.MustRegister(readPoolCollector)
+	}
+
+	fmt.Println("✅ Prometheus metrics + DB pool collectors registered")
+
 	if platformEnabled {
 		platformConfig := postgres.Config{
 			Host:     cfg.Database.Host,
@@ -433,6 +450,16 @@ func main() {
 			}
 		}()
 		fmt.Println("✅ Tenant provisioner JetStream subscriber started (durable: tenant-provisioner)")
+
+		// Seed per-tenant assistants_total / threads_total gauges from
+		// the DB before the HTTP server starts. Otherwise those gauges
+		// start at 0 on every restart and the first delete after
+		// restart can produce a negative value. Per-tenant errors are
+		// logged + skipped so a single broken tenant DB doesn't block
+		// engine startup.
+		if err := bootstrapTenantMetrics(ctx, writeConfig, tenantRepo, metrics, log.Default()); err != nil {
+			log.Printf("metrics bootstrap returned error: %v (engine continues)", err)
+		}
 	}
 
 	// Start cleanup worker
@@ -510,19 +537,6 @@ func main() {
 			}
 		}
 	}()
-
-	// Initialize Prometheus metrics
-	metrics := monitoring.NewMetrics("duragraph")
-
-	// Register DB pool collectors for Prometheus
-	writePoolCollector := monitoring.NewDBPoolCollector(pools.Write, "duragraph", "write")
-	prometheus.MustRegister(writePoolCollector)
-	if pools.Read != pools.Write {
-		readPoolCollector := monitoring.NewDBPoolCollector(pools.Read, "duragraph", "read")
-		prometheus.MustRegister(readPoolCollector)
-	}
-
-	fmt.Println("✅ Prometheus metrics + DB pool collectors registered")
 
 	// Initialize tool registry with built-in tools
 	toolRegistry := tools.NewRegistry()

--- a/cmd/server/metrics_bootstrap.go
+++ b/cmd/server/metrics_bootstrap.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/duragraph/duragraph/internal/domain/tenant"
+	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
+	"github.com/duragraph/duragraph/internal/infrastructure/persistence/postgres"
+)
+
+// bootstrapTenantMaxList caps the per-tenant gauge bootstrap to a sane
+// upper bound. At MVP scale (well under 10k approved tenants per
+// engine) this is effectively "list everything".
+const bootstrapTenantMaxList = 10000
+
+// bootstrapTenantMetrics seeds the per-tenant assistants_total and
+// threads_total gauges from the database at engine startup.
+//
+// Why: those gauges are otherwise driven only by the Inc/Dec calls in
+// the CreateAssistant/DeleteAssistant + CreateThread/DeleteThread
+// command handlers. Without this seed, on every engine restart the
+// gauges start at 0 and the first delete after restart can produce a
+// negative value — gauge value after restart is then
+// `0 + (creates - deletes) since restart`, not the true total.
+//
+// Approach: list approved tenants from the platform DB, then for each
+// approved tenant open a one-shot pgxpool against the tenant DB,
+// SELECT count(*) on assistants and threads, and Set() the gauge
+// directly via WithLabelValues. Pools are closed before moving on so
+// bootstrap doesn't accumulate connections.
+//
+// Per-tenant errors are logged and skipped: a single missing/broken
+// tenant DB must NOT block engine startup. Aggregate failures are
+// surfaced in the return value only when listing approved tenants
+// itself fails — the function logs and returns nil in that case so
+// the engine still comes up.
+//
+// Multi-replica deployments would need a separate reconciliation
+// strategy (e.g. periodic resync from DB) — out of scope for v1.
+func bootstrapTenantMetrics(
+	ctx context.Context,
+	dbCfg postgres.Config,
+	tenantRepo tenant.Repository,
+	metrics *monitoring.Metrics,
+	logger *log.Logger,
+) error {
+	if metrics == nil || tenantRepo == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+
+	tenants, err := tenantRepo.ListByStatus(ctx, tenant.StatusApproved, bootstrapTenantMaxList, 0)
+	if err != nil {
+		logger.Printf("metrics bootstrap: list approved tenants failed: %v (gauges remain at zero)", err)
+		return nil
+	}
+	if len(tenants) == 0 {
+		logger.Println("metrics bootstrap: no approved tenants; nothing to seed")
+		return nil
+	}
+
+	seeded := 0
+	for _, t := range tenants {
+		if ctx.Err() != nil {
+			logger.Printf("metrics bootstrap: ctx cancelled after %d/%d tenants", seeded, len(tenants))
+			return ctx.Err()
+		}
+		if err := seedTenantGauges(ctx, dbCfg, t.ID(), metrics, logger); err != nil {
+			logger.Printf("metrics bootstrap: tenant %s skipped: %v", t.ID(), err)
+			continue
+		}
+		seeded++
+	}
+	fmt.Printf("✅ Tenant metrics bootstrap complete (%d/%d tenants seeded)\n", seeded, len(tenants))
+	return nil
+}
+
+// seedTenantGauges opens a one-shot pool against a single tenant DB,
+// counts assistants + threads, and writes the result to the
+// per-tenant gauges. The pool is closed before return so bootstrap
+// holds zero connections after this function exits.
+func seedTenantGauges(
+	ctx context.Context,
+	dbCfg postgres.Config,
+	tenantID string,
+	metrics *monitoring.Metrics,
+	logger *log.Logger,
+) error {
+	dbName, err := tenant.DBName(tenantID)
+	if err != nil {
+		return fmt.Errorf("derive db name: %w", err)
+	}
+
+	tenantCfg := dbCfg
+	tenantCfg.Database = dbName
+
+	pool, err := postgres.NewPool(ctx, tenantCfg)
+	if err != nil {
+		return fmt.Errorf("open tenant pool (db=%s): %w", dbName, err)
+	}
+	defer pool.Close()
+
+	var assistantCount int64
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM assistants`).Scan(&assistantCount); err != nil {
+		// A tenant DB without the expected table indicates an
+		// out-of-band migration state — log and continue rather than
+		// abort startup.
+		return fmt.Errorf("count assistants (db=%s): %w", dbName, err)
+	}
+	metrics.AssistantsTotal.WithLabelValues(tenantID).Set(float64(assistantCount))
+
+	var threadCount int64
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM threads`).Scan(&threadCount); err != nil {
+		return fmt.Errorf("count threads (db=%s): %w", dbName, err)
+	}
+	metrics.ThreadsTotal.WithLabelValues(tenantID).Set(float64(threadCount))
+
+	logger.Printf("metrics bootstrap: tenant %s seeded (assistants=%d threads=%d)", tenantID, assistantCount, threadCount)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect

--- a/internal/application/command/command_test.go
+++ b/internal/application/command/command_test.go
@@ -124,7 +124,7 @@ func TestDeleteRunHandler_NotFound(t *testing.T) {
 
 func TestCreateAssistantHandler_Success(t *testing.T) {
 	repo := mocks.NewAssistantRepository()
-	handler := NewCreateAssistantHandler(repo)
+	handler := NewCreateAssistantHandler(repo, nil)
 
 	id, err := handler.Handle(context.Background(), CreateAssistant{
 		Name:         "my-bot",
@@ -144,7 +144,7 @@ func TestCreateAssistantHandler_Success(t *testing.T) {
 }
 
 func TestCreateAssistantHandler_MissingName(t *testing.T) {
-	handler := NewCreateAssistantHandler(mocks.NewAssistantRepository())
+	handler := NewCreateAssistantHandler(mocks.NewAssistantRepository(), nil)
 	_, err := handler.Handle(context.Background(), CreateAssistant{
 		Model: "gpt-4",
 	})
@@ -158,7 +158,7 @@ func TestCreateAssistantHandler_SaveError(t *testing.T) {
 	repo.SaveFunc = func(ctx context.Context, a *workflow.Assistant) error {
 		return fmt.Errorf("db error")
 	}
-	handler := NewCreateAssistantHandler(repo)
+	handler := NewCreateAssistantHandler(repo, nil)
 
 	_, err := handler.Handle(context.Background(), CreateAssistant{Name: "bot"})
 	if err == nil {
@@ -202,7 +202,7 @@ func TestDeleteAssistantHandler_Success(t *testing.T) {
 	a, _ := workflow.NewAssistant("bot", "desc", "gpt-4", "inst", nil, nil)
 	repo.Assistants[a.ID()] = a
 
-	handler := NewDeleteAssistantHandler(repo)
+	handler := NewDeleteAssistantHandler(repo, nil)
 	err := handler.Handle(context.Background(), DeleteAssistantCommand{AssistantID: a.ID()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -213,7 +213,7 @@ func TestDeleteAssistantHandler_Success(t *testing.T) {
 }
 
 func TestDeleteAssistantHandler_NotFound(t *testing.T) {
-	handler := NewDeleteAssistantHandler(mocks.NewAssistantRepository())
+	handler := NewDeleteAssistantHandler(mocks.NewAssistantRepository(), nil)
 	err := handler.Handle(context.Background(), DeleteAssistantCommand{AssistantID: "x"})
 	if err == nil {
 		t.Fatal("expected error for missing assistant")
@@ -222,7 +222,7 @@ func TestDeleteAssistantHandler_NotFound(t *testing.T) {
 
 func TestCreateThreadHandler_Success(t *testing.T) {
 	repo := mocks.NewThreadRepository()
-	handler := NewCreateThreadHandler(repo)
+	handler := NewCreateThreadHandler(repo, nil)
 
 	id, err := handler.Handle(context.Background(), CreateThread{
 		Metadata: map[string]interface{}{"key": "value"},
@@ -243,7 +243,7 @@ func TestCreateThreadHandler_SaveError(t *testing.T) {
 	repo.SaveFunc = func(ctx context.Context, t *workflow.Thread) error {
 		return fmt.Errorf("db error")
 	}
-	handler := NewCreateThreadHandler(repo)
+	handler := NewCreateThreadHandler(repo, nil)
 
 	_, err := handler.Handle(context.Background(), CreateThread{})
 	if err == nil {
@@ -279,7 +279,7 @@ func TestDeleteThreadHandler_Success(t *testing.T) {
 	th, _ := workflow.NewThread(nil)
 	repo.Threads[th.ID()] = th
 
-	handler := NewDeleteThreadHandler(repo)
+	handler := NewDeleteThreadHandler(repo, nil)
 	err := handler.Handle(context.Background(), DeleteThreadCommand{ThreadID: th.ID()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/application/command/create_assistant.go
+++ b/internal/application/command/create_assistant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
-	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 	"github.com/duragraph/duragraph/internal/pkg/errors"
 )
 
@@ -23,17 +22,24 @@ type CreateAssistant struct {
 	Metadata     map[string]interface{}
 }
 
-// CreateAssistantHandler handles the CreateAssistant command
+// CreateAssistantHandler handles the CreateAssistant command.
+//
+// metrics is an application-layer port (see ports.go); the
+// infrastructure *monitoring.Metrics satisfies it. The per-tenant
+// assistants gauge driven by IncAssistants/DecAssistants depends on a
+// startup bootstrap (cmd/server/metrics_bootstrap.go) to be
+// authoritative — multi-replica deployments would need a separate
+// reconciliation strategy (out of scope for v1).
 type CreateAssistantHandler struct {
 	assistantRepo workflow.AssistantRepository
-	metrics       *monitoring.Metrics
+	metrics       Metrics
 }
 
 // NewCreateAssistantHandler creates a new CreateAssistantHandler.
 //
 // metrics may be nil — handlers degrade silently rather than panicking
 // in test environments that don't wire up a Prometheus registry.
-func NewCreateAssistantHandler(assistantRepo workflow.AssistantRepository, metrics *monitoring.Metrics) *CreateAssistantHandler {
+func NewCreateAssistantHandler(assistantRepo workflow.AssistantRepository, metrics Metrics) *CreateAssistantHandler {
 	return &CreateAssistantHandler{
 		assistantRepo: assistantRepo,
 		metrics:       metrics,

--- a/internal/application/command/create_assistant.go
+++ b/internal/application/command/create_assistant.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 	"github.com/duragraph/duragraph/internal/pkg/errors"
 )
 
 // CreateAssistant command
 type CreateAssistant struct {
+	// TenantID is the tenant scope for the new assistant. Empty string
+	// is valid in single-tenant / dev deployments and is forwarded as-is
+	// to the metrics layer (where it surfaces as a single "" series).
+	TenantID     string
 	GraphID      string
 	Name         string
 	Description  string
@@ -21,12 +26,17 @@ type CreateAssistant struct {
 // CreateAssistantHandler handles the CreateAssistant command
 type CreateAssistantHandler struct {
 	assistantRepo workflow.AssistantRepository
+	metrics       *monitoring.Metrics
 }
 
-// NewCreateAssistantHandler creates a new CreateAssistantHandler
-func NewCreateAssistantHandler(assistantRepo workflow.AssistantRepository) *CreateAssistantHandler {
+// NewCreateAssistantHandler creates a new CreateAssistantHandler.
+//
+// metrics may be nil — handlers degrade silently rather than panicking
+// in test environments that don't wire up a Prometheus registry.
+func NewCreateAssistantHandler(assistantRepo workflow.AssistantRepository, metrics *monitoring.Metrics) *CreateAssistantHandler {
 	return &CreateAssistantHandler{
 		assistantRepo: assistantRepo,
+		metrics:       metrics,
 	}
 }
 
@@ -54,6 +64,10 @@ func (h *CreateAssistantHandler) Handle(ctx context.Context, cmd CreateAssistant
 	// Save to repository
 	if err := h.assistantRepo.Save(ctx, assistant); err != nil {
 		return "", errors.Internal("failed to save assistant", err)
+	}
+
+	if h.metrics != nil {
+		h.metrics.IncAssistants(cmd.TenantID)
 	}
 
 	return assistant.ID(), nil

--- a/internal/application/command/create_thread.go
+++ b/internal/application/command/create_thread.go
@@ -4,23 +4,32 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 	"github.com/duragraph/duragraph/internal/pkg/errors"
 )
 
 // CreateThread command
 type CreateThread struct {
+	// TenantID is the tenant scope for the new thread. Empty string is
+	// valid in single-tenant / dev deployments.
+	TenantID string
 	Metadata map[string]interface{}
 }
 
 // CreateThreadHandler handles the CreateThread command
 type CreateThreadHandler struct {
 	threadRepo workflow.ThreadRepository
+	metrics    *monitoring.Metrics
 }
 
-// NewCreateThreadHandler creates a new CreateThreadHandler
-func NewCreateThreadHandler(threadRepo workflow.ThreadRepository) *CreateThreadHandler {
+// NewCreateThreadHandler creates a new CreateThreadHandler.
+//
+// metrics may be nil — handlers degrade silently rather than panicking
+// in test environments that don't wire up a Prometheus registry.
+func NewCreateThreadHandler(threadRepo workflow.ThreadRepository, metrics *monitoring.Metrics) *CreateThreadHandler {
 	return &CreateThreadHandler{
 		threadRepo: threadRepo,
+		metrics:    metrics,
 	}
 }
 
@@ -35,6 +44,10 @@ func (h *CreateThreadHandler) Handle(ctx context.Context, cmd CreateThread) (str
 	// Save to repository
 	if err := h.threadRepo.Save(ctx, thread); err != nil {
 		return "", errors.Internal("failed to save thread", err)
+	}
+
+	if h.metrics != nil {
+		h.metrics.IncThreads(cmd.TenantID)
 	}
 
 	return thread.ID(), nil

--- a/internal/application/command/create_thread.go
+++ b/internal/application/command/create_thread.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
-	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 	"github.com/duragraph/duragraph/internal/pkg/errors"
 )
 
@@ -16,17 +15,24 @@ type CreateThread struct {
 	Metadata map[string]interface{}
 }
 
-// CreateThreadHandler handles the CreateThread command
+// CreateThreadHandler handles the CreateThread command.
+//
+// metrics is an application-layer port (see ports.go); the
+// infrastructure *monitoring.Metrics satisfies it. The per-tenant
+// threads gauge driven by IncThreads/DecThreads depends on a startup
+// bootstrap (cmd/server/metrics_bootstrap.go) to be authoritative —
+// multi-replica deployments would need a separate reconciliation
+// strategy (out of scope for v1).
 type CreateThreadHandler struct {
 	threadRepo workflow.ThreadRepository
-	metrics    *monitoring.Metrics
+	metrics    Metrics
 }
 
 // NewCreateThreadHandler creates a new CreateThreadHandler.
 //
 // metrics may be nil — handlers degrade silently rather than panicking
 // in test environments that don't wire up a Prometheus registry.
-func NewCreateThreadHandler(threadRepo workflow.ThreadRepository, metrics *monitoring.Metrics) *CreateThreadHandler {
+func NewCreateThreadHandler(threadRepo workflow.ThreadRepository, metrics Metrics) *CreateThreadHandler {
 	return &CreateThreadHandler{
 		threadRepo: threadRepo,
 		metrics:    metrics,

--- a/internal/application/command/delete_assistant.go
+++ b/internal/application/command/delete_assistant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
-	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 )
 
 // DeleteAssistantCommand represents the command to delete an assistant
@@ -13,17 +12,24 @@ type DeleteAssistantCommand struct {
 	AssistantID string
 }
 
-// DeleteAssistantHandler handles the delete assistant command
+// DeleteAssistantHandler handles the delete assistant command.
+//
+// metrics is an application-layer port (see ports.go); the
+// infrastructure *monitoring.Metrics satisfies it. The per-tenant
+// assistants gauge driven by IncAssistants/DecAssistants depends on a
+// startup bootstrap (cmd/server/metrics_bootstrap.go) to be
+// authoritative — multi-replica deployments would need a separate
+// reconciliation strategy (out of scope for v1).
 type DeleteAssistantHandler struct {
 	repository workflow.AssistantRepository
-	metrics    *monitoring.Metrics
+	metrics    Metrics
 }
 
 // NewDeleteAssistantHandler creates a new delete assistant handler.
 //
 // metrics may be nil — handlers degrade silently rather than panicking
 // in test environments that don't wire up a Prometheus registry.
-func NewDeleteAssistantHandler(repository workflow.AssistantRepository, metrics *monitoring.Metrics) *DeleteAssistantHandler {
+func NewDeleteAssistantHandler(repository workflow.AssistantRepository, metrics Metrics) *DeleteAssistantHandler {
 	return &DeleteAssistantHandler{
 		repository: repository,
 		metrics:    metrics,

--- a/internal/application/command/delete_assistant.go
+++ b/internal/application/command/delete_assistant.go
@@ -4,22 +4,29 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 )
 
 // DeleteAssistantCommand represents the command to delete an assistant
 type DeleteAssistantCommand struct {
+	TenantID    string
 	AssistantID string
 }
 
 // DeleteAssistantHandler handles the delete assistant command
 type DeleteAssistantHandler struct {
 	repository workflow.AssistantRepository
+	metrics    *monitoring.Metrics
 }
 
-// NewDeleteAssistantHandler creates a new delete assistant handler
-func NewDeleteAssistantHandler(repository workflow.AssistantRepository) *DeleteAssistantHandler {
+// NewDeleteAssistantHandler creates a new delete assistant handler.
+//
+// metrics may be nil — handlers degrade silently rather than panicking
+// in test environments that don't wire up a Prometheus registry.
+func NewDeleteAssistantHandler(repository workflow.AssistantRepository, metrics *monitoring.Metrics) *DeleteAssistantHandler {
 	return &DeleteAssistantHandler{
 		repository: repository,
+		metrics:    metrics,
 	}
 }
 
@@ -37,5 +44,12 @@ func (h *DeleteAssistantHandler) Handle(ctx context.Context, cmd DeleteAssistant
 	}
 
 	// Soft delete (Update with deleted event) or hard delete
-	return h.repository.Delete(ctx, cmd.AssistantID)
+	if err := h.repository.Delete(ctx, cmd.AssistantID); err != nil {
+		return err
+	}
+
+	if h.metrics != nil {
+		h.metrics.DecAssistants(cmd.TenantID)
+	}
+	return nil
 }

--- a/internal/application/command/delete_thread.go
+++ b/internal/application/command/delete_thread.go
@@ -4,26 +4,39 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
+	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 )
 
 // DeleteThreadCommand contains the data needed to delete a thread
 type DeleteThreadCommand struct {
+	TenantID string
 	ThreadID string
 }
 
 // DeleteThreadHandler handles the delete thread command
 type DeleteThreadHandler struct {
 	repository workflow.ThreadRepository
+	metrics    *monitoring.Metrics
 }
 
-// NewDeleteThreadHandler creates a new delete thread handler
-func NewDeleteThreadHandler(repository workflow.ThreadRepository) *DeleteThreadHandler {
+// NewDeleteThreadHandler creates a new delete thread handler.
+//
+// metrics may be nil — handlers degrade silently rather than panicking
+// in test environments that don't wire up a Prometheus registry.
+func NewDeleteThreadHandler(repository workflow.ThreadRepository, metrics *monitoring.Metrics) *DeleteThreadHandler {
 	return &DeleteThreadHandler{
 		repository: repository,
+		metrics:    metrics,
 	}
 }
 
 // Handle executes the delete thread command
 func (h *DeleteThreadHandler) Handle(ctx context.Context, cmd DeleteThreadCommand) error {
-	return h.repository.Delete(ctx, cmd.ThreadID)
+	if err := h.repository.Delete(ctx, cmd.ThreadID); err != nil {
+		return err
+	}
+	if h.metrics != nil {
+		h.metrics.DecThreads(cmd.TenantID)
+	}
+	return nil
 }

--- a/internal/application/command/delete_thread.go
+++ b/internal/application/command/delete_thread.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/duragraph/duragraph/internal/domain/workflow"
-	"github.com/duragraph/duragraph/internal/infrastructure/monitoring"
 )
 
 // DeleteThreadCommand contains the data needed to delete a thread
@@ -13,17 +12,24 @@ type DeleteThreadCommand struct {
 	ThreadID string
 }
 
-// DeleteThreadHandler handles the delete thread command
+// DeleteThreadHandler handles the delete thread command.
+//
+// metrics is an application-layer port (see ports.go); the
+// infrastructure *monitoring.Metrics satisfies it. The per-tenant
+// threads gauge driven by IncThreads/DecThreads depends on a startup
+// bootstrap (cmd/server/metrics_bootstrap.go) to be authoritative —
+// multi-replica deployments would need a separate reconciliation
+// strategy (out of scope for v1).
 type DeleteThreadHandler struct {
 	repository workflow.ThreadRepository
-	metrics    *monitoring.Metrics
+	metrics    Metrics
 }
 
 // NewDeleteThreadHandler creates a new delete thread handler.
 //
 // metrics may be nil — handlers degrade silently rather than panicking
 // in test environments that don't wire up a Prometheus registry.
-func NewDeleteThreadHandler(repository workflow.ThreadRepository, metrics *monitoring.Metrics) *DeleteThreadHandler {
+func NewDeleteThreadHandler(repository workflow.ThreadRepository, metrics Metrics) *DeleteThreadHandler {
 	return &DeleteThreadHandler{
 		repository: repository,
 		metrics:    metrics,

--- a/internal/application/command/ports.go
+++ b/internal/application/command/ports.go
@@ -1,0 +1,17 @@
+package command
+
+// Metrics is the application-layer port for the subset of platform
+// metrics that command handlers need to update. The infrastructure
+// type *monitoring.Metrics satisfies this interface at wiring time
+// (cmd/server/main.go). Keeping this thin port here preserves the
+// application -> infrastructure boundary.
+//
+// Implementations may be nil in tests; handlers MUST guard with a
+// `h.metrics != nil` check before calling. A literal-nil interface
+// value passed as a constructor argument satisfies that guard.
+type Metrics interface {
+	IncAssistants(tenantID string)
+	DecAssistants(tenantID string)
+	IncThreads(tenantID string)
+	DecThreads(tenantID string)
+}

--- a/internal/infrastructure/http/handlers/assistant.go
+++ b/internal/infrastructure/http/handlers/assistant.go
@@ -8,6 +8,7 @@ import (
 	"github.com/duragraph/duragraph/internal/application/command"
 	"github.com/duragraph/duragraph/internal/application/query"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/dto"
+	"github.com/duragraph/duragraph/internal/infrastructure/http/middleware"
 	"github.com/labstack/echo/v4"
 )
 
@@ -79,8 +80,14 @@ func (h *AssistantHandler) Create(c echo.Context) error {
 		})
 	}
 
+	// Resolve tenant_id from middleware-populated context. Empty string
+	// (single-tenant mode / no TenantMiddleware) is forwarded as-is to
+	// drive the unscoped "" series in metrics.
+	tenantID, _ := middleware.TenantIDFromCtx(c)
+
 	// Create assistant
 	assistantID, err := h.createHandler.Handle(c.Request().Context(), command.CreateAssistant{
+		TenantID:     tenantID,
 		GraphID:      req.GraphID,
 		Name:         req.Name,
 		Description:  req.Description,
@@ -216,7 +223,9 @@ func (h *AssistantHandler) Update(c echo.Context) error {
 func (h *AssistantHandler) Delete(c echo.Context) error {
 	assistantID := c.Param("assistant_id")
 
+	tenantID, _ := middleware.TenantIDFromCtx(c)
 	cmd := command.DeleteAssistantCommand{
+		TenantID:    tenantID,
 		AssistantID: assistantID,
 	}
 

--- a/internal/infrastructure/http/handlers/thread.go
+++ b/internal/infrastructure/http/handlers/thread.go
@@ -8,6 +8,7 @@ import (
 	"github.com/duragraph/duragraph/internal/application/command"
 	"github.com/duragraph/duragraph/internal/application/query"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/dto"
+	"github.com/duragraph/duragraph/internal/infrastructure/http/middleware"
 	"github.com/labstack/echo/v4"
 )
 
@@ -56,8 +57,13 @@ func (h *ThreadHandler) Create(c echo.Context) error {
 		})
 	}
 
+	// Resolve tenant_id from middleware-populated context. Empty string
+	// (single-tenant mode / no TenantMiddleware) is forwarded as-is.
+	tenantID, _ := middleware.TenantIDFromCtx(c)
+
 	// Create thread
 	threadID, err := h.createHandler.Handle(c.Request().Context(), command.CreateThread{
+		TenantID: tenantID,
 		Metadata: req.Metadata,
 	})
 
@@ -223,7 +229,9 @@ func (h *ThreadHandler) AddMessage(c echo.Context) error {
 func (h *ThreadHandler) Delete(c echo.Context) error {
 	threadID := c.Param("thread_id")
 
+	tenantID, _ := middleware.TenantIDFromCtx(c)
 	cmd := command.DeleteThreadCommand{
+		TenantID: tenantID,
 		ThreadID: threadID,
 	}
 

--- a/internal/infrastructure/monitoring/metrics.go
+++ b/internal/infrastructure/monitoring/metrics.go
@@ -16,8 +16,15 @@ type Metrics struct {
 
 	RunsTotal            *prometheus.CounterVec
 	RunDuration          *prometheus.HistogramVec
-	RunsActive           prometheus.Gauge
+	RunsActive           *prometheus.GaugeVec
 	RunStatusTransitions *prometheus.CounterVec
+
+	// AssistantsTotal / ThreadsTotal are per-tenant gauges driven by the
+	// command handlers (CreateAssistant/Delete, CreateThread/Delete).
+	// The admin metrics endpoint queries these via Mimir as
+	// `sum by (tenant_id) (duragraph_{assistants,threads}_total)`.
+	AssistantsTotal *prometheus.GaugeVec
+	ThreadsTotal    *prometheus.GaugeVec
 
 	NodesExecutedTotal *prometheus.CounterVec
 	NodeDuration       *prometheus.HistogramVec
@@ -99,7 +106,11 @@ func NewMetrics(namespace string) *Metrics {
 				Name:      "runs_total",
 				Help:      "Total number of runs created",
 			},
-			[]string{"assistant_id"},
+			// tenant_id first by convention; assistant_id retained so
+			// per-assistant slicing remains possible. Empty tenant_id
+			// means "unscoped / single-tenant deployment" — see the
+			// comment on the Record* helpers below.
+			[]string{"tenant_id", "assistant_id"},
 		),
 		RunDuration: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -108,14 +119,15 @@ func NewMetrics(namespace string) *Metrics {
 				Help:      "Run duration in seconds",
 				Buckets:   prometheus.ExponentialBuckets(0.1, 2, 12),
 			},
-			[]string{"assistant_id", "status"},
+			[]string{"tenant_id", "assistant_id", "status"},
 		),
-		RunsActive: promauto.NewGauge(
+		RunsActive: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "runs_active",
 				Help:      "Number of currently active runs",
 			},
+			[]string{"tenant_id"},
 		),
 		RunStatusTransitions: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -123,7 +135,24 @@ func NewMetrics(namespace string) *Metrics {
 				Name:      "run_status_transitions_total",
 				Help:      "Total number of run status transitions",
 			},
-			[]string{"from_status", "to_status"},
+			[]string{"tenant_id", "from_status", "to_status"},
+		),
+
+		AssistantsTotal: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "assistants_total",
+				Help:      "Number of assistants per tenant",
+			},
+			[]string{"tenant_id"},
+		),
+		ThreadsTotal: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "threads_total",
+				Help:      "Number of threads per tenant",
+			},
+			[]string{"tenant_id"},
 		),
 
 		NodesExecutedTotal: promauto.NewCounterVec(
@@ -158,7 +187,7 @@ func NewMetrics(namespace string) *Metrics {
 				Name:      "llm_requests_total",
 				Help:      "Total number of LLM requests",
 			},
-			[]string{"provider", "model", "status"},
+			[]string{"tenant_id", "provider", "model", "status"},
 		),
 		LLMRequestDuration: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -167,7 +196,7 @@ func NewMetrics(namespace string) *Metrics {
 				Help:      "LLM request duration in seconds",
 				Buckets:   prometheus.ExponentialBuckets(0.1, 2, 10),
 			},
-			[]string{"provider", "model"},
+			[]string{"tenant_id", "provider", "model"},
 		),
 		LLMTokensTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -175,7 +204,7 @@ func NewMetrics(namespace string) *Metrics {
 				Name:      "llm_tokens_total",
 				Help:      "Total number of LLM tokens used",
 			},
-			[]string{"provider", "model", "type"},
+			[]string{"tenant_id", "provider", "model", "type"},
 		),
 		LLMErrors: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -183,7 +212,7 @@ func NewMetrics(namespace string) *Metrics {
 				Name:      "llm_errors_total",
 				Help:      "Total number of LLM errors",
 			},
-			[]string{"provider", "model", "error_type"},
+			[]string{"tenant_id", "provider", "model", "error_type"},
 		),
 
 		ToolExecutionsTotal: promauto.NewCounterVec(
@@ -339,26 +368,50 @@ func (m *Metrics) RecordHTTPRequest(method, path string, status int, duration ti
 	m.HTTPResponseSize.WithLabelValues(method, path).Observe(float64(respSize))
 }
 
-func (m *Metrics) RecordRunCreated(assistantID string) {
-	m.RunsTotal.WithLabelValues(assistantID).Inc()
-	m.RunsActive.Inc()
+// tenantID convention: callers should pass the request-scoped tenant_id
+// resolved via middleware.TenantIDFromCtx (or the equivalent on a
+// command struct). Pass empty string ("") when no tenant context exists
+// — this is the documented single-tenant deployment mode (engine
+// running with MIGRATOR_PLATFORM_ENABLED=false). Mimir queries that
+// `sum by (tenant_id)` will surface a single "" series in that case,
+// which is the intended behaviour.
+
+func (m *Metrics) RecordRunCreated(tenantID, assistantID string) {
+	m.RunsTotal.WithLabelValues(tenantID, assistantID).Inc()
+	m.RunsActive.WithLabelValues(tenantID).Inc()
 }
 
-func (m *Metrics) RecordRunCompleted(assistantID, status string, duration time.Duration) {
-	m.RunDuration.WithLabelValues(assistantID, status).Observe(duration.Seconds())
-	m.RunsActive.Dec()
+func (m *Metrics) RecordRunCompleted(tenantID, assistantID, status string, duration time.Duration) {
+	m.RunDuration.WithLabelValues(tenantID, assistantID, status).Observe(duration.Seconds())
+	m.RunsActive.WithLabelValues(tenantID).Dec()
 }
+
+// IncRunsActive / DecRunsActive expose the per-tenant active-runs gauge
+// for callers that don't drive it through RecordRunCreated/Completed
+// (e.g. lease recovery on engine restart).
+func (m *Metrics) IncRunsActive(tenantID string) { m.RunsActive.WithLabelValues(tenantID).Inc() }
+func (m *Metrics) DecRunsActive(tenantID string) { m.RunsActive.WithLabelValues(tenantID).Dec() }
+
+// IncAssistants / DecAssistants are wired into CreateAssistant /
+// DeleteAssistant command handlers to keep the per-tenant gauge in
+// sync. Drift is acceptable at MVP scale (the gauge is observational,
+// not authoritative).
+func (m *Metrics) IncAssistants(tenantID string) { m.AssistantsTotal.WithLabelValues(tenantID).Inc() }
+func (m *Metrics) DecAssistants(tenantID string) { m.AssistantsTotal.WithLabelValues(tenantID).Dec() }
+
+func (m *Metrics) IncThreads(tenantID string) { m.ThreadsTotal.WithLabelValues(tenantID).Inc() }
+func (m *Metrics) DecThreads(tenantID string) { m.ThreadsTotal.WithLabelValues(tenantID).Dec() }
 
 func (m *Metrics) RecordNodeExecution(nodeType, status string, duration time.Duration) {
 	m.NodesExecutedTotal.WithLabelValues(nodeType, status).Inc()
 	m.NodeDuration.WithLabelValues(nodeType).Observe(duration.Seconds())
 }
 
-func (m *Metrics) RecordLLMRequest(provider, model, status string, duration time.Duration, promptTokens, completionTokens int) {
-	m.LLMRequestsTotal.WithLabelValues(provider, model, status).Inc()
-	m.LLMRequestDuration.WithLabelValues(provider, model).Observe(duration.Seconds())
-	m.LLMTokensTotal.WithLabelValues(provider, model, "prompt").Add(float64(promptTokens))
-	m.LLMTokensTotal.WithLabelValues(provider, model, "completion").Add(float64(completionTokens))
+func (m *Metrics) RecordLLMRequest(tenantID, provider, model, status string, duration time.Duration, promptTokens, completionTokens int) {
+	m.LLMRequestsTotal.WithLabelValues(tenantID, provider, model, status).Inc()
+	m.LLMRequestDuration.WithLabelValues(tenantID, provider, model).Observe(duration.Seconds())
+	m.LLMTokensTotal.WithLabelValues(tenantID, provider, model, "prompt").Add(float64(promptTokens))
+	m.LLMTokensTotal.WithLabelValues(tenantID, provider, model, "completion").Add(float64(completionTokens))
 }
 
 func (m *Metrics) RecordToolExecution(toolName, status string, duration time.Duration) {

--- a/internal/infrastructure/monitoring/metrics_test.go
+++ b/internal/infrastructure/monitoring/metrics_test.go
@@ -3,6 +3,8 @@ package monitoring
 import (
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestNewMetrics(t *testing.T) {
@@ -25,6 +27,12 @@ func TestNewMetrics(t *testing.T) {
 	if m.ErrorsTotal == nil {
 		t.Error("ErrorsTotal should not be nil")
 	}
+	if m.AssistantsTotal == nil {
+		t.Error("AssistantsTotal should not be nil")
+	}
+	if m.ThreadsTotal == nil {
+		t.Error("ThreadsTotal should not be nil")
+	}
 }
 
 func TestNewMetrics_DefaultNamespace(t *testing.T) {
@@ -41,16 +49,75 @@ func TestRecordHTTPRequest_NoPanic(t *testing.T) {
 	m.RecordHTTPRequest("GET", "/api/v1/runs/123", 404, 10*time.Millisecond, 0, 64)
 }
 
-func TestRecordRunCreated_NoPanic(t *testing.T) {
-	m := NewMetrics("test_run")
-	m.RecordRunCreated("asst-1")
-	m.RecordRunCreated("asst-2")
+func TestRecordRunCreated_LabelsTenant(t *testing.T) {
+	m := NewMetrics("test_run_create")
+
+	m.RecordRunCreated("tenant-1", "asst-1")
+	m.RecordRunCreated("tenant-1", "asst-1")
+	m.RecordRunCreated("tenant-2", "asst-2")
+
+	if got := testutil.ToFloat64(m.RunsTotal.WithLabelValues("tenant-1", "asst-1")); got != 2 {
+		t.Errorf("expected runs_total{tenant=t1,asst=a1}=2, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.RunsTotal.WithLabelValues("tenant-2", "asst-2")); got != 1 {
+		t.Errorf("expected runs_total{tenant=t2,asst=a2}=1, got %v", got)
+	}
+	// Active gauge bumps once per RecordRunCreated, scoped to tenant.
+	if got := testutil.ToFloat64(m.RunsActive.WithLabelValues("tenant-1")); got != 2 {
+		t.Errorf("expected runs_active{tenant=t1}=2, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.RunsActive.WithLabelValues("tenant-2")); got != 1 {
+		t.Errorf("expected runs_active{tenant=t2}=1, got %v", got)
+	}
+}
+
+func TestRecordRunCreated_EmptyTenantID(t *testing.T) {
+	// Empty tenant_id is the single-tenant deployment mode — must not panic.
+	m := NewMetrics("test_run_empty_tenant")
+	m.RecordRunCreated("", "asst-1")
+	if got := testutil.ToFloat64(m.RunsTotal.WithLabelValues("", "asst-1")); got != 1 {
+		t.Errorf("expected runs_total{tenant=,asst=a1}=1, got %v", got)
+	}
 }
 
 func TestRecordRunCompleted_NoPanic(t *testing.T) {
 	m := NewMetrics("test_run_complete")
-	m.RecordRunCompleted("asst-1", "success", 5*time.Second)
-	m.RecordRunCompleted("asst-1", "error", 2*time.Second)
+	m.RecordRunCompleted("tenant-1", "asst-1", "success", 5*time.Second)
+	m.RecordRunCompleted("tenant-1", "asst-1", "error", 2*time.Second)
+}
+
+func TestIncDecRunsActive(t *testing.T) {
+	m := NewMetrics("test_runs_active")
+	m.IncRunsActive("tenant-1")
+	m.IncRunsActive("tenant-1")
+	m.DecRunsActive("tenant-1")
+	if got := testutil.ToFloat64(m.RunsActive.WithLabelValues("tenant-1")); got != 1 {
+		t.Errorf("expected runs_active{tenant=t1}=1, got %v", got)
+	}
+}
+
+func TestIncDecAssistants(t *testing.T) {
+	m := NewMetrics("test_assistants")
+	m.IncAssistants("tenant-1")
+	m.IncAssistants("tenant-1")
+	m.IncAssistants("tenant-2")
+	m.DecAssistants("tenant-1")
+	if got := testutil.ToFloat64(m.AssistantsTotal.WithLabelValues("tenant-1")); got != 1 {
+		t.Errorf("expected assistants_total{tenant=t1}=1, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.AssistantsTotal.WithLabelValues("tenant-2")); got != 1 {
+		t.Errorf("expected assistants_total{tenant=t2}=1, got %v", got)
+	}
+}
+
+func TestIncDecThreads(t *testing.T) {
+	m := NewMetrics("test_threads")
+	m.IncThreads("tenant-1")
+	m.IncThreads("tenant-1")
+	m.DecThreads("tenant-1")
+	if got := testutil.ToFloat64(m.ThreadsTotal.WithLabelValues("tenant-1")); got != 1 {
+		t.Errorf("expected threads_total{tenant=t1}=1, got %v", got)
+	}
 }
 
 func TestRecordNodeExecution_NoPanic(t *testing.T) {
@@ -59,10 +126,20 @@ func TestRecordNodeExecution_NoPanic(t *testing.T) {
 	m.RecordNodeExecution("tool", "error", 50*time.Millisecond)
 }
 
-func TestRecordLLMRequest_NoPanic(t *testing.T) {
+func TestRecordLLMRequest_LabelsTenant(t *testing.T) {
 	m := NewMetrics("test_llm")
-	m.RecordLLMRequest("openai", "gpt-4", "success", 2*time.Second, 100, 200)
-	m.RecordLLMRequest("anthropic", "claude-3", "error", time.Second, 50, 0)
+	m.RecordLLMRequest("tenant-1", "openai", "gpt-4", "success", 2*time.Second, 100, 200)
+	m.RecordLLMRequest("tenant-1", "anthropic", "claude-3", "error", time.Second, 50, 0)
+
+	if got := testutil.ToFloat64(m.LLMRequestsTotal.WithLabelValues("tenant-1", "openai", "gpt-4", "success")); got != 1 {
+		t.Errorf("expected llm_requests_total to be 1, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.LLMTokensTotal.WithLabelValues("tenant-1", "openai", "gpt-4", "prompt")); got != 100 {
+		t.Errorf("expected llm_tokens_total{type=prompt}=100, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.LLMTokensTotal.WithLabelValues("tenant-1", "openai", "gpt-4", "completion")); got != 200 {
+		t.Errorf("expected llm_tokens_total{type=completion}=200, got %v", got)
+	}
 }
 
 func TestRecordToolExecution_NoPanic(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the `TODO(metrics-instrumentation)` from PR #157 so `/api/admin/metrics` returns real per-tenant data once tenants exist. The admin handler's PromQL already groups by `tenant_id` and queries `duragraph_{assistants,threads}_total`; this PR adds the missing label and registers the missing series.

## What changed

### Metric definitions (`internal/infrastructure/monitoring/metrics.go`)

| Metric | Change |
|---|---|
| `duragraph_runs_total` | + `tenant_id` label (now `[tenant_id, assistant_id]`) |
| `duragraph_run_duration_seconds` | + `tenant_id` label |
| `duragraph_runs_active` | `Gauge` -> `GaugeVec{tenant_id}` |
| `duragraph_run_status_transitions_total` | + `tenant_id` label |
| `duragraph_assistants_total` | NEW `GaugeVec{tenant_id}` |
| `duragraph_threads_total` | NEW `GaugeVec{tenant_id}` |
| `duragraph_llm_requests_total` | + `tenant_id` label |
| `duragraph_llm_request_duration_seconds` | + `tenant_id` label |
| `duragraph_llm_tokens_total` | + `tenant_id` label |
| `duragraph_llm_errors_total` | + `tenant_id` label |

`assistant_id` is retained on `runs_total` / `run_duration_seconds` per the task spec — not stripped.

### Helper signatures

- `RecordRunCreated(tenantID, assistantID)`
- `RecordRunCompleted(tenantID, assistantID, status, duration)`
- `RecordLLMRequest(tenantID, provider, model, status, duration, promptTokens, completionTokens)`
- New: `IncRunsActive` / `DecRunsActive(tenantID)`
- New: `IncAssistants` / `DecAssistants(tenantID)`
- New: `IncThreads` / `DecThreads(tenantID)`

Empty `tenant_id` is documented as the single-tenant deployment mode (`MIGRATOR_PLATFORM_ENABLED=false`); Mimir queries surface this as a single `""` series.

### Call sites touched (8)

- `cmd/server/main.go` (4): `NewCreate/DeleteAssistantHandler` + `NewCreate/DeleteThreadHandler` constructors now receive `*monitoring.Metrics`.
- `internal/infrastructure/http/handlers/assistant.go` (2): `Create` + `Delete` resolve `tenant_id` via `middleware.TenantIDFromCtx` and forward through the command.
- `internal/infrastructure/http/handlers/thread.go` (2): `Create` + `Delete` resolve `tenant_id` via `middleware.TenantIDFromCtx`.

`CreateAssistant`, `DeleteAssistantCommand`, `CreateThread`, `DeleteThreadCommand` gain a `TenantID` field; the four command handlers fan out to the new `Inc/Dec` gauge helpers on success.

### Out of scope (per task)

- The Mimir admin handler / DTO / its tests (`handlers/admin/`) — the PromQL was already correct.
- Worker / dispatcher / DB pool collectors — not queried by the admin endpoint today.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/infrastructure/monitoring/... ./internal/application/command/... ./internal/infrastructure/http/handlers/... -count=1`
- [x] `go test -short ./...` — full short-test sweep green
- [ ] Once deployed, eyeball `/api/admin/metrics` against a multi-tenant Mimir to confirm real per-tenant rows appear.