### PR TITLE
feat(dashboard): capability-aware admin gating + /info expansion

### DIFF
--- a/dashboard/src/api/info.ts
+++ b/dashboard/src/api/info.ts
@@ -1,0 +1,58 @@
+/**
+ * Engine capability discovery via GET /info.
+ *
+ * Note: /info is served at the engine root (not under /api/v1), so this
+ * module bypasses the `api` client in `./client.ts` and uses plain fetch.
+ */
+
+export type EngineMode = "dev" | "serve" | "multitenant"
+export type OAuthProvider = "google" | "github"
+
+/**
+ * Capabilities is the typed shape of the /info response that the dashboard
+ * cares about. The engine returns additional fields (capabilities array,
+ * runtime_config, etc.) which we ignore here.
+ */
+export interface Capabilities {
+  version: string
+  goVersion: string
+  platform: string
+  arch: string
+  mode: EngineMode
+  platformEnabled: boolean
+  authEnabled: boolean
+  oauthProviders: OAuthProvider[]
+}
+
+/** Raw wire shape returned by GET /info — snake_case as it comes off Go. */
+interface InfoResponseWire {
+  version: string
+  go_version: string
+  platform: string
+  arch: string
+  mode: EngineMode
+  platform_enabled: boolean
+  auth_enabled: boolean
+  oauth_providers: OAuthProvider[]
+}
+
+/** Fetch /info and convert snake_case to camelCase. */
+export async function fetchInfo(): Promise<Capabilities> {
+  const response = await fetch("/info", {
+    headers: { Accept: "application/json" },
+  })
+  if (!response.ok) {
+    throw new Error(`GET /info failed: HTTP ${response.status}`)
+  }
+  const raw = (await response.json()) as InfoResponseWire
+  return {
+    version: raw.version,
+    goVersion: raw.go_version,
+    platform: raw.platform,
+    arch: raw.arch,
+    mode: raw.mode,
+    platformEnabled: raw.platform_enabled,
+    authEnabled: raw.auth_enabled,
+    oauthProviders: raw.oauth_providers ?? [],
+  }
+}

--- a/dashboard/src/components/CapabilitiesProvider.tsx
+++ b/dashboard/src/components/CapabilitiesProvider.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { fetchInfo } from "@/api/info"
+import { CAPABILITIES_QUERY_KEY } from "@/hooks/useCapabilities"
+
+interface CapabilitiesProviderProps {
+  children: ReactNode
+}
+
+/**
+ * CapabilitiesProvider performs the boot-time fetch of GET /info and gates
+ * the rest of the app behind it. Once data is in the QueryClient cache,
+ * `useCapabilities()` and route `beforeLoad` guards (via
+ * `queryClient.getQueryData`) can read it synchronously.
+ */
+export function CapabilitiesProvider({ children }: CapabilitiesProviderProps) {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: CAPABILITIES_QUERY_KEY,
+    queryFn: fetchInfo,
+    staleTime: Infinity,
+    retry: 1,
+  })
+
+  if (isError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-lg font-semibold">Engine unreachable</h1>
+          <p className="text-sm text-muted-foreground">
+            Could not load engine capabilities from <code>/info</code>.
+            {error instanceof Error ? ` ${error.message}` : ""}
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              void refetch()
+            }}
+            className="px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (isLoading || !data) {
+    // Brief blank — the fetch is local to the same origin and typically
+    // resolves in a few ms. A spinner would flash worse than nothing.
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -14,11 +14,14 @@ import {
   BarChart3,
   DollarSign,
   User,
+  Users,
+  Gauge,
   X,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { useCapabilities } from "@/hooks/useCapabilities"
 
 const navItems = [
   { icon: LayoutDashboard, label: "Dashboard", path: "/" },
@@ -38,10 +41,19 @@ const configItems = [
   { icon: Settings, label: "Settings", path: "/settings" },
 ]
 
+// Admin nav items are only rendered when the engine is in multi-tenant mode
+// (MIGRATOR_PLATFORM_ENABLED=true). The actual /admin/* pages are placeholders
+// until Phase 3 frontend work lands.
+const adminItems = [
+  { icon: Users, label: "Users", path: "/admin/users" },
+  { icon: Gauge, label: "Metrics", path: "/admin/metrics" },
+]
+
 export function Sidebar() {
   const { sidebarCollapsed, toggleSidebar, mobileMenuOpen, setMobileMenuOpen } = useUIStore()
   const router = useRouterState()
   const currentPath = router.location.pathname
+  const capabilities = useCapabilities()
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -148,6 +160,27 @@ export function Sidebar() {
               collapsed={sidebarCollapsed && !mobileMenuOpen}
             />
           ))}
+
+          {capabilities.platformEnabled && (
+            <>
+              <Separator className="my-3" />
+
+              <div className={cn("px-3 py-2", sidebarCollapsed && !mobileMenuOpen && "hidden")}>
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Admin
+                </span>
+              </div>
+
+              {adminItems.map((item) => (
+                <NavItem
+                  key={item.path}
+                  {...item}
+                  isActive={currentPath === item.path}
+                  collapsed={sidebarCollapsed && !mobileMenuOpen}
+                />
+              ))}
+            </>
+          )}
         </nav>
 
         {/* Collapse Toggle - hidden on mobile */}

--- a/dashboard/src/hooks/useCapabilities.ts
+++ b/dashboard/src/hooks/useCapabilities.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query"
+import { fetchInfo, type Capabilities } from "@/api/info"
+
+/** Stable query key for the engine capabilities query. */
+export const CAPABILITIES_QUERY_KEY = ["capabilities"] as const
+
+/**
+ * useCapabilities returns engine capabilities loaded by `<CapabilitiesProvider>`.
+ *
+ * The provider performs the initial fetch at app boot and only renders
+ * children once data is available — so within the app tree this hook is
+ * guaranteed to return a populated `Capabilities`. Outside the provider it
+ * would throw.
+ */
+export function useCapabilities(): Capabilities {
+  const { data } = useQuery({
+    queryKey: CAPABILITIES_QUERY_KEY,
+    queryFn: fetchInfo,
+    staleTime: Infinity,
+    retry: 1,
+  })
+  if (!data) {
+    throw new Error(
+      "useCapabilities() called before <CapabilitiesProvider> populated the cache",
+    )
+  }
+  return data
+}

--- a/dashboard/src/lib/queryClient.ts
+++ b/dashboard/src/lib/queryClient.ts
@@ -1,0 +1,20 @@
+import { QueryClient } from "@tanstack/react-query"
+
+/**
+ * Shared QueryClient instance.
+ *
+ * Exported as a module singleton so route guards (which run outside React)
+ * can read cached data via `queryClient.getQueryData(...)` synchronously.
+ * The same instance is provided to React via `<QueryClientProvider>` in
+ * `src/routes/__root.tsx`.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60, // 1 minute
+      gcTime: 1000 * 60 * 10, // 10 minutes
+      retry: 3,
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/dashboard/src/lib/routeGuards.ts
+++ b/dashboard/src/lib/routeGuards.ts
@@ -1,0 +1,33 @@
+/**
+ * Route guards for TanStack Router.
+ *
+ * These run synchronously in `beforeLoad`. They read engine capabilities from
+ * the QueryClient cache populated by `<CapabilitiesProvider>` at app boot.
+ * Attach them to admin-only routes to redirect users away from features that
+ * are unavailable in the current engine mode.
+ *
+ * Usage in a route file:
+ *   import { adminOnlyGuard } from '@/lib/routeGuards'
+ *   export const Route = createFileRoute('/_app/admin')({
+ *     beforeLoad: adminOnlyGuard,
+ *     component: AdminLayout,
+ *   })
+ */
+
+import { redirect } from "@tanstack/react-router"
+import type { Capabilities } from "@/api/info"
+import { CAPABILITIES_QUERY_KEY } from "@/hooks/useCapabilities"
+import { queryClient } from "@/lib/queryClient"
+
+/**
+ * adminOnlyGuard redirects to "/" when the engine is not in multi-tenant mode.
+ *
+ * Reads from the QueryClient cache; does not fetch. Safe to use synchronously
+ * because `<CapabilitiesProvider>` blocks rendering until data is populated.
+ */
+export function adminOnlyGuard() {
+  const caps = queryClient.getQueryData<Capabilities>(CAPABILITIES_QUERY_KEY)
+  if (!caps?.platformEnabled) {
+    throw redirect({ to: "/" })
+  }
+}

--- a/dashboard/src/lib/routeGuards.ts
+++ b/dashboard/src/lib/routeGuards.ts
@@ -1,10 +1,19 @@
 /**
  * Route guards for TanStack Router.
  *
- * These run synchronously in `beforeLoad`. They read engine capabilities from
- * the QueryClient cache populated by `<CapabilitiesProvider>` at app boot.
- * Attach them to admin-only routes to redirect users away from features that
- * are unavailable in the current engine mode.
+ * These run in `beforeLoad`, BEFORE child components mount. They cannot rely
+ * on `<CapabilitiesProvider>` having already populated the query cache —
+ * that provider only runs once the route's component subtree mounts, which
+ * is *after* `beforeLoad`. Cold loads / deep links / page refreshes hit
+ * empty cache.
+ *
+ * We use `queryClient.ensureQueryData` so the guard:
+ *   - returns cached capabilities if present (warm in-app navigation), or
+ *   - fires the query and awaits it (cold load), or
+ *   - rethrows on fetch failure (TanStack Router surfaces it).
+ *
+ * The query key + queryFn + staleTime: Infinity must match `useCapabilities`
+ * so both code paths share the same query identity in the cache.
  *
  * Usage in a route file:
  *   import { adminOnlyGuard } from '@/lib/routeGuards'
@@ -15,19 +24,24 @@
  */
 
 import { redirect } from "@tanstack/react-router"
-import type { Capabilities } from "@/api/info"
+import { fetchInfo, type Capabilities } from "@/api/info"
 import { CAPABILITIES_QUERY_KEY } from "@/hooks/useCapabilities"
 import { queryClient } from "@/lib/queryClient"
 
 /**
  * adminOnlyGuard redirects to "/" when the engine is not in multi-tenant mode.
  *
- * Reads from the QueryClient cache; does not fetch. Safe to use synchronously
- * because `<CapabilitiesProvider>` blocks rendering until data is populated.
+ * Async: uses `ensureQueryData` so it works on cold load (deep link / refresh)
+ * before `<CapabilitiesProvider>` mounts. TanStack Router's `beforeLoad`
+ * accepts async functions and awaits them.
  */
-export function adminOnlyGuard() {
-  const caps = queryClient.getQueryData<Capabilities>(CAPABILITIES_QUERY_KEY)
-  if (!caps?.platformEnabled) {
+export async function adminOnlyGuard() {
+  const caps = await queryClient.ensureQueryData<Capabilities>({
+    queryKey: CAPABILITIES_QUERY_KEY,
+    queryFn: fetchInfo,
+    staleTime: Infinity,
+  })
+  if (!caps.platformEnabled) {
     throw redirect({ to: "/" })
   }
 }

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -19,10 +19,14 @@ import { Route as AppProfileRouteImport } from './routes/_app/profile'
 import { Route as AppCostsRouteImport } from './routes/_app/costs'
 import { Route as AppAssistantsRouteImport } from './routes/_app/assistants'
 import { Route as AppAnalyticsRouteImport } from './routes/_app/analytics'
+import { Route as AppAdminRouteImport } from './routes/_app/admin'
+import { Route as AppAdminIndexRouteImport } from './routes/_app/admin/index'
 import { Route as AppTracesTraceIdRouteImport } from './routes/_app/traces/$traceId'
 import { Route as AppThreadsThreadIdRouteImport } from './routes/_app/threads/$threadId'
 import { Route as AppRunsRunIdRouteImport } from './routes/_app/runs/$runId'
 import { Route as AppAssistantsAssistantIdRouteImport } from './routes/_app/assistants/$assistantId'
+import { Route as AppAdminUsersRouteImport } from './routes/_app/admin/users'
+import { Route as AppAdminMetricsRouteImport } from './routes/_app/admin/metrics'
 
 const AppRoute = AppRouteImport.update({
   id: '/_app',
@@ -73,6 +77,16 @@ const AppAnalyticsRoute = AppAnalyticsRouteImport.update({
   path: '/analytics',
   getParentRoute: () => AppRoute,
 } as any)
+const AppAdminRoute = AppAdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppAdminIndexRoute = AppAdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppAdminRoute,
+} as any)
 const AppTracesTraceIdRoute = AppTracesTraceIdRouteImport.update({
   id: '/$traceId',
   path: '/$traceId',
@@ -94,8 +108,19 @@ const AppAssistantsAssistantIdRoute =
     path: '/$assistantId',
     getParentRoute: () => AppAssistantsRoute,
   } as any)
+const AppAdminUsersRoute = AppAdminUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminMetricsRoute = AppAdminMetricsRouteImport.update({
+  id: '/metrics',
+  path: '/metrics',
+  getParentRoute: () => AppAdminRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
+  '/admin': typeof AppAdminRouteWithChildren
   '/analytics': typeof AppAnalyticsRoute
   '/assistants': typeof AppAssistantsRouteWithChildren
   '/costs': typeof AppCostsRoute
@@ -105,10 +130,13 @@ export interface FileRoutesByFullPath {
   '/threads': typeof AppThreadsRouteWithChildren
   '/traces': typeof AppTracesRouteWithChildren
   '/': typeof AppIndexRoute
+  '/admin/metrics': typeof AppAdminMetricsRoute
+  '/admin/users': typeof AppAdminUsersRoute
   '/assistants/$assistantId': typeof AppAssistantsAssistantIdRoute
   '/runs/$runId': typeof AppRunsRunIdRoute
   '/threads/$threadId': typeof AppThreadsThreadIdRoute
   '/traces/$traceId': typeof AppTracesTraceIdRoute
+  '/admin/': typeof AppAdminIndexRoute
 }
 export interface FileRoutesByTo {
   '/analytics': typeof AppAnalyticsRoute
@@ -120,14 +148,18 @@ export interface FileRoutesByTo {
   '/threads': typeof AppThreadsRouteWithChildren
   '/traces': typeof AppTracesRouteWithChildren
   '/': typeof AppIndexRoute
+  '/admin/metrics': typeof AppAdminMetricsRoute
+  '/admin/users': typeof AppAdminUsersRoute
   '/assistants/$assistantId': typeof AppAssistantsAssistantIdRoute
   '/runs/$runId': typeof AppRunsRunIdRoute
   '/threads/$threadId': typeof AppThreadsThreadIdRoute
   '/traces/$traceId': typeof AppTracesTraceIdRoute
+  '/admin': typeof AppAdminIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_app': typeof AppRouteWithChildren
+  '/_app/admin': typeof AppAdminRouteWithChildren
   '/_app/analytics': typeof AppAnalyticsRoute
   '/_app/assistants': typeof AppAssistantsRouteWithChildren
   '/_app/costs': typeof AppCostsRoute
@@ -137,14 +169,18 @@ export interface FileRoutesById {
   '/_app/threads': typeof AppThreadsRouteWithChildren
   '/_app/traces': typeof AppTracesRouteWithChildren
   '/_app/': typeof AppIndexRoute
+  '/_app/admin/metrics': typeof AppAdminMetricsRoute
+  '/_app/admin/users': typeof AppAdminUsersRoute
   '/_app/assistants/$assistantId': typeof AppAssistantsAssistantIdRoute
   '/_app/runs/$runId': typeof AppRunsRunIdRoute
   '/_app/threads/$threadId': typeof AppThreadsThreadIdRoute
   '/_app/traces/$traceId': typeof AppTracesTraceIdRoute
+  '/_app/admin/': typeof AppAdminIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/admin'
     | '/analytics'
     | '/assistants'
     | '/costs'
@@ -154,10 +190,13 @@ export interface FileRouteTypes {
     | '/threads'
     | '/traces'
     | '/'
+    | '/admin/metrics'
+    | '/admin/users'
     | '/assistants/$assistantId'
     | '/runs/$runId'
     | '/threads/$threadId'
     | '/traces/$traceId'
+    | '/admin/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/analytics'
@@ -169,13 +208,17 @@ export interface FileRouteTypes {
     | '/threads'
     | '/traces'
     | '/'
+    | '/admin/metrics'
+    | '/admin/users'
     | '/assistants/$assistantId'
     | '/runs/$runId'
     | '/threads/$threadId'
     | '/traces/$traceId'
+    | '/admin'
   id:
     | '__root__'
     | '/_app'
+    | '/_app/admin'
     | '/_app/analytics'
     | '/_app/assistants'
     | '/_app/costs'
@@ -185,10 +228,13 @@ export interface FileRouteTypes {
     | '/_app/threads'
     | '/_app/traces'
     | '/_app/'
+    | '/_app/admin/metrics'
+    | '/_app/admin/users'
     | '/_app/assistants/$assistantId'
     | '/_app/runs/$runId'
     | '/_app/threads/$threadId'
     | '/_app/traces/$traceId'
+    | '/_app/admin/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -267,6 +313,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAnalyticsRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/admin': {
+      id: '/_app/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AppAdminRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/admin/': {
+      id: '/_app/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AppAdminIndexRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
     '/_app/traces/$traceId': {
       id: '/_app/traces/$traceId'
       path: '/$traceId'
@@ -295,8 +355,38 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAssistantsAssistantIdRouteImport
       parentRoute: typeof AppAssistantsRoute
     }
+    '/_app/admin/users': {
+      id: '/_app/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AppAdminUsersRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/metrics': {
+      id: '/_app/admin/metrics'
+      path: '/metrics'
+      fullPath: '/admin/metrics'
+      preLoaderRoute: typeof AppAdminMetricsRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
   }
 }
+
+interface AppAdminRouteChildren {
+  AppAdminMetricsRoute: typeof AppAdminMetricsRoute
+  AppAdminUsersRoute: typeof AppAdminUsersRoute
+  AppAdminIndexRoute: typeof AppAdminIndexRoute
+}
+
+const AppAdminRouteChildren: AppAdminRouteChildren = {
+  AppAdminMetricsRoute: AppAdminMetricsRoute,
+  AppAdminUsersRoute: AppAdminUsersRoute,
+  AppAdminIndexRoute: AppAdminIndexRoute,
+}
+
+const AppAdminRouteWithChildren = AppAdminRoute._addFileChildren(
+  AppAdminRouteChildren,
+)
 
 interface AppAssistantsRouteChildren {
   AppAssistantsAssistantIdRoute: typeof AppAssistantsAssistantIdRoute
@@ -346,6 +436,7 @@ const AppTracesRouteWithChildren = AppTracesRoute._addFileChildren(
 )
 
 interface AppRouteChildren {
+  AppAdminRoute: typeof AppAdminRouteWithChildren
   AppAnalyticsRoute: typeof AppAnalyticsRoute
   AppAssistantsRoute: typeof AppAssistantsRouteWithChildren
   AppCostsRoute: typeof AppCostsRoute
@@ -358,6 +449,7 @@ interface AppRouteChildren {
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppAdminRoute: AppAdminRouteWithChildren,
   AppAnalyticsRoute: AppAnalyticsRoute,
   AppAssistantsRoute: AppAssistantsRouteWithChildren,
   AppCostsRoute: AppCostsRoute,

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -1,24 +1,17 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/router-devtools"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { Toaster } from "@/components/ui/sonner"
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60, // 1 minute
-      gcTime: 1000 * 60 * 10, // 10 minutes
-      retry: 3,
-      refetchOnWindowFocus: false,
-    },
-  },
-})
+import { queryClient } from "@/lib/queryClient"
+import { CapabilitiesProvider } from "@/components/CapabilitiesProvider"
 
 export const Route = createRootRoute({
   component: () => (
     <QueryClientProvider client={queryClient}>
-      <Outlet />
+      <CapabilitiesProvider>
+        <Outlet />
+      </CapabilitiesProvider>
       <Toaster />
       <ReactQueryDevtools initialIsOpen={false} />
       <TanStackRouterDevtools />

--- a/dashboard/src/routes/_app/admin.tsx
+++ b/dashboard/src/routes/_app/admin.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { adminOnlyGuard } from "@/lib/routeGuards"
+
+/**
+ * Admin layout route. Hidden when the engine is not in multi-tenant mode.
+ *
+ * The `beforeLoad` guard reads engine capabilities from the QueryClient cache
+ * (populated by `<CapabilitiesProvider>` at boot) and redirects to "/" when
+ * MIGRATOR_PLATFORM_ENABLED is not set on the engine. This is defence-in-depth:
+ * the sidebar already hides admin links in single-tenant mode.
+ */
+export const Route = createFileRoute("/_app/admin")({
+  beforeLoad: adminOnlyGuard,
+  component: AdminLayout,
+})
+
+function AdminLayout() {
+  return <Outlet />
+}

--- a/dashboard/src/routes/_app/admin/index.tsx
+++ b/dashboard/src/routes/_app/admin/index.tsx
@@ -1,0 +1,31 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+/**
+ * Admin landing page. Shown if the user lands on /admin directly. The actual
+ * admin features (Users, Metrics, etc.) are Phase 3 frontend work — this page
+ * is a placeholder so the route resolves cleanly when platform mode is on.
+ */
+export const Route = createFileRoute("/_app/admin/")({
+  component: AdminIndex,
+})
+
+function AdminIndex() {
+  return (
+    <div className="max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Admin</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground space-y-2">
+          <p>Multi-tenant admin features will appear here.</p>
+          <p>
+            If you reached this page in single-tenant mode, restart the engine
+            with <code>MIGRATOR_PLATFORM_ENABLED=true</code> to enable admin
+            APIs.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/dashboard/src/routes/_app/admin/metrics.tsx
+++ b/dashboard/src/routes/_app/admin/metrics.tsx
@@ -1,0 +1,28 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+/**
+ * Placeholder for the multi-tenant Metrics admin page. Phase 3 frontend work
+ * will wire this to Mimir / cross-tenant metrics. The route exists now so the
+ * sidebar `<Link to="/admin/metrics">` resolves under platform mode.
+ */
+export const Route = createFileRoute("/_app/admin/metrics")({
+  component: AdminMetrics,
+})
+
+function AdminMetrics() {
+  return (
+    <div className="max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Metrics</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Cross-tenant metrics UI is not yet implemented. This route exists to
+          exercise the admin capability gating; the real screen lands in
+          Phase 3.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/dashboard/src/routes/_app/admin/users.tsx
+++ b/dashboard/src/routes/_app/admin/users.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+/**
+ * Placeholder for the multi-tenant Users admin page. Phase 3 frontend work
+ * will replace this with the real UI; the route exists now so the sidebar
+ * `<Link to="/admin/users">` resolves and the capability gating mechanism is
+ * exercisable end-to-end.
+ */
+export const Route = createFileRoute("/_app/admin/users")({
+  component: AdminUsers,
+})
+
+function AdminUsers() {
+  return (
+    <div className="max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Users</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          User management UI is not yet implemented. This route exists to
+          exercise the admin capability gating; the real screen lands in
+          Phase 3.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/internal/infrastructure/http/handlers/system.go
+++ b/internal/infrastructure/http/handlers/system.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"os"
 	"runtime"
 
 	"github.com/labstack/echo/v4"
@@ -24,6 +25,21 @@ type OkResponse struct {
 	Ok bool `json:"ok"`
 }
 
+// EngineMode describes how the engine is running.
+//
+// "multitenant" — MIGRATOR_PLATFORM_ENABLED=true, full platform features active.
+// "serve"       — single-tenant `duragraph serve` (default for non-platform mode).
+// "dev"         — `duragraph dev`. Phase 4 will populate this from the cobra
+//
+//	command; for now we never emit "dev" from /info.
+type EngineMode string
+
+const (
+	ModeDev         EngineMode = "dev"
+	ModeServe       EngineMode = "serve"
+	ModeMultitenant EngineMode = "multitenant"
+)
+
 // InfoResponse represents the response for GET /info
 type InfoResponse struct {
 	Version       string   `json:"version"`
@@ -36,6 +52,16 @@ type InfoResponse struct {
 		Checkpointer string `json:"checkpointer"`
 		Store        string `json:"store"`
 	} `json:"runtime_config"`
+	// Mode reports the engine's runtime mode. See EngineMode.
+	Mode EngineMode `json:"mode"`
+	// PlatformEnabled is true when multi-tenant features (admin APIs, tenant
+	// provisioning, etc.) are active. Driven by MIGRATOR_PLATFORM_ENABLED.
+	PlatformEnabled bool `json:"platform_enabled"`
+	// AuthEnabled mirrors the AUTH_ENABLED env toggle (JWT/auth gating).
+	AuthEnabled bool `json:"auth_enabled"`
+	// OAuthProviders lists configured OAuth providers in alphabetical order.
+	// Always non-nil so the JSON shape is `[]` not `null`.
+	OAuthProviders []string `json:"oauth_providers"`
 }
 
 // Ok handles GET /ok - simple health check
@@ -43,8 +69,32 @@ func (h *SystemHandler) Ok(c echo.Context) error {
 	return c.JSON(http.StatusOK, OkResponse{Ok: true})
 }
 
-// Info handles GET /info - system information
+// Info handles GET /info - system information.
+//
+// Capability flags (mode, platform_enabled, auth_enabled, oauth_providers) are
+// read from environment variables on every call. /info is low-frequency (the
+// embedded dashboard fetches once at boot) so we avoid plumbing them through
+// the constructor.
 func (h *SystemHandler) Info(c echo.Context) error {
+	platformEnabled := os.Getenv("MIGRATOR_PLATFORM_ENABLED") == "true"
+	authEnabled := os.Getenv("AUTH_ENABLED") == "true"
+
+	// alphabetical, stable for tests
+	oauthProviders := []string{}
+	if os.Getenv("OAUTH_GITHUB_CLIENT_ID") != "" {
+		oauthProviders = append(oauthProviders, "github")
+	}
+	if os.Getenv("OAUTH_GOOGLE_CLIENT_ID") != "" {
+		oauthProviders = append(oauthProviders, "google")
+	}
+
+	mode := ModeServe
+	if platformEnabled {
+		mode = ModeMultitenant
+	}
+	// TODO(phase-4): when `duragraph dev` is wired, pass a sentinel through the
+	// cobra command so the handler can return ModeDev for that case.
+
 	return c.JSON(http.StatusOK, InfoResponse{
 		Version:      h.version,
 		GoVersion:    runtime.Version(),
@@ -64,5 +114,9 @@ func (h *SystemHandler) Info(c echo.Context) error {
 			Checkpointer: "postgres",
 			Store:        "postgres",
 		},
+		Mode:            mode,
+		PlatformEnabled: platformEnabled,
+		AuthEnabled:     authEnabled,
+		OAuthProviders:  oauthProviders,
 	})
 }

--- a/internal/infrastructure/http/handlers/system_test.go
+++ b/internal/infrastructure/http/handlers/system_test.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TestInfo_Capabilities exercises the capability fields on GET /info that
+// power the embedded dashboard's admin gating.
+func TestInfo_Capabilities(t *testing.T) {
+	tests := []struct {
+		name               string
+		env                map[string]string
+		wantMode           EngineMode
+		wantPlatform       bool
+		wantAuth           bool
+		wantOAuthProviders []string
+	}{
+		{
+			name:               "empty env defaults to serve mode with no providers",
+			env:                map[string]string{},
+			wantMode:           ModeServe,
+			wantPlatform:       false,
+			wantAuth:           false,
+			wantOAuthProviders: []string{},
+		},
+		{
+			name: "platform enabled flips mode to multitenant",
+			env: map[string]string{
+				"MIGRATOR_PLATFORM_ENABLED": "true",
+			},
+			wantMode:           ModeMultitenant,
+			wantPlatform:       true,
+			wantAuth:           false,
+			wantOAuthProviders: []string{},
+		},
+		{
+			name: "auth enabled toggle",
+			env: map[string]string{
+				"AUTH_ENABLED": "true",
+			},
+			wantMode:           ModeServe,
+			wantPlatform:       false,
+			wantAuth:           true,
+			wantOAuthProviders: []string{},
+		},
+		{
+			name: "google provider only",
+			env: map[string]string{
+				"OAUTH_GOOGLE_CLIENT_ID": "fake-google-id",
+			},
+			wantMode:           ModeServe,
+			wantOAuthProviders: []string{"google"},
+		},
+		{
+			name: "github provider only",
+			env: map[string]string{
+				"OAUTH_GITHUB_CLIENT_ID": "fake-github-id",
+			},
+			wantMode:           ModeServe,
+			wantOAuthProviders: []string{"github"},
+		},
+		{
+			name: "both providers, alphabetical order",
+			env: map[string]string{
+				"OAUTH_GOOGLE_CLIENT_ID": "g",
+				"OAUTH_GITHUB_CLIENT_ID": "h",
+			},
+			wantMode:           ModeServe,
+			wantOAuthProviders: []string{"github", "google"},
+		},
+		{
+			name: "all flags together",
+			env: map[string]string{
+				"MIGRATOR_PLATFORM_ENABLED": "true",
+				"AUTH_ENABLED":              "true",
+				"OAUTH_GOOGLE_CLIENT_ID":    "g",
+				"OAUTH_GITHUB_CLIENT_ID":    "h",
+			},
+			wantMode:           ModeMultitenant,
+			wantPlatform:       true,
+			wantAuth:           true,
+			wantOAuthProviders: []string{"github", "google"},
+		},
+		{
+			name: "platform flag with value other than true is treated as false",
+			env: map[string]string{
+				"MIGRATOR_PLATFORM_ENABLED": "1",
+			},
+			wantMode:           ModeServe,
+			wantPlatform:       false,
+			wantOAuthProviders: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv automatically restores prior values on test completion.
+			// We also explicitly clear the four vars we care about so a value
+			// leaked from the host env does not contaminate "absent" cases.
+			for _, k := range []string{
+				"MIGRATOR_PLATFORM_ENABLED",
+				"AUTH_ENABLED",
+				"OAUTH_GOOGLE_CLIENT_ID",
+				"OAUTH_GITHUB_CLIENT_ID",
+			} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/info", nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+
+			h := NewSystemHandler("test-version")
+			if err := h.Info(ctx); err != nil {
+				t.Fatalf("Info handler returned error: %v", err)
+			}
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+
+			var resp InfoResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+			}
+
+			if resp.Mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", resp.Mode, tc.wantMode)
+			}
+			if resp.PlatformEnabled != tc.wantPlatform {
+				t.Errorf("platform_enabled = %v, want %v", resp.PlatformEnabled, tc.wantPlatform)
+			}
+			if resp.AuthEnabled != tc.wantAuth {
+				t.Errorf("auth_enabled = %v, want %v", resp.AuthEnabled, tc.wantAuth)
+			}
+			if !slicesEqual(resp.OAuthProviders, tc.wantOAuthProviders) {
+				t.Errorf("oauth_providers = %v, want %v", resp.OAuthProviders, tc.wantOAuthProviders)
+			}
+		})
+	}
+}
+
+// TestInfo_OAuthProvidersJSONShape verifies the JSON wire format renders an
+// empty array (not null) when no providers are configured. This matters for
+// the dashboard's TypeScript types, which expect `OAuthProvider[]`.
+func TestInfo_OAuthProvidersJSONShape(t *testing.T) {
+	for _, k := range []string{
+		"MIGRATOR_PLATFORM_ENABLED",
+		"AUTH_ENABLED",
+		"OAUTH_GOOGLE_CLIENT_ID",
+		"OAUTH_GITHUB_CLIENT_ID",
+	} {
+		t.Setenv(k, "")
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/info", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	h := NewSystemHandler("test-version")
+	if err := h.Info(ctx); err != nil {
+		t.Fatalf("Info handler returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"oauth_providers":[]`) {
+		t.Errorf("expected oauth_providers to render as `[]`, got body=%s", body)
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Adds the mechanism for the embedded React dashboard to discover engine capabilities at boot and gate admin-only nav and routes accordingly. Phase 4 (`duragraph dev`) and `duragraph serve` without `MIGRATOR_PLATFORM_ENABLED` both run in single-tenant mode; without this gating, admin links would 404 because `/api/admin/*` isn't registered.

The actual `/admin/users` and `/admin/metrics` UI pages are placeholders — Phase 3 frontend work fills them in. This PR is the gating mechanism only.

## Backend (`internal/infrastructure/http/handlers/system.go`)

- `GET /info` now returns 4 new fields:
  - `mode: "dev" | "serve" | "multitenant"`
  - `platform_enabled: boolean` — driven by `MIGRATOR_PLATFORM_ENABLED`
  - `auth_enabled: boolean` — mirrors `AUTH_ENABLED`
  - `oauth_providers: string[]` — built in alphabetical order (`github`, `google`) by checking `OAUTH_<PROVIDER>_CLIENT_ID`. Always renders as `[]`, never `null`.
- Flags read from env directly inside `Info()` to avoid constructor churn (low-frequency endpoint; dashboard fetches once at boot).
- `mode = "multitenant"` when platform is enabled, else `"serve"`. A TODO marks where Phase 4 will wire `"dev"` via a cobra sentinel.
- Existing `/info` fields unchanged (`version`, `go_version`, `platform`, `arch`, `capabilities`, `runtime_config`).
- `cmd/duragraph/cmd/serve.go` untouched — `NewSystemHandler(version)` signature did not change.

Table-driven tests in new `system_test.go` cover all combinations (empty env, each flag in isolation, all flags together, both providers, alphabetical ordering, JSON `[]` shape).

## Frontend (`dashboard/`)

- `src/api/info.ts` — `Capabilities` type + `fetchInfo()` (calls `/info` directly via plain `fetch`, not via `api.get` which prefixes `/api/v1`).
- `src/hooks/useCapabilities.ts` — TanStack Query hook with `staleTime: Infinity` and a stable `CAPABILITIES_QUERY_KEY` export.
- `src/components/CapabilitiesProvider.tsx` — performs boot-time fetch, blocks render until cache populated, renders a full-page retry on error.
- `src/lib/queryClient.ts` — extracted the QueryClient to a module singleton (was previously inline in `__root.tsx`) so synchronous route guards can read from the same cache via `queryClient.getQueryData`.
- `src/lib/routeGuards.ts` — `adminOnlyGuard()` reads `Capabilities` from cache, redirects to `/` when `!platformEnabled`.
- `src/routes/__root.tsx` — wraps `<Outlet />` in `<CapabilitiesProvider>` inside the existing `QueryClientProvider`.
- `src/components/layout/Sidebar.tsx` — calls `useCapabilities()` and conditionally renders an Admin section (Users + Metrics) when `platformEnabled` is true.
- New placeholder routes:
  - `_app/admin.tsx` — layout route with `beforeLoad: adminOnlyGuard` and `<Outlet />`
  - `_app/admin/index.tsx` — landing page explaining the mode requirement
  - `_app/admin/users.tsx`, `_app/admin/metrics.tsx` — stubs so the sidebar `<Link to="...">` typechecks; Phase 3 fills them in
- `routeTree.gen.ts` was regenerated by the TanStack Router vite plugin (expected).

## Spec divergence — paired spec PR needed

`duragraph-spec/api/duragraph-latest.yaml` documents `/info` with a totally different shape (`langgraph_py_version`, `flags`, `metadata`) — a pre-existing divergence from what the Go handler actually returns. This PR widens the gap by adding 4 more fields not in the spec. **A paired spec PR is needed** to align the `ServerInfo` schema with the actual engine response (existing fields + the 4 new ones). Not done here per the spec-first PR convention.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/infrastructure/http/handlers/... -count=1 -short` passes (new `TestInfo_Capabilities` + `TestInfo_OAuthProvidersJSONShape`)
- [x] `pnpm run build` in `dashboard/` succeeds (`tsc -b` + vite both green)
- [x] `pnpm exec eslint` on the touched/new dashboard files reports no errors (pre-existing lint errors in `useThreadStream.ts` and `traces/$traceId.tsx` are unrelated and untouched)
- [ ] Manual: start engine without `MIGRATOR_PLATFORM_ENABLED` → dashboard sidebar should NOT show Admin section; `/admin` should redirect to `/`.
- [ ] Manual: start engine with `MIGRATOR_PLATFORM_ENABLED=true` → Admin section visible, `/admin/users` and `/admin/metrics` reachable (placeholders).