### PR TITLE
fix(persistence): align Claim RETURNING with scanTask column set

### DIFF
--- a/internal/infrastructure/persistence/postgres/task_assignment_repository.go
+++ b/internal/infrastructure/persistence/postgres/task_assignment_repository.go
@@ -65,7 +65,8 @@ func (r *TaskAssignmentRepository) Claim(ctx context.Context, workerID string, g
 		WHERE t.id = c.id
 		RETURNING t.id, t.run_id, t.worker_id, t.status, t.graph_id,
 		          t.thread_id, t.assistant_id, t.input, t.config,
-		          t.created_at, t.claimed_at, t.lease_expires_at, t.retry_count
+		          t.created_at, t.claimed_at, t.completed_at, t.lease_expires_at,
+		          t.retry_count, t.max_retries, t.error_message
 	`, graphIDs, maxTasks, workerID, leaseExpiry)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

- The `Claim` query in `task_assignment_repository.go` emitted 13 columns in its `RETURNING` clause, but `scanTask()` reads 16. The mismatch caused worker poll to return 500 immediately after dispatch.
- The UPDATE itself succeeds (row transitions to `claimed`), but the scan errors, so the worker never sees the task. Net effect: dispatched runs sit forever.
- This is **A1** in `POST_DEMO_FIXES.md` — discovered during the multi-agent demo prep on 2026-05-05; the multi-tenancy worktree branches missed it because the divergence happened during column-rename mid-flight.

## Why

`scanTask` is the canonical scanner for `task_assignments` rows; every other query that uses it reads all 16 columns. The `Claim` `RETURNING` clause was the lone outlier, missing `completed_at`, `max_retries`, and `error_message`.

## Test plan

- [x] `go build ./...` clean
- [x] Existing unit + integration tests still pass
- [ ] Live verification (operator): `task up`, register a worker, `POST /runs`, confirm `GET /runs/{id}` reaches `completed` without manual intervention

## Companion PRs

- A2 (RunRepository.FindByThreadID): incoming
- A3 (WorkerHandler.ReceiveEvent — HITL + SSE expansion): incoming