### PR TITLE
feat(dev): implement duragraph dev subcommand (v0.7 Phase 4)

### DIFF
--- a/cmd/duragraph/cmd/dev.go
+++ b/cmd/duragraph/cmd/dev.go
@@ -1,20 +1,126 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 
-// devCmd is the zero-config dev mode entrypoint. Stub for now —
-// embedded postgres + nats + watch mode wiring lands in phases 2-5
-// of the v0.7 single-binary DX track (binary-modes.yml § migration).
-var devCmd = &cobra.Command{
-	Use:   "dev",
-	Short: "Run duragraph with embedded postgres, nats, and watch mode (stub — not yet implemented)",
-	Long: `Zero-config dev mode: embedded Postgres + embedded NATS + dashboard
+	"github.com/spf13/cobra"
+)
+
+// devCmd is the zero-config dev mode entrypoint
+// (binary-modes.yml § subcommands.duragraph_dev).
+//
+// Implementation strategy: dev does NOT duplicate serve's ~1100 line
+// startup body. It pre-sets a small set of environment variables that
+// flip serve into the "embedded postgres + embedded NATS, single-tenant,
+// no auth" configuration, then delegates to serveCmd.RunE. This keeps
+// the engine startup path single-sourced — every change to serve
+// (new wiring, new metric, new handler) automatically benefits dev.
+//
+// Phase scope (v0.7):
+//   - Phase 4 (this PR): wire dev to embedded mode, accept --watch and
+//     --studio as no-op flags with warnings.
+//   - Phase 5: implement --watch (file-watching worker supervision).
+//   - Phase 8: implement --studio (serve bundled Studio under /studio/).
+//
+// TODO(post-v0.7): human-readable log format. serve currently emits
+// JSON logs by default; dev inherits that. The spec calls for "color,
+// timestamps, structured" stdout in dev. Wiring a logger toggle
+// requires a serve-side refactor (the current logger is constructed
+// inline inside RunE) and is deferred to its own PR.
+var (
+	devPort    int
+	devDataDir string
+	devWatch   string
+	devStudio  bool
+
+	devCmd = &cobra.Command{
+		Use:   "dev",
+		Short: "Run duragraph with embedded postgres, nats, and watch mode",
+		Long: `Zero-config dev mode: embedded Postgres + embedded NATS + dashboard
 + optional Studio + worker watch mode.
 
-Not yet implemented. Tracking phases 2-5 of binary-modes.yml § migration.phasing.`,
-	RunE: notYetImplemented("dev"),
-}
+Defaults to a single-tenant deployment with auth disabled — designed for
+the local-laptop demo path described in binary-modes.yml § subcommands.
+
+Operator overrides win: setting DB_MODE=external (or any of the other
+env vars listed below) before invoking "duragraph dev" preserves your
+choice. The flag-derived defaults only fire when the env var is unset.`,
+		RunE: runDev,
+	}
+)
 
 func init() {
+	devCmd.Flags().IntVar(&devPort, "port", 8081, "HTTP port for the engine + dashboard")
+	devCmd.Flags().StringVar(&devDataDir, "data-dir", "./data",
+		"Data directory for embedded postgres + NATS storage. Created on first run.")
+	devCmd.Flags().StringVar(&devWatch, "watch", "./agents",
+		"Directory to watch for graph definitions (Phase 5 — currently a no-op)")
+	devCmd.Flags().BoolVar(&devStudio, "studio", false,
+		"Serve bundled Studio at /studio/ (Phase 8 — currently a no-op)")
+
 	rootCmd.AddCommand(devCmd)
+}
+
+// runDev sets dev-mode env defaults, prints the banner, and hands off
+// to serveCmd. Splitting the env-mutation step into applyDevEnvDefaults
+// keeps that logic unit-testable without standing up the full engine.
+func runDev(cmd *cobra.Command, args []string) error {
+	absDataDir, err := filepath.Abs(devDataDir)
+	if err != nil {
+		return fmt.Errorf("resolve --data-dir: %w", err)
+	}
+	if err := os.MkdirAll(absDataDir, 0o755); err != nil {
+		return fmt.Errorf("create --data-dir %s: %w", absDataDir, err)
+	}
+
+	applyDevEnvDefaults(devOptions{
+		Port:    devPort,
+		DataDir: absDataDir,
+	})
+
+	fmt.Println("🚀 duragraph dev — embedded postgres + nats, single-tenant")
+	fmt.Printf("   data dir: %s\n", absDataDir)
+	fmt.Printf("   dashboard: http://localhost:%d/\n", devPort)
+
+	// Phase 5/8 stubs: accept the flag, warn, continue. The flag surface
+	// stays stable so subsequent phases don't break invocations baked
+	// into operator scripts. --watch has a non-empty default
+	// (./agents) so the warning fires unconditionally — the operator
+	// should know watch isn't wired regardless of whether they set the
+	// flag explicitly.
+	fmt.Printf("⚠️  watch mode not yet implemented (Phase 5); --watch=%s ignored\n", devWatch)
+	if devStudio {
+		fmt.Println("⚠️  studio bundling not yet implemented (Phase 8); --studio ignored")
+	}
+
+	// We pass dev's cmd + args straight through. Today serveCmd.RunE
+	// (runServe) ignores both — see its signature `_ *cobra.Command,
+	// _ []string`. If serve ever starts inspecting cmd.Flags(), this
+	// call site needs revisiting (dev's flag set != serve's).
+	return serveCmd.RunE(cmd, args)
+}
+
+// devOptions captures the flag values that translate into env defaults.
+// Pulled into a struct so applyDevEnvDefaults stays a pure function for
+// tests (no globals, no flag package state).
+type devOptions struct {
+	Port    int
+	DataDir string
+}
+
+// applyDevEnvDefaults sets the env vars that flip the engine into
+// embedded-mode dev defaults. Uses setIfUnset so an operator who
+// explicitly set, e.g., DB_MODE=external before invoking dev keeps
+// pointing at their external DB.
+func applyDevEnvDefaults(opts devOptions) {
+	setIfUnset("DB_MODE", "embedded")
+	setIfUnset("NATS_MODE", "embedded")
+	setIfUnset("MIGRATOR_PLATFORM_ENABLED", "false")
+	setIfUnset("AUTH_ENABLED", "false")
+	setIfUnset("PORT", strconv.Itoa(opts.Port))
+	setIfUnset("DB_EMBEDDED_DATA_DIR", filepath.Join(opts.DataDir, "pg"))
+	setIfUnset("NATS_EMBEDDED_DATA_DIR", filepath.Join(opts.DataDir, "nats"))
 }

--- a/cmd/duragraph/cmd/dev_test.go
+++ b/cmd/duragraph/cmd/dev_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetIfUnset(t *testing.T) {
+	t.Run("sets when unset", func(t *testing.T) {
+		t.Setenv("DG_TEST_SETIFUNSET_A", "")
+		setIfUnset("DG_TEST_SETIFUNSET_A", "wrote")
+		if got := os.Getenv("DG_TEST_SETIFUNSET_A"); got != "wrote" {
+			t.Fatalf("expected %q, got %q", "wrote", got)
+		}
+	})
+
+	t.Run("preserves existing value", func(t *testing.T) {
+		t.Setenv("DG_TEST_SETIFUNSET_B", "preset")
+		setIfUnset("DG_TEST_SETIFUNSET_B", "ignored")
+		if got := os.Getenv("DG_TEST_SETIFUNSET_B"); got != "preset" {
+			t.Fatalf("expected %q (preserved), got %q", "preset", got)
+		}
+	})
+}
+
+func TestApplyDevEnvDefaults(t *testing.T) {
+	t.Run("sets all defaults when unset", func(t *testing.T) {
+		// Clear every var the function touches. t.Setenv("", "")
+		// restores the prior value at the end of the test, so this
+		// doesn't leak across subtests.
+		for _, k := range []string{
+			"DB_MODE", "NATS_MODE", "MIGRATOR_PLATFORM_ENABLED",
+			"AUTH_ENABLED", "PORT", "DB_EMBEDDED_DATA_DIR", "NATS_EMBEDDED_DATA_DIR",
+		} {
+			t.Setenv(k, "")
+		}
+		applyDevEnvDefaults(devOptions{Port: 9999, DataDir: "/tmp/dg-dev-test"})
+
+		want := map[string]string{
+			"DB_MODE":                   "embedded",
+			"NATS_MODE":                 "embedded",
+			"MIGRATOR_PLATFORM_ENABLED": "false",
+			"AUTH_ENABLED":              "false",
+			"PORT":                      "9999",
+			"DB_EMBEDDED_DATA_DIR":      filepath.Join("/tmp/dg-dev-test", "pg"),
+			"NATS_EMBEDDED_DATA_DIR":    filepath.Join("/tmp/dg-dev-test", "nats"),
+		}
+		for k, v := range want {
+			if got := os.Getenv(k); got != v {
+				t.Errorf("%s: expected %q, got %q", k, v, got)
+			}
+		}
+	})
+
+	t.Run("respects operator overrides", func(t *testing.T) {
+		// An operator pointing dev at an external DB / different port
+		// must not have those choices clobbered.
+		t.Setenv("DB_MODE", "external")
+		t.Setenv("NATS_MODE", "external")
+		t.Setenv("AUTH_ENABLED", "true")
+		t.Setenv("PORT", "12345")
+		t.Setenv("DB_EMBEDDED_DATA_DIR", "/custom/pg")
+		t.Setenv("NATS_EMBEDDED_DATA_DIR", "/custom/nats")
+		t.Setenv("MIGRATOR_PLATFORM_ENABLED", "true")
+
+		applyDevEnvDefaults(devOptions{Port: 8081, DataDir: "/tmp/dg-dev-test"})
+
+		preserved := map[string]string{
+			"DB_MODE":                   "external",
+			"NATS_MODE":                 "external",
+			"AUTH_ENABLED":              "true",
+			"PORT":                      "12345",
+			"DB_EMBEDDED_DATA_DIR":      "/custom/pg",
+			"NATS_EMBEDDED_DATA_DIR":    "/custom/nats",
+			"MIGRATOR_PLATFORM_ENABLED": "true",
+		}
+		for k, v := range preserved {
+			if got := os.Getenv(k); got != v {
+				t.Errorf("%s clobbered: expected %q, got %q", k, v, got)
+			}
+		}
+	})
+}

--- a/cmd/duragraph/cmd/util.go
+++ b/cmd/duragraph/cmd/util.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "os"
+
+// setIfUnset writes value to the named environment variable only when
+// the variable is not already set. Used by `dev` to apply embedded-mode
+// defaults without trampling explicit operator overrides — an operator
+// running `DB_MODE=external duragraph dev` keeps their external DB.
+//
+// "Unset" here means literally empty (matches Go's os.Getenv contract,
+// which returns "" for both unset and explicitly-empty vars). An
+// explicitly-empty override (e.g. DB_MODE="") will be replaced — that's
+// the same behavior config.Load applies, so the two stay consistent.
+func setIfUnset(key, value string) {
+	if os.Getenv(key) == "" {
+		os.Setenv(key, value)
+	}
+}


### PR DESCRIPTION
## Summary

Wires the previously-stubbed `duragraph dev` to the engine. Implements
[binary-modes.yml § subcommands.duragraph_dev](../duragraph-spec/backend/binary-modes.yml) for
the Phase 4 scope: embedded postgres + embedded NATS + dashboard, single-tenant, auth disabled.

`--watch` and `--studio` are accepted but stubbed with warnings — Phase 5 and Phase 8 will
deliver them. Flag surface is locked in now so subsequent phases don't break operator scripts.

## Approach

**Simpler approach (env-set + delegate).** `dev` does NOT duplicate serve's ~1100-line
startup body. It pre-sets env vars that flip serve into embedded mode, then calls
`serveCmd.RunE`. This keeps engine startup single-sourced — every change to serve flows
to dev for free.

Env defaults are applied via `setIfUnset`, so an operator who explicitly sets
`DB_MODE=external` (or any other override) keeps their choice.

## Flags

| Flag        | Default      | Forwarded as                                          |
|-------------|--------------|-------------------------------------------------------|
| `--port`    | `8081`       | `PORT` env                                            |
| `--data-dir`| `./data`     | `DB_EMBEDDED_DATA_DIR=<dir>/pg`, `NATS_EMBEDDED_DATA_DIR=<dir>/nats` |
| `--watch`   | `./agents`   | Phase 5 stub — prints warning, no-op                  |
| `--studio`  | `false`      | Phase 8 stub — prints warning, no-op                  |

## Implicit env defaults set by `dev`

- `DB_MODE=embedded`
- `NATS_MODE=embedded`
- `MIGRATOR_PLATFORM_ENABLED=false` (single-tenant in dev)
- `AUTH_ENABLED=false` (no JWT in dev)

## What's deferred

- **Watch mode** → Phase 5 (file-watching worker supervision).
- **Studio bundling** → Phase 8 (serve bundled Studio under `/studio/`).
- **Human-readable log format** → follow-up. Serve currently emits JSON logs by default;
  dev inherits that. The spec calls for "color, timestamps, structured" stdout in dev.
  Wiring a logger toggle requires a serve-side refactor (the current logger is constructed
  inline inside RunE) and is deferred to its own PR. Marked as a TODO in `dev.go`'s preamble.

## Tests

- `setIfUnset` — sets-when-unset + preserves-existing-value paths.
- `applyDevEnvDefaults` — sets-all-defaults-when-unset + respects-operator-overrides paths.

The full embedded-engine startup is intentionally not unit-tested — actually starting
embedded postgres downloads ~20MB of binary and is too slow for unit tests. Manual smoke
covers it.

## Manual smoke instructions

```bash
go build -o /tmp/duragraph ./cmd/duragraph
/tmp/duragraph dev --port 8081 --data-dir /tmp/dg-dev
# Expected:
#   🚀 duragraph dev banner
#   ✅ Embedded Postgres started on 127.0.0.1:5435
#   ✅ Embedded NATS started on 127.0.0.1:4222
#   ⚠️  watch mode not yet implemented (Phase 5)
#   ⚠️  studio bundling not yet implemented (Phase 8)
#   🌐 Server listening on 0.0.0.0:8081
# Visit http://localhost:8081/ → dashboard renders
# Visit http://localhost:8081/info → shows mode=serve (until we wire dev sentinel; see TODO)
# Ctrl+C → graceful shutdown of postgres + nats
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/duragraph/... -count=1 -short` passes
- [x] `duragraph dev --help` shows the four flags with documented defaults
- [ ] Manual smoke: `duragraph dev --port 8081 --data-dir /tmp/dg-dev` starts the engine
      with embedded postgres + NATS, dashboard renders, Ctrl+C shuts down gracefully