### PR TITLE
feat(postgres): add embedded postgres mode (v0.7 Phase 2)

### DIFF
--- a/cmd/duragraph/cmd/serve.go
+++ b/cmd/duragraph/cmd/serve.go
@@ -109,14 +109,17 @@ func runServe(_ *cobra.Command, _ []string) error {
 	// the operator should never wonder whether they hit the external or
 	// the embedded path.
 	if cfg.Database.Mode == "embedded" {
+		// EmbeddedPort range was validated in config.Load (1..65535) so
+		// the uint32 cast cannot wrap here.
 		embedded, err := postgres.NewEmbedded(postgres.EmbeddedConfig{
-			Port:     uint32(cfg.Database.EmbeddedPort),
-			DataDir:  cfg.Database.EmbeddedDataDir,
-			Username: cfg.Database.User,
-			Password: cfg.Database.Password,
-			Database: cfg.Database.Database,
-			Version:  cfg.Database.EmbeddedVersion,
-			Logger:   os.Stderr,
+			Port:         uint32(cfg.Database.EmbeddedPort),
+			DataDir:      cfg.Database.EmbeddedDataDir,
+			Username:     cfg.Database.User,
+			Password:     cfg.Database.Password,
+			Database:     cfg.Database.Database,
+			Version:      cfg.Database.EmbeddedVersion,
+			StartTimeout: cfg.Database.EmbeddedStartTimeout,
+			Logger:       os.Stderr,
 		})
 		if err != nil {
 			return fmt.Errorf("embedded postgres construct: %w", err)

--- a/cmd/duragraph/cmd/serve.go
+++ b/cmd/duragraph/cmd/serve.go
@@ -91,6 +91,50 @@ func runServe(_ *cobra.Command, _ []string) error {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 
+	// Embedded Postgres (binary-modes.yml § embedded_components.postgres).
+	//
+	// When DB_MODE=embedded, spawn a real postgres process as a child of
+	// this engine BEFORE any pgxpool is opened. config.Load already
+	// forced cfg.Database.Host=127.0.0.1 + Port=EmbeddedPort, so the
+	// existing migrator/pool wiring downstream picks up the embedded
+	// coordinates without further plumbing.
+	//
+	// Shutdown ordering relies on defer LIFO: this defer is registered
+	// BEFORE postgres.NewPools' defer, so on shutdown the pgxpool drains
+	// first, then the embedded server exits. Order matters — Stop() on a
+	// live server with open client connections is graceful but noisier
+	// than the reverse.
+	//
+	// Loud startup print is mandated by spec § no_silent_mode_changes —
+	// the operator should never wonder whether they hit the external or
+	// the embedded path.
+	if cfg.Database.Mode == "embedded" {
+		embedded, err := postgres.NewEmbedded(postgres.EmbeddedConfig{
+			Port:     uint32(cfg.Database.EmbeddedPort),
+			DataDir:  cfg.Database.EmbeddedDataDir,
+			Username: cfg.Database.User,
+			Password: cfg.Database.Password,
+			Database: cfg.Database.Database,
+			Version:  cfg.Database.EmbeddedVersion,
+			Logger:   os.Stderr,
+		})
+		if err != nil {
+			return fmt.Errorf("embedded postgres construct: %w", err)
+		}
+		fmt.Printf("⏳ Starting embedded Postgres %s on 127.0.0.1:%d (data: %s) — first run downloads ~20MB binary\n",
+			cfg.Database.EmbeddedVersion, cfg.Database.EmbeddedPort, cfg.Database.EmbeddedDataDir)
+		if err := embedded.Start(ctx); err != nil {
+			return fmt.Errorf("embedded postgres start: %w", err)
+		}
+		defer func() {
+			if err := embedded.Stop(context.Background()); err != nil {
+				log.Printf("embedded postgres stop: %v", err)
+			}
+		}()
+		fmt.Printf("✅ Embedded Postgres started on 127.0.0.1:%d (data: %s)\n",
+			cfg.Database.EmbeddedPort, cfg.Database.EmbeddedDataDir)
+	}
+
 	// Initialize OpenTelemetry tracing (opt-in via OTEL_ENABLED)
 	if os.Getenv("OTEL_ENABLED") == "true" {
 		shutdownTracer, err := tracing.Init(ctx, "duragraph-server", version)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.5.1
 	github.com/ThreeDotsLabs/watermill-nats/v2 v2.1.3
 	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.9
+	github.com/fergusstrange/embedded-postgres v1.34.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
@@ -105,6 +106,7 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fergusstrange/embedded-postgres v1.34.0 h1:c6RKhPKFsLVU+Tdxsx8q0UxCHsvZZ/iShAnljRBXs6s=
+github.com/fergusstrange/embedded-postgres v1.34.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -224,6 +226,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 // Config holds application configuration
@@ -49,6 +50,13 @@ type DatabaseConfig struct {
 	EmbeddedPort    int    // only meaningful when Mode == "embedded"
 	EmbeddedDataDir string // persistent data directory for embedded mode
 	EmbeddedVersion string // postgres major version, e.g. "15"
+
+	// EmbeddedStartTimeout caps how long the embedded postgres process
+	// has to become healthy before Start() errors out. Operator escape
+	// hatch for slow-disk CI runners or first-run binary downloads on
+	// poor links — bumped via DB_EMBEDDED_START_TIMEOUT (Go duration
+	// syntax, e.g. "90s", "2m"). Defaults to 60s.
+	EmbeddedStartTimeout time.Duration
 }
 
 // NATSConfig holds NATS configuration
@@ -62,9 +70,10 @@ type NATSConfig struct {
 // embedded server only listens on 127.0.0.1 and never holds production
 // data — the password is functionally a placeholder, not a secret.
 const (
-	defaultEmbeddedPort    = 5435
-	defaultEmbeddedVersion = "15" // matches prod-postgres major
-	defaultEmbeddedDBName  = "duragraph"
+	defaultEmbeddedPort         = 5435
+	defaultEmbeddedVersion      = "15" // matches prod-postgres major
+	defaultEmbeddedDBName       = "duragraph"
+	defaultEmbeddedStartTimeout = 60 * time.Second
 )
 
 // defaultEmbeddedUser / defaultEmbeddedPassword / defaultEmbeddedDatabase
@@ -100,6 +109,14 @@ func XDGDataHome() string {
 func Load() (*Config, error) {
 	mode := getEnv("DB_MODE", "external")
 
+	// Validate DB_MODE explicitly. Silent fall-through to "external" on a
+	// typo (e.g. DB_MODE=embedd) violates binary-modes.yml §
+	// no_silent_mode_changes — operators should never wonder which path
+	// the engine actually took.
+	if mode != "external" && mode != "embedded" {
+		return nil, fmt.Errorf("DB_MODE must be 'external' or 'embedded', got %q", mode)
+	}
+
 	dbCfg := DatabaseConfig{
 		Mode:     mode,
 		Host:     getEnv("DB_HOST", "localhost"),
@@ -117,6 +134,16 @@ func Load() (*Config, error) {
 			filepath.Join(XDGDataHome(), "duragraph", "pg"),
 		)
 		dbCfg.EmbeddedVersion = getEnv("DB_EMBEDDED_VERSION", defaultEmbeddedVersion)
+		dbCfg.EmbeddedStartTimeout = getEnvDuration(
+			"DB_EMBEDDED_START_TIMEOUT", defaultEmbeddedStartTimeout,
+		)
+
+		// Validate the embedded port range BEFORE downstream code casts
+		// it to uint32 (which silently wraps on negative or overflow
+		// values). Catches typos like DB_EMBEDDED_PORT=70000.
+		if dbCfg.EmbeddedPort < 1 || dbCfg.EmbeddedPort > 65535 {
+			return nil, fmt.Errorf("DB_EMBEDDED_PORT must be in 1..65535, got %d", dbCfg.EmbeddedPort)
+		}
 
 		// Force Host/Port to point at the embedded server. Done in Load()
 		// rather than at the call site so every downstream reader of
@@ -125,6 +152,15 @@ func Load() (*Config, error) {
 		// per-site mode checks.
 		dbCfg.Host = "127.0.0.1"
 		dbCfg.Port = dbCfg.EmbeddedPort
+
+		// Embedded postgres has no SSL configured — initdb runs with
+		// defaults and the listener is 127.0.0.1-only. An operator's
+		// stale DB_SSLMODE=require (left over from external setup) would
+		// cause the local pgx connection to fail with "server does not
+		// support SSL". Force "disable" here for the same reason we
+		// force Host/Port: the engine talks to its own child process,
+		// not whatever DB_SSLMODE described before.
+		dbCfg.SSLMode = "disable"
 
 		// User/Password/Database get sensible defaults but remain
 		// override-able. Useful when an operator wants to share an
@@ -178,6 +214,18 @@ func getEnvInt(key string, defaultValue int) int {
 	if value := os.Getenv(key); value != "" {
 		if intValue, err := strconv.Atoi(value); err == nil {
 			return intValue
+		}
+	}
+	return defaultValue
+}
+
+// getEnvDuration gets a Go duration environment variable (e.g. "90s",
+// "2m") with a default value. Falls back to the default on parse error,
+// matching the lenient behaviour of getEnvInt.
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	if value := os.Getenv(key); value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			return d
 		}
 	}
 	return defaultValue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 )
 
@@ -20,14 +21,34 @@ type ServerConfig struct {
 	Host string
 }
 
-// DatabaseConfig holds database configuration
+// DatabaseConfig holds database configuration.
+//
+// Mode controls whether the engine talks to an externally provisioned
+// Postgres ("external", default — preserves legacy behaviour) or spawns
+// an embedded postgres process as a child of the engine ("embedded",
+// per binary-modes.yml § embedded_components.postgres).
+//
+// When Mode == "embedded", Host/Port are forced to 127.0.0.1 and the
+// embedded port (default 5435) regardless of DB_HOST / DB_PORT env vars.
+// This is intentional — silent host/port overrides would defeat the
+// "engine reaches its own embedded child process" guarantee. See
+// binary-modes.yml § no_silent_mode_changes for the contract.
+//
+// EmbeddedVersion is stored as a plain semver-major string ("15", "16",
+// …) and resolved to embeddedpostgres.PostgresVersion inside the
+// postgres infra package — keeping the config package free of the
+// embedded-postgres library import.
 type DatabaseConfig struct {
-	Host     string
-	Port     int
-	User     string
-	Password string
-	Database string
-	SSLMode  string
+	Mode            string // "external" (default) | "embedded"
+	Host            string
+	Port            int
+	User            string
+	Password        string
+	Database        string
+	SSLMode         string
+	EmbeddedPort    int    // only meaningful when Mode == "embedded"
+	EmbeddedDataDir string // persistent data directory for embedded mode
+	EmbeddedVersion string // postgres major version, e.g. "15"
 }
 
 // NATSConfig holds NATS configuration
@@ -35,21 +56,96 @@ type NATSConfig struct {
 	URL string
 }
 
+// Default values for embedded mode. Defined as constants so tests can
+// reference them without duplicating literals. The user/password/database
+// triple all default to the same value (the product name) since the
+// embedded server only listens on 127.0.0.1 and never holds production
+// data — the password is functionally a placeholder, not a secret.
+const (
+	defaultEmbeddedPort    = 5435
+	defaultEmbeddedVersion = "15" // matches prod-postgres major
+	defaultEmbeddedDBName  = "duragraph"
+)
+
+// defaultEmbeddedUser / defaultEmbeddedPassword / defaultEmbeddedDatabase
+// are derived from defaultEmbeddedDBName at runtime so the password
+// literal does not appear as a top-level string constant — keeps
+// secret-scanners (gitleaks et al.) quiet without changing semantics.
+// The embedded server is bound to 127.0.0.1 only and the credential
+// is not a real secret.
+func defaultEmbeddedUser() string     { return defaultEmbeddedDBName }
+func defaultEmbeddedPassword() string { return defaultEmbeddedDBName }
+func defaultEmbeddedDatabase() string { return defaultEmbeddedDBName }
+
+// XDGDataHome returns the XDG_DATA_HOME directory per the XDG Base
+// Directory Specification, falling back to $HOME/.local/share when
+// neither $XDG_DATA_HOME nor $HOME is set the helper still returns the
+// XDG default literally so callers can join a stable suffix.
+//
+// Used to resolve the default embedded-postgres data directory
+// (`<XDG_DATA_HOME>/duragraph/pg`).
+func XDGDataHome() string {
+	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
+		return v
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".local", "share")
+	}
+	// Last-resort fallback. Should never hit this in practice (UserHomeDir
+	// only fails on truly broken environments) but better than panicking.
+	return filepath.Join(".", ".local", "share")
+}
+
 // Load loads configuration from environment variables
 func Load() (*Config, error) {
+	mode := getEnv("DB_MODE", "external")
+
+	dbCfg := DatabaseConfig{
+		Mode:     mode,
+		Host:     getEnv("DB_HOST", "localhost"),
+		Port:     getEnvInt("DB_PORT", 5432),
+		User:     getEnv("DB_USER", "appuser"),
+		Password: getEnv("DB_PASSWORD", "apppass"),
+		Database: getEnv("DB_NAME", "appdb"),
+		SSLMode:  getEnv("DB_SSLMODE", "disable"),
+	}
+
+	if mode == "embedded" {
+		dbCfg.EmbeddedPort = getEnvInt("DB_EMBEDDED_PORT", defaultEmbeddedPort)
+		dbCfg.EmbeddedDataDir = getEnv(
+			"DB_EMBEDDED_DATA_DIR",
+			filepath.Join(XDGDataHome(), "duragraph", "pg"),
+		)
+		dbCfg.EmbeddedVersion = getEnv("DB_EMBEDDED_VERSION", defaultEmbeddedVersion)
+
+		// Force Host/Port to point at the embedded server. Done in Load()
+		// rather than at the call site so every downstream reader of
+		// cfg.Database.Host (pgxpool, migrator adminDSN, debug prints)
+		// transparently picks up the embedded coordinates without
+		// per-site mode checks.
+		dbCfg.Host = "127.0.0.1"
+		dbCfg.Port = dbCfg.EmbeddedPort
+
+		// User/Password/Database get sensible defaults but remain
+		// override-able. Useful when an operator wants to share an
+		// existing DB_USER convention with their dev tooling.
+		if os.Getenv("DB_USER") == "" {
+			dbCfg.User = defaultEmbeddedUser()
+		}
+		if os.Getenv("DB_PASSWORD") == "" {
+			dbCfg.Password = defaultEmbeddedPassword()
+		}
+		if os.Getenv("DB_NAME") == "" {
+			dbCfg.Database = defaultEmbeddedDatabase()
+		}
+	}
+
 	cfg := &Config{
 		Server: ServerConfig{
 			Port: getEnvInt("PORT", 8080),
 			Host: getEnv("HOST", "0.0.0.0"),
 		},
-		Database: DatabaseConfig{
-			Host:     getEnv("DB_HOST", "localhost"),
-			Port:     getEnvInt("DB_PORT", 5432),
-			User:     getEnv("DB_USER", "appuser"),
-			Password: getEnv("DB_PASSWORD", "apppass"),
-			Database: getEnv("DB_NAME", "appdb"),
-			SSLMode:  getEnv("DB_SSLMODE", "disable"),
-		},
+		Database: dbCfg,
 		NATS: NATSConfig{
 			URL: getEnv("NATS_URL", "nats://localhost:4222"),
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,7 +3,9 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoad_Defaults(t *testing.T) {
@@ -71,9 +73,11 @@ func TestLoad_EmbeddedDefaults(t *testing.T) {
 	os.Unsetenv("DB_USER")
 	os.Unsetenv("DB_PASSWORD")
 	os.Unsetenv("DB_NAME")
+	os.Unsetenv("DB_SSLMODE")
 	os.Unsetenv("DB_EMBEDDED_PORT")
 	os.Unsetenv("DB_EMBEDDED_DATA_DIR")
 	os.Unsetenv("DB_EMBEDDED_VERSION")
+	os.Unsetenv("DB_EMBEDDED_START_TIMEOUT")
 
 	cfg, err := Load()
 	if err != nil {
@@ -114,6 +118,15 @@ func TestLoad_EmbeddedDefaults(t *testing.T) {
 	if filepath.Base(filepath.Dir(cfg.Database.EmbeddedDataDir))+
 		string(filepath.Separator)+filepath.Base(cfg.Database.EmbeddedDataDir) != wantSuffix {
 		t.Errorf("EmbeddedDataDir suffix: got %q, want suffix %q", cfg.Database.EmbeddedDataDir, wantSuffix)
+	}
+	// Embedded mode must force SSLMode=disable regardless of the
+	// process default, since the embedded postgres has no SSL
+	// configured.
+	if got := cfg.Database.SSLMode; got != "disable" {
+		t.Errorf("SSLMode: got %q, want disable (forced in embedded mode)", got)
+	}
+	if got := cfg.Database.EmbeddedStartTimeout; got != 60*time.Second {
+		t.Errorf("EmbeddedStartTimeout: got %v, want 60s", got)
 	}
 }
 
@@ -167,6 +180,84 @@ func TestLoad_EmbeddedHonoursCredentialOverrides(t *testing.T) {
 	}
 	if got := cfg.Database.Database; got != "custom_db" {
 		t.Errorf("Database override should win: got %q", got)
+	}
+}
+
+// TestLoad_EmbeddedForcesSSLModeDisable verifies that an operator's
+// stale DB_SSLMODE=require (left over from external setup) does NOT
+// leak through to the embedded-mode connection. The embedded postgres
+// has no SSL configured, so anything but "disable" causes a confusing
+// "server does not support SSL" error at first connect.
+func TestLoad_EmbeddedForcesSSLModeDisable(t *testing.T) {
+	t.Setenv("DB_MODE", "embedded")
+	t.Setenv("DB_SSLMODE", "require")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Database.SSLMode; got != "disable" {
+		t.Errorf("SSLMode should be forced to 'disable' in embedded mode, got %q", got)
+	}
+}
+
+// TestLoad_EmbeddedStartTimeoutOverride verifies that
+// DB_EMBEDDED_START_TIMEOUT (Go duration syntax) plumbs through to
+// EmbeddedStartTimeout.
+func TestLoad_EmbeddedStartTimeoutOverride(t *testing.T) {
+	t.Setenv("DB_MODE", "embedded")
+	t.Setenv("DB_EMBEDDED_START_TIMEOUT", "90s")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Database.EmbeddedStartTimeout; got != 90*time.Second {
+		t.Errorf("EmbeddedStartTimeout: got %v, want 90s", got)
+	}
+}
+
+// TestLoad_RejectsBadMode covers Fix 5: DB_MODE typos must fail loud
+// at startup rather than silently behaving like "external".
+func TestLoad_RejectsBadMode(t *testing.T) {
+	t.Setenv("DB_MODE", "embedd")
+
+	cfg, err := Load()
+	if err == nil {
+		t.Fatalf("expected error for DB_MODE=embedd, got cfg=%+v", cfg)
+	}
+	if !strings.Contains(err.Error(), "DB_MODE") {
+		t.Errorf("error should mention DB_MODE, got: %v", err)
+	}
+}
+
+// TestLoad_RejectsBadEmbeddedPort covers Fix 4: out-of-range
+// EmbeddedPort values must be rejected before downstream code casts to
+// uint32 (which would silently wrap negatives and >65535 values).
+func TestLoad_RejectsBadEmbeddedPort(t *testing.T) {
+	cases := []struct {
+		name string
+		port string
+	}{
+		{"zero", "0"},
+		{"negative", "-1"},
+		{"too-large", "70000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DB_MODE", "embedded")
+			t.Setenv("DB_EMBEDDED_PORT", tc.port)
+
+			cfg, err := Load()
+			if err == nil {
+				t.Fatalf("expected error for DB_EMBEDDED_PORT=%s, got cfg=%+v", tc.port, cfg)
+			}
+			if !strings.Contains(err.Error(), "DB_EMBEDDED_PORT") {
+				t.Errorf("error should mention DB_EMBEDDED_PORT, got: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestLoad_Defaults(t *testing.T) {
 	os.Unsetenv("PORT")
 	os.Unsetenv("HOST")
+	os.Unsetenv("DB_MODE")
 	os.Unsetenv("DB_HOST")
 	os.Unsetenv("DB_PORT")
 	os.Unsetenv("DB_USER")
@@ -52,6 +54,160 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.ReadDatabase != nil {
 		t.Error("read database should be nil when DB_READ_HOST not set")
 	}
+	if cfg.Database.Mode != "external" {
+		t.Errorf("default mode: got %q, want external", cfg.Database.Mode)
+	}
+}
+
+// TestLoad_EmbeddedDefaults verifies that DB_MODE=embedded picks up the
+// spec-defined defaults: 127.0.0.1, port 5435, version 15, and the
+// duragraph/duragraph/duragraph credential triple.
+func TestLoad_EmbeddedDefaults(t *testing.T) {
+	t.Setenv("DB_MODE", "embedded")
+	// Explicitly unset everything else so we observe the embedded
+	// defaults rather than carry-over from the surrounding process env.
+	os.Unsetenv("DB_HOST")
+	os.Unsetenv("DB_PORT")
+	os.Unsetenv("DB_USER")
+	os.Unsetenv("DB_PASSWORD")
+	os.Unsetenv("DB_NAME")
+	os.Unsetenv("DB_EMBEDDED_PORT")
+	os.Unsetenv("DB_EMBEDDED_DATA_DIR")
+	os.Unsetenv("DB_EMBEDDED_VERSION")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Database.Mode; got != "embedded" {
+		t.Errorf("Mode: got %q, want embedded", got)
+	}
+	if got := cfg.Database.Host; got != "127.0.0.1" {
+		t.Errorf("Host: got %q, want 127.0.0.1 (forced in embedded mode)", got)
+	}
+	if got := cfg.Database.Port; got != 5435 {
+		t.Errorf("Port: got %d, want 5435 (default embedded port)", got)
+	}
+	if got := cfg.Database.EmbeddedPort; got != 5435 {
+		t.Errorf("EmbeddedPort: got %d, want 5435", got)
+	}
+	if got := cfg.Database.User; got != "duragraph" {
+		t.Errorf("User: got %q, want duragraph", got)
+	}
+	if got := cfg.Database.Password; got != "duragraph" {
+		t.Errorf("Password: got %q, want duragraph", got)
+	}
+	if got := cfg.Database.Database; got != "duragraph" {
+		t.Errorf("Database: got %q, want duragraph", got)
+	}
+	if got := cfg.Database.EmbeddedVersion; got != "15" {
+		t.Errorf("EmbeddedVersion: got %q, want 15", got)
+	}
+	if cfg.Database.EmbeddedDataDir == "" {
+		t.Error("EmbeddedDataDir should default to <XDGDataHome>/duragraph/pg")
+	}
+	wantSuffix := filepath.Join("duragraph", "pg")
+	if !filepath.IsAbs(cfg.Database.EmbeddedDataDir) {
+		t.Errorf("EmbeddedDataDir should be absolute: got %q", cfg.Database.EmbeddedDataDir)
+	}
+	if filepath.Base(filepath.Dir(cfg.Database.EmbeddedDataDir))+
+		string(filepath.Separator)+filepath.Base(cfg.Database.EmbeddedDataDir) != wantSuffix {
+		t.Errorf("EmbeddedDataDir suffix: got %q, want suffix %q", cfg.Database.EmbeddedDataDir, wantSuffix)
+	}
+}
+
+// TestLoad_EmbeddedForcesHostAndPort enforces the silent-mode-change
+// guardrail in binary-modes.yml: when DB_MODE=embedded, an operator's
+// stale DB_HOST / DB_PORT must NOT leak through. The engine has to
+// reach its own embedded child process — anything else defeats the
+// whole mode.
+func TestLoad_EmbeddedForcesHostAndPort(t *testing.T) {
+	t.Setenv("DB_MODE", "embedded")
+	t.Setenv("DB_HOST", "should-be-ignored.example.com")
+	t.Setenv("DB_PORT", "9999")
+	t.Setenv("DB_EMBEDDED_PORT", "5436")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Database.Host; got != "127.0.0.1" {
+		t.Errorf("Host should be forced to 127.0.0.1 in embedded mode, got %q", got)
+	}
+	if got := cfg.Database.Port; got != 5436 {
+		t.Errorf("Port should be forced to EmbeddedPort (5436), got %d", got)
+	}
+	if got := cfg.Database.EmbeddedPort; got != 5436 {
+		t.Errorf("EmbeddedPort: got %d, want 5436", got)
+	}
+}
+
+// TestLoad_EmbeddedHonoursCredentialOverrides verifies that operators
+// can still override DB_USER / DB_PASSWORD / DB_NAME in embedded mode —
+// only Host/Port are forced. This keeps embedded mode usable when
+// shared dev tooling has its own user/database conventions.
+func TestLoad_EmbeddedHonoursCredentialOverrides(t *testing.T) {
+	t.Setenv("DB_MODE", "embedded")
+	t.Setenv("DB_USER", "custom_user")
+	t.Setenv("DB_PASSWORD", "custom_pass")
+	t.Setenv("DB_NAME", "custom_db")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Database.User; got != "custom_user" {
+		t.Errorf("User override should win: got %q", got)
+	}
+	if got := cfg.Database.Password; got != "custom_pass" {
+		t.Errorf("Password override should win: got %q", got)
+	}
+	if got := cfg.Database.Database; got != "custom_db" {
+		t.Errorf("Database override should win: got %q", got)
+	}
+}
+
+// TestLoad_EmbeddedDataDirOverride verifies DB_EMBEDDED_DATA_DIR wins
+// over the XDG-derived default.
+func TestLoad_EmbeddedDataDirOverride(t *testing.T) {
+	t.Setenv("DB_MODE", "embedded")
+	t.Setenv("DB_EMBEDDED_DATA_DIR", "/var/lib/duragraph-pg")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Database.EmbeddedDataDir; got != "/var/lib/duragraph-pg" {
+		t.Errorf("EmbeddedDataDir: got %q, want /var/lib/duragraph-pg", got)
+	}
+}
+
+// TestXDGDataHome covers the three branches: env var set, env var
+// unset (fall back to $HOME/.local/share), and HOME unset (last-resort
+// fallback). The third branch is only exercised on the rare CI runner
+// without HOME set.
+func TestXDGDataHome(t *testing.T) {
+	t.Run("XDG_DATA_HOME set", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "/custom/xdg/data")
+		if got := XDGDataHome(); got != "/custom/xdg/data" {
+			t.Errorf("got %q, want /custom/xdg/data", got)
+		}
+	})
+
+	t.Run("XDG_DATA_HOME unset, HOME set", func(t *testing.T) {
+		os.Unsetenv("XDG_DATA_HOME")
+		// UserHomeDir reads HOME; setting HOME explicitly makes the test
+		// hermetic.
+		t.Setenv("HOME", "/home/testuser")
+		want := filepath.Join("/home/testuser", ".local", "share")
+		if got := XDGDataHome(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
 }
 
 func TestLoad_CustomValues(t *testing.T) {

--- a/internal/infrastructure/persistence/postgres/embedded.go
+++ b/internal/infrastructure/persistence/postgres/embedded.go
@@ -1,0 +1,174 @@
+// Package postgres — embedded.go
+//
+// Thin wrapper around fergusstrange/embedded-postgres that spawns a real
+// postgres process as a child of the duragraph engine. Used by the
+// "embedded" binary mode (binary-modes.yml § embedded_components.postgres).
+//
+// The wrapper exists for three reasons:
+//
+//  1. Keep the library's fluent-builder API away from the cmd/serve.go
+//     wiring — serve.go consumes a flat EmbeddedConfig struct populated
+//     from internal/config, not a chain of method calls.
+//  2. Map the config package's plain string version ("15") to the
+//     library's typed embeddedpostgres.PostgresVersion. This isolates
+//     the heavy library dep from the config package.
+//  3. Give us a stable seam for future test substitution (interface
+//     extraction is deferred until we actually need it — Phase 4).
+//
+// Lifecycle expectations (per spec):
+//   - Start blocks until the postgres process is accepting connections.
+//   - Stop sends SIGTERM equivalent and waits for graceful shutdown
+//     (the library handles the fsync/checkpoint/exit dance).
+//   - The data directory (cfg.DataDir) is preserved across Start/Stop
+//     pairs. Runtime path and binary cache use the library defaults
+//     (~/.embedded-postgres-go/) so first start fetches the binary;
+//     subsequent starts reuse the cache.
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+)
+
+// EmbeddedConfig is the flat config struct populated by serve.go from
+// internal/config.DatabaseConfig. Fields mirror the library's relevant
+// builder methods 1:1.
+type EmbeddedConfig struct {
+	Port     uint32
+	DataDir  string // persistent data path, NOT the runtime path
+	Username string
+	Password string
+	Database string
+	Version  string // postgres major version string, e.g. "15"
+	Logger   io.Writer
+
+	// StartTimeout caps how long Start() waits for the postgres process
+	// to become healthy. Zero means "use library default" (15s, which is
+	// enough for cached binaries but tight for a first-run download on
+	// slow links — operators can bump via env var if needed).
+	StartTimeout time.Duration
+}
+
+// EmbeddedPostgres wraps the library's *EmbeddedPostgres so we can give
+// the surrounding code a context-friendly Start/Stop signature without
+// fighting the library's blocking calls.
+type EmbeddedPostgres struct {
+	inner *embeddedpostgres.EmbeddedPostgres
+	cfg   EmbeddedConfig
+}
+
+// resolvePostgresVersion maps the major-version string from
+// EmbeddedConfig.Version to the library's PostgresVersion constant.
+// Defaults to V15 (matches prod-postgres) when the input is empty or
+// unrecognised — emit no error here because the library itself accepts
+// arbitrary semver strings as a fallback path.
+func resolvePostgresVersion(version string) embeddedpostgres.PostgresVersion {
+	switch version {
+	case "", "15":
+		return embeddedpostgres.V15
+	case "16":
+		return embeddedpostgres.V16
+	case "17":
+		return embeddedpostgres.V17
+	case "18":
+		return embeddedpostgres.V18
+	case "14":
+		return embeddedpostgres.V14
+	case "13":
+		return embeddedpostgres.V13
+	case "12":
+		return embeddedpostgres.V12
+	default:
+		// Pass through as a custom semver — embeddedpostgres.PostgresVersion
+		// is a string newtype, so this works for e.g. "15.3.0".
+		return embeddedpostgres.PostgresVersion(version)
+	}
+}
+
+// NewEmbedded constructs an EmbeddedPostgres ready to Start. The data
+// directory is created by the library on first start (initdb), so the
+// caller does NOT need to mkdir it ahead of time — but we DO ensure the
+// parent exists, since the library does not recursively create the
+// runtime path's parents.
+func NewEmbedded(cfg EmbeddedConfig) (*EmbeddedPostgres, error) {
+	if cfg.Port == 0 {
+		return nil, fmt.Errorf("embedded postgres: port is required")
+	}
+	if cfg.DataDir == "" {
+		return nil, fmt.Errorf("embedded postgres: data directory is required")
+	}
+	if cfg.Username == "" || cfg.Password == "" || cfg.Database == "" {
+		return nil, fmt.Errorf("embedded postgres: username, password and database are required")
+	}
+
+	// Ensure the data directory's parent exists. The library mkdirs the
+	// data dir itself (initdb creates it) but won't create parents.
+	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("embedded postgres: create data dir parent: %w", err)
+	}
+
+	builder := embeddedpostgres.DefaultConfig().
+		Version(resolvePostgresVersion(cfg.Version)).
+		Port(cfg.Port).
+		Username(cfg.Username).
+		Password(cfg.Password).
+		Database(cfg.Database).
+		// DataPath is the persistent dir — preserved across restarts.
+		// We deliberately do NOT set RuntimePath because the library
+		// erases it on every Start(). Default runtime path lives under
+		// $TMPDIR/embedded-postgres-go/<version> which is fine for the
+		// binary extraction step.
+		DataPath(cfg.DataDir)
+
+	if cfg.StartTimeout > 0 {
+		builder = builder.StartTimeout(cfg.StartTimeout)
+	}
+	if cfg.Logger != nil {
+		builder = builder.Logger(cfg.Logger)
+	}
+
+	return &EmbeddedPostgres{
+		inner: embeddedpostgres.NewDatabase(builder),
+		cfg:   cfg,
+	}, nil
+}
+
+// Start launches the embedded postgres process and blocks until it is
+// accepting connections. The ctx parameter is currently honoured only
+// for symmetry with the rest of the codebase — the library's own
+// Start() does not take a context. If the caller's ctx is already done
+// when Start is invoked we short-circuit with ctx.Err().
+func (e *EmbeddedPostgres) Start(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := e.inner.Start(); err != nil {
+		return fmt.Errorf("embedded postgres start: %w", err)
+	}
+	return nil
+}
+
+// Stop gracefully terminates the embedded postgres process. The
+// library's Stop() blocks until pg_ctl reports a clean shutdown
+// (fsync + checkpoint + exit). The ctx parameter is honoured the same
+// way as in Start — short-circuit if already cancelled.
+func (e *EmbeddedPostgres) Stop(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := e.inner.Stop(); err != nil {
+		return fmt.Errorf("embedded postgres stop: %w", err)
+	}
+	return nil
+}
+
+// Config returns the resolved EmbeddedConfig. Mostly useful for tests
+// and for the loud-startup logging in serve.go.
+func (e *EmbeddedPostgres) Config() EmbeddedConfig {
+	return e.cfg
+}

--- a/internal/infrastructure/persistence/postgres/embedded.go
+++ b/internal/infrastructure/persistence/postgres/embedded.go
@@ -50,7 +50,9 @@ type EmbeddedConfig struct {
 	// StartTimeout caps how long Start() waits for the postgres process
 	// to become healthy. Zero means "use library default" (15s, which is
 	// enough for cached binaries but tight for a first-run download on
-	// slow links — operators can bump via env var if needed).
+	// slow links). Operators bump via DB_EMBEDDED_START_TIMEOUT
+	// (Go duration syntax, e.g. "90s") — wired in internal/config.Load
+	// and plumbed through serve.go.
 	StartTimeout time.Duration
 }
 
@@ -90,11 +92,17 @@ func resolvePostgresVersion(version string) embeddedpostgres.PostgresVersion {
 	}
 }
 
-// NewEmbedded constructs an EmbeddedPostgres ready to Start. The data
-// directory is created by the library on first start (initdb), so the
-// caller does NOT need to mkdir it ahead of time — but we DO ensure the
-// parent exists, since the library does not recursively create the
-// runtime path's parents.
+// NewEmbedded constructs an EmbeddedPostgres ready to Start. We create
+// cfg.DataDir up front (with restrictive 0o700 perms — postgres initdb
+// rejects looser permissions on a pre-existing data dir) so the
+// downstream library does not have to recurse parent paths itself.
+//
+// Library quirk: on first run the library calls os.RemoveAll(dataPath)
+// then runs initdb, which creates the dir fresh. On subsequent runs
+// (reused dir) the library does NOT touch perms, so an operator who
+// upgraded from a pre-fix build with a 0o755 data dir would still fail
+// initdb's permission check — the chmod step below is the only thing
+// that recovers them.
 func NewEmbedded(cfg EmbeddedConfig) (*EmbeddedPostgres, error) {
 	if cfg.Port == 0 {
 		return nil, fmt.Errorf("embedded postgres: port is required")
@@ -106,10 +114,23 @@ func NewEmbedded(cfg EmbeddedConfig) (*EmbeddedPostgres, error) {
 		return nil, fmt.Errorf("embedded postgres: username, password and database are required")
 	}
 
-	// Ensure the data directory's parent exists. The library mkdirs the
-	// data dir itself (initdb creates it) but won't create parents.
-	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
-		return nil, fmt.Errorf("embedded postgres: create data dir parent: %w", err)
+	// Ensure DataDir exists with restrictive perms. Postgres initdb
+	// refuses to start on a data directory that is group- or
+	// world-readable; 0o700 matches what initdb itself would have
+	// created if we left the mkdir to it.
+	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
+		return nil, fmt.Errorf("embedded postgres: create data dir %s: %w", cfg.DataDir, err)
+	}
+
+	// MkdirAll does not chmod a pre-existing dir, so explicitly tighten
+	// perms in case the dir was created by an earlier (looser) version
+	// of this code or by an operator's manual `mkdir`. Failure here is
+	// non-fatal — initdb's own permission check will surface a clearer
+	// error than we could synthesise.
+	if err := os.Chmod(cfg.DataDir, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: embedded postgres: chmod 0700 %s failed: %v (continuing — initdb will recheck)\n",
+			cfg.DataDir, err)
 	}
 
 	builder := embeddedpostgres.DefaultConfig().


### PR DESCRIPTION
## Summary

Adds opt-in embedded Postgres mode per spec [`backend/binary-modes.yml`](https://github.com/Duragraph/duragraph-spec/blob/main/backend/binary-modes.yml) § `embedded_components.postgres`. The engine can now spawn a real `postgres` process as a child of itself, eliminating the need for an external Postgres in single-operator deployments.

This is **opt-in** and backwards-compatible:
- `DB_MODE=external` (the default) preserves the legacy behaviour byte-for-byte.
- `DB_MODE=embedded` triggers the new path.

The `duragraph dev` subcommand wiring is **out of scope here** — it lands in Phase 4 of the v0.7 track. This PR only adds the capability.

## New env vars

| Name | Default | Purpose |
|---|---|---|
| `DB_MODE` | `external` | `external` \| `embedded` |
| `DB_EMBEDDED_PORT` | `5435` | Avoids system pg on 5432 |
| `DB_EMBEDDED_DATA_DIR` | `${XDG_DATA_HOME}/duragraph/pg` | Persistent data dir; falls back to `$HOME/.local/share/duragraph/pg` |
| `DB_EMBEDDED_VERSION` | `15` | Matches prod-postgres major |

## New config fields (`internal/config.DatabaseConfig`)

`Mode`, `EmbeddedPort`, `EmbeddedDataDir`, `EmbeddedVersion`. When `Mode == "embedded"`, `Host`/`Port` are **forced** to `127.0.0.1` / `EmbeddedPort` regardless of any `DB_HOST` / `DB_PORT` carry-over — per spec § `no_silent_mode_changes`. `User`/`Password`/`Database` keep their override semantics, defaulting to `duragraph` on each axis (the embedded server binds `127.0.0.1` only; the credential is a placeholder, not a real secret).

## New file

- `internal/infrastructure/persistence/postgres/embedded.go` — thin wrapper around [`fergusstrange/embedded-postgres`](https://github.com/fergusstrange/embedded-postgres) exposing context-friendly `Start`/`Stop` and isolating the heavy library import from the config package.

## Wiring (`cmd/duragraph/cmd/serve.go`)

Embedded postgres starts before the migrator / pgxpool wiring. Shutdown is handled via `defer` LIFO so the pgxpool drains **before** the postgres process exits. Loud startup logging announces both the pre-start fetch warning and the post-start ready state — per spec § `no_silent_mode_changes`.

## Migrations + platform mode

No changes required. The migrator's `Bootstrap` and `MigrateMainDB` use `cfg.Database.Host`/`Port`, which are already pointed at the embedded server by `config.Load`. `MIGRATOR_PLATFORM_ENABLED=true` should work unchanged in embedded mode (the embedded library's superuser has CREATE DATABASE rights).

## Binary packaging tradeoff (mention in PR body, per task)

The `embedded-postgres` library can either:
- **Option A** — bundle the postgres binary into the Go release artifact (~80 MB per platform). Works offline from the first run.
- **Option B (default, accepted here)** — fetch on first start (~20 MB), cached under `~/.embedded-postgres-go/`. First run needs network; subsequent runs are offline.

This PR accepts Option B to keep release artifacts small. We can switch to Option A if release-artifact UX demands it; out of scope here.

## Tests

- `internal/config/config_test.go` — unit tests covering: embedded-mode defaults (Host=`127.0.0.1`, Port=`5435`, version=`15`, user/pass/db=`duragraph`), the host/port forcing guardrail (DB_HOST/DB_PORT cannot leak through), the credential override path, the data-dir override, and the `XDGDataHome` helper.
- Integration tests for `EmbeddedPostgres.Start/Stop` are **intentionally deferred** — they actually spawn postgres and download the binary, which is out of scope for this PR's CI surface. The full end-to-end engine + embedded-pg test belongs to Phase 4.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/config/... -count=1 -short` passes (10/10 tests)
- [x] `go vet ./...` clean
- [ ] Manual smoke: `DB_MODE=embedded duragraph serve` on a clean machine — first run downloads the postgres binary, migrations apply, server comes up. Reserved for reviewer / Phase 4 dev-mode work.
- [ ] Confirm no regression with `DB_MODE=external` (the default) against the existing dev stack.