### PR TITLE
fix(persistence): RunRepository.FindByThreadID reconstructs from row data

### DIFF
--- a/internal/infrastructure/persistence/postgres/run_repository.go
+++ b/internal/infrastructure/persistence/postgres/run_repository.go
@@ -242,7 +242,8 @@ func (r *RunRepository) FindAll(ctx context.Context, limit, offset int) ([]*run.
 // FindByThreadID retrieves runs for a specific thread
 func (r *RunRepository) FindByThreadID(ctx context.Context, threadID string, limit, offset int) ([]*run.Run, error) {
 	rows, err := r.readPool.Query(ctx, `
-		SELECT id, thread_id, assistant_id, status, input, metadata, created_at
+		SELECT id, thread_id, assistant_id, status, input, output, error, metadata,
+		       created_at, started_at, completed_at, updated_at
 		FROM runs
 		WHERE thread_id = $1
 		ORDER BY created_at DESC
@@ -257,21 +258,45 @@ func (r *RunRepository) FindByThreadID(ctx context.Context, threadID string, lim
 	runs := make([]*run.Run, 0)
 
 	for rows.Next() {
-		var runID, threadID, assistantID, status string
-		var inputJSON, metadataJSON []byte
-		var createdAt time.Time
+		var runID, tID, assistantID, status string
+		var errorMsg *string
+		var inputJSON, outputJSON, metadataJSON []byte
+		var createdAt, updatedAt time.Time
+		var startedAt, completedAt *time.Time
 
-		err := rows.Scan(&runID, &threadID, &assistantID, &status, &inputJSON, &metadataJSON, &createdAt)
+		err := rows.Scan(
+			&runID, &tID, &assistantID, &status,
+			&inputJSON, &outputJSON, &errorMsg, &metadataJSON,
+			&createdAt, &startedAt, &completedAt, &updatedAt,
+		)
 		if err != nil {
 			return nil, errors.Internal("failed to scan run", err)
 		}
 
-		var input, metadata map[string]interface{}
+		var input, output, metadata map[string]interface{}
 		json.Unmarshal(inputJSON, &input)
+		json.Unmarshal(outputJSON, &output)
 		json.Unmarshal(metadataJSON, &metadata)
 
-		runAgg, _ := run.NewRun(threadID, assistantID, input)
-		runs = append(runs, runAgg)
+		errStr := ""
+		if errorMsg != nil {
+			errStr = *errorMsg
+		}
+
+		runs = append(runs, run.ReconstructFromData(run.RunData{
+			ID:          runID,
+			ThreadID:    tID,
+			AssistantID: assistantID,
+			Status:      status,
+			Input:       input,
+			Output:      output,
+			Error:       errStr,
+			Metadata:    metadata,
+			CreatedAt:   createdAt,
+			StartedAt:   startedAt,
+			CompletedAt: completedAt,
+			UpdatedAt:   updatedAt,
+		}))
 	}
 
 	return runs, nil


### PR DESCRIPTION
## Summary

- `FindByThreadID` was calling `run.NewRun(...)` inside the row-iteration loop. That factory generates a fresh UUID and sets `status=queued`, `created_at=time.Now()`. The DB row's actual `id` was scanned and immediately thrown away.
- Replaced with `run.ReconstructFromData` (the constructor every other list method in this file uses correctly).
- Expanded the `SELECT` to include `output, error, started_at, completed_at, updated_at` so the list response carries fields callers actually need.
- This is **A2** in `POST_DEMO_FIXES.md` — discovered during the multi-agent demo prep on 2026-05-05.

## Symptoms (before fix)

- `GET /threads/{tid}/runs` returns runs with fabricated UUIDs that don't exist in any table
- Studio's sidebar shows ghost runs that 404 when clicked
- Every list response carries the same fabricated `created_at` (microseconds apart — all generated in one loop)
- `status` is always `"queued"` regardless of actual state

## Why

The fix is a bug correction, not a refactor. `NewRun` is the wrong constructor for hydration; `ReconstructFromData` is the right one (and is used by neighboring methods in the same file).

## Test plan

- [x] `go build ./...` clean
- [ ] Live verification: create a thread, run a few chats, then `curl /api/v1/threads/{tid}/runs | jq '.[].run_id'` — every ID should be present in the database

## Companion PRs

- A1 (Claim SQL/scan mismatch): #161
- A3 (WorkerHandler.ReceiveEvent — HITL + SSE expansion): incoming

## Follow-up note

The HTTP handler `RunHandler.ListRuns` in `handlers/run.go` constructs a `dto.GetRunResponse` that drops `input/output/error/started_at/completed_at`. Now that the repo returns these fields, a follow-up PR should pass them through the DTO too.