### PR TITLE
fix(handlers): WorkerHandler.ReceiveEvent publishes all event types (HITL + SSE)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -677,6 +677,7 @@ func main() {
 	)
 	workerHandler := handlers.NewWorkerHandler(
 		workerService,
+		eventBus,
 		30*time.Second, // Health threshold
 		fmt.Sprintf("http://%s", cfg.ServerAddr()),
 	)

--- a/internal/infrastructure/http/handlers/worker.go
+++ b/internal/infrastructure/http/handlers/worker.go
@@ -251,7 +251,19 @@ func (h *WorkerHandler) ReceiveEvent(c echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	now := time.Now()
+	// Prefer the worker-supplied timestamp so SSE consumers see the
+	// actual event time; fall back to server time if absent.
+	now := req.Timestamp
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Resolve NodeID once for node_* events: the DTO has it as a top-level
+	// field, but older workers may still tuck it under data.
+	nodeID := req.NodeID
+	if nodeID == "" {
+		nodeID = stringFromData(req.Data, "node_id")
+	}
 
 	switch req.EventType {
 	case "run_started":
@@ -264,7 +276,11 @@ func (h *WorkerHandler) ReceiveEvent(c echo.Context) error {
 			})
 		}
 
-	case "run_requires_action":
+	// "human_required" is an alias kept for backwards compatibility:
+	// the in-repo Go e2e worker emits this name (see tests/e2e/go_worker/
+	// executor/executor.go), while the Python worker uses the canonical
+	// "run_requires_action". A future PR can converge on one name.
+	case "run_requires_action", "human_required":
 		// HITL pause. Translate to the aggregate transition AND publish
 		// so Studio's ApprovalDialog opens via the SSE stream.
 		if err := h.workerService.UpdateRunStatus(ctx, req.RunID, "requires_action", nil, ""); err != nil {
@@ -314,7 +330,7 @@ func (h *WorkerHandler) ReceiveEvent(c echo.Context) error {
 			input, _ := req.Data["input"].(map[string]interface{})
 			h.eventBus.Publish(ctx, execution.NodeStarted{
 				RunID:      req.RunID,
-				NodeID:     stringFromData(req.Data, "node_id"),
+				NodeID:     nodeID,
 				NodeType:   stringFromData(req.Data, "node_type"),
 				Input:      input,
 				OccurredAt: now,
@@ -326,7 +342,7 @@ func (h *WorkerHandler) ReceiveEvent(c echo.Context) error {
 			output, _ := req.Data["output"].(map[string]interface{})
 			h.eventBus.Publish(ctx, execution.NodeCompleted{
 				RunID:      req.RunID,
-				NodeID:     stringFromData(req.Data, "node_id"),
+				NodeID:     nodeID,
 				NodeType:   stringFromData(req.Data, "node_type"),
 				Output:     output,
 				OccurredAt: now,
@@ -339,7 +355,7 @@ func (h *WorkerHandler) ReceiveEvent(c echo.Context) error {
 			input, _ := req.Data["input"].(map[string]interface{})
 			h.eventBus.Publish(ctx, execution.NodeFailed{
 				RunID:      req.RunID,
-				NodeID:     stringFromData(req.Data, "node_id"),
+				NodeID:     nodeID,
 				NodeType:   stringFromData(req.Data, "node_type"),
 				Error:      errMsg,
 				Input:      input,

--- a/internal/infrastructure/http/handlers/worker.go
+++ b/internal/infrastructure/http/handlers/worker.go
@@ -6,22 +6,27 @@ import (
 	"time"
 
 	"github.com/duragraph/duragraph/internal/application/service"
+	"github.com/duragraph/duragraph/internal/domain/execution"
+	"github.com/duragraph/duragraph/internal/domain/run"
 	"github.com/duragraph/duragraph/internal/domain/worker"
 	"github.com/duragraph/duragraph/internal/infrastructure/http/dto"
+	"github.com/duragraph/duragraph/internal/pkg/eventbus"
 	"github.com/labstack/echo/v4"
 )
 
 // WorkerHandler handles worker-related HTTP requests
 type WorkerHandler struct {
 	workerService   *service.WorkerService
+	eventBus        *eventbus.EventBus
 	healthThreshold time.Duration
 	baseURL         string
 }
 
 // NewWorkerHandler creates a new WorkerHandler
-func NewWorkerHandler(workerService *service.WorkerService, healthThreshold time.Duration, baseURL string) *WorkerHandler {
+func NewWorkerHandler(workerService *service.WorkerService, eventBus *eventbus.EventBus, healthThreshold time.Duration, baseURL string) *WorkerHandler {
 	return &WorkerHandler{
 		workerService:   workerService,
+		eventBus:        eventBus,
 		healthThreshold: healthThreshold,
 		baseURL:         baseURL,
 	}
@@ -245,25 +250,115 @@ func (h *WorkerHandler) ReceiveEvent(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
 
-	if req.EventType == "run_completed" || req.EventType == "run_failed" {
-		status := "success"
-		errMsg := ""
-		if req.EventType == "run_failed" {
-			status = "error"
-			if e, ok := req.Data["error"].(string); ok {
-				errMsg = e
-			}
+	ctx := c.Request().Context()
+	now := time.Now()
+
+	switch req.EventType {
+	case "run_started":
+		// Aggregate already transitioned to in_progress at dispatch; we
+		// just need to publish so SSE/streaming clients see the start.
+		if h.eventBus != nil {
+			h.eventBus.Publish(ctx, run.RunStarted{
+				RunID:      req.RunID,
+				OccurredAt: now,
+			})
 		}
 
+	case "run_requires_action":
+		// HITL pause. Translate to the aggregate transition AND publish
+		// so Studio's ApprovalDialog opens via the SSE stream.
+		if err := h.workerService.UpdateRunStatus(ctx, req.RunID, "requires_action", nil, ""); err != nil {
+			c.Logger().Warnf("failed to set run %s to requires_action: %v", req.RunID, err)
+		}
+		if h.eventBus != nil {
+			reason, _ := req.Data["action_type"].(string)
+			if reason == "" {
+				reason = "tool_call"
+			}
+			h.eventBus.Publish(ctx, run.RunRequiresAction{
+				RunID:       req.RunID,
+				InterruptID: stringFromData(req.Data, "interrupt_id"),
+				Reason:      reason,
+				OccurredAt:  now,
+			})
+		}
+
+	case "run_completed":
 		output, _ := req.Data["output"].(map[string]interface{})
-		if err := h.workerService.UpdateRunStatus(c.Request().Context(), req.RunID, status, output, errMsg); err != nil {
+		if err := h.workerService.UpdateRunStatus(ctx, req.RunID, "success", output, ""); err != nil {
 			c.Logger().Warnf("failed to update run status: %v", err)
+		}
+		if h.eventBus != nil {
+			h.eventBus.Publish(ctx, run.RunCompleted{
+				RunID:      req.RunID,
+				Output:     output,
+				OccurredAt: now,
+			})
+		}
+
+	case "run_failed":
+		errMsg, _ := req.Data["error"].(string)
+		if err := h.workerService.UpdateRunStatus(ctx, req.RunID, "error", nil, errMsg); err != nil {
+			c.Logger().Warnf("failed to update run status: %v", err)
+		}
+		if h.eventBus != nil {
+			h.eventBus.Publish(ctx, run.RunFailed{
+				RunID:      req.RunID,
+				Error:      errMsg,
+				OccurredAt: now,
+			})
+		}
+
+	case "node_started":
+		if h.eventBus != nil {
+			input, _ := req.Data["input"].(map[string]interface{})
+			h.eventBus.Publish(ctx, execution.NodeStarted{
+				RunID:      req.RunID,
+				NodeID:     stringFromData(req.Data, "node_id"),
+				NodeType:   stringFromData(req.Data, "node_type"),
+				Input:      input,
+				OccurredAt: now,
+			})
+		}
+
+	case "node_completed":
+		if h.eventBus != nil {
+			output, _ := req.Data["output"].(map[string]interface{})
+			h.eventBus.Publish(ctx, execution.NodeCompleted{
+				RunID:      req.RunID,
+				NodeID:     stringFromData(req.Data, "node_id"),
+				NodeType:   stringFromData(req.Data, "node_type"),
+				Output:     output,
+				OccurredAt: now,
+			})
+		}
+
+	case "node_failed":
+		if h.eventBus != nil {
+			errMsg, _ := req.Data["error"].(string)
+			input, _ := req.Data["input"].(map[string]interface{})
+			h.eventBus.Publish(ctx, execution.NodeFailed{
+				RunID:      req.RunID,
+				NodeID:     stringFromData(req.Data, "node_id"),
+				NodeType:   stringFromData(req.Data, "node_type"),
+				Error:      errMsg,
+				Input:      input,
+				OccurredAt: now,
+			})
 		}
 	}
 
 	return c.JSON(http.StatusOK, dto.WorkerEventResponse{
 		Received: true,
 	})
+}
+
+// stringFromData safely extracts a string field from an event payload map.
+func stringFromData(data map[string]interface{}, key string) string {
+	if v, ok := data[key].(string); ok {
+		return v
+	}
+	return ""
 }
 
 // GetGraphDefinition handles GET /workers/graphs/:graph_id

--- a/internal/infrastructure/streaming/bridge.go
+++ b/internal/infrastructure/streaming/bridge.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/duragraph/duragraph/internal/domain/execution"
+	"github.com/duragraph/duragraph/internal/domain/run"
 	"github.com/duragraph/duragraph/internal/infrastructure/messaging/nats"
 	"github.com/duragraph/duragraph/internal/pkg/eventbus"
 )
@@ -34,6 +35,14 @@ func (b *StreamingBridge) Start() {
 	b.eventBus.Subscribe(execution.EventTypeNodeCompleted, b.handleNodeCompleted)
 	b.eventBus.Subscribe(execution.EventTypeNodeFailed, b.handleNodeFailed)
 	b.eventBus.Subscribe(execution.EventTypeNodeSkipped, b.handleNodeSkipped)
+
+	// Run-level events drive the SSE stream's run lifecycle messages
+	// (start, completion, HITL pause, failure). The worker handler
+	// publishes these in response to worker-reported events.
+	b.eventBus.Subscribe(run.EventTypeRunStarted, b.handleRunStarted)
+	b.eventBus.Subscribe(run.EventTypeRunCompleted, b.handleRunCompleted)
+	b.eventBus.Subscribe(run.EventTypeRunFailed, b.handleRunFailed)
+	b.eventBus.Subscribe(run.EventTypeRunRequiresAction, b.handleRunRequiresAction)
 
 	b.eventBus.Subscribe("streaming.metadata", b.handleMetadataEvent)
 	b.eventBus.Subscribe("streaming.values", b.handleValuesEvent)
@@ -109,6 +118,64 @@ func (b *StreamingBridge) handleNodeSkipped(ctx context.Context, event eventbus.
 		"node_type": nodeEvent.NodeType,
 		"reason":    nodeEvent.Reason,
 		"timestamp": nodeEvent.OccurredAt,
+	})
+}
+
+// handleRunStarted handles run started events
+func (b *StreamingBridge) handleRunStarted(ctx context.Context, event eventbus.Event) error {
+	runEvent, ok := event.(run.RunStarted)
+	if !ok {
+		return nil
+	}
+
+	return b.publishStreamEvent(ctx, runEvent.RunID, "run_started", map[string]interface{}{
+		"run_id":    runEvent.RunID,
+		"timestamp": runEvent.OccurredAt,
+	})
+}
+
+// handleRunCompleted handles run completed events
+func (b *StreamingBridge) handleRunCompleted(ctx context.Context, event eventbus.Event) error {
+	runEvent, ok := event.(run.RunCompleted)
+	if !ok {
+		return nil
+	}
+
+	return b.publishStreamEvent(ctx, runEvent.RunID, "run_completed", map[string]interface{}{
+		"run_id":    runEvent.RunID,
+		"output":    runEvent.Output,
+		"timestamp": runEvent.OccurredAt,
+	})
+}
+
+// handleRunFailed handles run failed events
+func (b *StreamingBridge) handleRunFailed(ctx context.Context, event eventbus.Event) error {
+	runEvent, ok := event.(run.RunFailed)
+	if !ok {
+		return nil
+	}
+
+	return b.publishStreamEvent(ctx, runEvent.RunID, "run_failed", map[string]interface{}{
+		"run_id":    runEvent.RunID,
+		"error":     runEvent.Error,
+		"timestamp": runEvent.OccurredAt,
+	})
+}
+
+// handleRunRequiresAction handles HITL pause events so Studio's
+// ApprovalDialog can open via the SSE stream.
+func (b *StreamingBridge) handleRunRequiresAction(ctx context.Context, event eventbus.Event) error {
+	runEvent, ok := event.(run.RunRequiresAction)
+	if !ok {
+		return nil
+	}
+
+	return b.publishStreamEvent(ctx, runEvent.RunID, "run_requires_action", map[string]interface{}{
+		"run_id":       runEvent.RunID,
+		"interrupt_id": runEvent.InterruptID,
+		"reason":       runEvent.Reason,
+		"tool_calls":   runEvent.ToolCalls,
+		"timestamp":    runEvent.OccurredAt,
 	})
 }
 


### PR DESCRIPTION
## Summary

- `WorkerHandler.ReceiveEvent` only handled `run_completed` and `run_failed`. Every other event type was silently 200-OK'd and dropped.
- Replaced the if-block with a 7-case switch covering `run_started`, `run_requires_action`, `run_completed`, `run_failed`, `node_started`, `node_completed`, `node_failed`.
- Each case publishes the appropriate domain event onto the existing `eventBus`. `StreamingBridge` already subscribes to those events; once on the bus, NATS fans them out to SSE clients.
- This is **A3** in `POST_DEMO_FIXES.md`, collapsing with **B1** (worker events not propagated to SSE) and **C2** (HITL never transitions) — same root cause.

## Why

Two demo-blocking bugs without this fix:

1. **HITL is broken**. `@human_node` → worker emits `run_requires_action` → handler drops it → run sits `in_progress` forever → Studio's approval dialog never opens.
2. **SSE is partial**. Worker-driven runs emit only the initial `metadata` event. Per-node lifecycle is invisible because nothing reaches the eventBus → NATS → SSE pipeline.

## Wiring change

`NewWorkerHandler` gains an `*eventbus.EventBus` parameter. `cmd/server/main.go` threads through the existing `eventBus` var (already constructed for the streaming bridge and graph engine). Bus-publish calls are guarded with `if h.eventBus != nil` so test harnesses without an eventBus stay green.

## Test plan

- [x] `go build ./...` clean
- [x] Existing handler tests pass
- [ ] Live: kick off a HITL run; confirm Studio's approval dialog opens (run reaches `requires_action`)
- [ ] Live: connect to `/threads/{tid}/runs/{rid}/stream` during a worker-driven run; confirm `run_started`, `node_started`, `node_completed`, `run_completed` events arrive in order

## Companion PRs

- A1 (Claim SQL/scan mismatch): #161
- A2 (RunRepository.FindByThreadID): #162

## Side effect once merged

The polling fallback in `duragraph-studio/src/lib/sse.ts` (introduced as B1 workaround) becomes redundant for the run/node lifecycle paths. The `requires_action` synthesis there is still useful as a paused-run safety net — keep it.