### PR TITLE
feat(dev): watch mode + worker supervision (v0.7 Phase 5)

### DIFF
--- a/cmd/duragraph/cmd/dev.go
+++ b/cmd/duragraph/cmd/dev.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 
+	"github.com/duragraph/duragraph/internal/dev/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -20,9 +23,10 @@ import (
 // (new wiring, new metric, new handler) automatically benefits dev.
 //
 // Phase scope (v0.7):
-//   - Phase 4 (this PR): wire dev to embedded mode, accept --watch and
-//     --studio as no-op flags with warnings.
-//   - Phase 5: implement --watch (file-watching worker supervision).
+//   - Phase 4: wire dev to embedded mode, accept --watch and --studio
+//     as no-op flags with warnings.
+//   - Phase 5 (this PR): implement --watch (file-watching worker
+//     supervision via internal/dev/watch).
 //   - Phase 8: implement --studio (serve bundled Studio under /studio/).
 //
 // TODO(post-v0.7): human-readable log format. serve currently emits
@@ -57,7 +61,7 @@ func init() {
 	devCmd.Flags().StringVar(&devDataDir, "data-dir", "./data",
 		"Data directory for embedded postgres + NATS storage. Created on first run.")
 	devCmd.Flags().StringVar(&devWatch, "watch", "./agents",
-		"Directory to watch for graph definitions (Phase 5 — currently a no-op)")
+		"Directory to watch (recursively) for Python graph files; pass empty string to disable")
 	devCmd.Flags().BoolVar(&devStudio, "studio", false,
 		"Serve bundled Studio at /studio/ (Phase 8 — currently a no-op)")
 
@@ -85,22 +89,60 @@ func runDev(cmd *cobra.Command, args []string) error {
 	fmt.Printf("   data dir: %s\n", absDataDir)
 	fmt.Printf("   dashboard: http://localhost:%d/\n", devPort)
 
-	// Phase 5/8 stubs: accept the flag, warn, continue. The flag surface
-	// stays stable so subsequent phases don't break invocations baked
-	// into operator scripts. --watch has a non-empty default
-	// (./agents) so the warning fires unconditionally — the operator
-	// should know watch isn't wired regardless of whether they set the
-	// flag explicitly.
-	fmt.Printf("⚠️  watch mode not yet implemented (Phase 5); --watch=%s ignored\n", devWatch)
 	if devStudio {
 		fmt.Println("⚠️  studio bundling not yet implemented (Phase 8); --studio ignored")
+	}
+
+	// Phase 5: --watch supervises Python graph workers under devWatch.
+	// We have to start the watcher BEFORE serveCmd.RunE because runServe
+	// blocks until SIGINT/SIGTERM — there's no return-after-startup hook.
+	// The watcher's first action is to poll http://localhost:<port>/health,
+	// so it intentionally idles until the engine is up. When serve
+	// returns (cobra command finishes), we cancel the watcher's context
+	// and wait for it to drain.
+	//
+	// Don't refactor serve.go for this — the goroutine pattern has the
+	// virtue of leaving the engine startup path untouched and of letting
+	// us add Phase 5 entirely behind the --watch flag.
+	watcherCtx, cancelWatcher := context.WithCancel(cmd.Context())
+	defer cancelWatcher()
+
+	var watcherDone chan struct{}
+	if devWatch != "" {
+		w, werr := watch.New(watch.Options{
+			WatchDir:   devWatch,
+			EnginePort: devPort,
+			Stdout:     os.Stdout,
+			Stderr:     os.Stderr,
+			Logger:     log.Default(),
+		})
+		if werr != nil {
+			return fmt.Errorf("watch init: %w", werr)
+		}
+		watcherDone = make(chan struct{})
+		go func() {
+			defer close(watcherDone)
+			if err := w.Run(watcherCtx); err != nil {
+				log.Printf("watch: %v", err)
+			}
+		}()
 	}
 
 	// We pass dev's cmd + args straight through. Today serveCmd.RunE
 	// (runServe) ignores both — see its signature `_ *cobra.Command,
 	// _ []string`. If serve ever starts inspecting cmd.Flags(), this
 	// call site needs revisiting (dev's flag set != serve's).
-	return serveCmd.RunE(cmd, args)
+	serveErr := serveCmd.RunE(cmd, args)
+
+	// Engine has shut down — cancel the watcher and wait for it to
+	// drain (kills its supervised subprocesses cleanly). Without this
+	// step, the binary returns to the operator's shell while child
+	// uv/python processes still hold the terminal.
+	cancelWatcher()
+	if watcherDone != nil {
+		<-watcherDone
+	}
+	return serveErr
 }
 
 // devOptions captures the flag values that translate into env defaults.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ThreeDotsLabs/watermill-nats/v2 v2.1.3
 	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.9
 	github.com/fergusstrange/embedded-postgres v1.34.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fergusstrange/embedded-postgres v1.34.0 h1:c6RKhPKFsLVU+Tdxsx8q0UxCHsvZZ/iShAnljRBXs6s=
 github.com/fergusstrange/embedded-postgres v1.34.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/dev/watch/prefix_writer.go
+++ b/internal/dev/watch/prefix_writer.go
@@ -1,0 +1,89 @@
+package watch
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+// prefixWriter wraps an io.Writer and prepends a fixed prefix to every
+// complete line it forwards. Subprocess stdout/stderr arrives in
+// arbitrary chunks (could be a partial line, several lines, or a line
+// without a trailing newline), so the writer line-buffers: complete
+// lines (terminated by '\n') are flushed with the prefix, and any
+// trailing bytes without a newline are held until the next Write or
+// an explicit Flush.
+//
+// Concurrent writes are serialised with a mutex; cmd.Stdout and
+// cmd.Stderr both pointing at the same writer is the common case and
+// must not interleave mid-line.
+type prefixWriter struct {
+	mu     sync.Mutex
+	prefix []byte
+	w      io.Writer
+	buf    bytes.Buffer
+}
+
+// newPrefixWriter returns a prefixWriter that emits to w with the given
+// prefix. The prefix is captured by value, so callers may reuse the
+// argument string after construction.
+func newPrefixWriter(prefix string, w io.Writer) *prefixWriter {
+	return &prefixWriter{prefix: []byte(prefix), w: w}
+}
+
+// Write implements io.Writer. It emits one prefixed line per '\n' in
+// the input and buffers any tail. The returned n always equals len(p)
+// on success — to upstream consumers (cmd.Stdout) it looks like a
+// passthrough writer.
+func (p *prefixWriter) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	n := len(b)
+	for {
+		i := bytes.IndexByte(b, '\n')
+		if i < 0 {
+			// No newline left — stash and report full consumption.
+			p.buf.Write(b)
+			return n, nil
+		}
+		// Emit prefix + buffered tail + this line (incl. \n).
+		if _, err := p.w.Write(p.prefix); err != nil {
+			return 0, err
+		}
+		if p.buf.Len() > 0 {
+			if _, err := p.w.Write(p.buf.Bytes()); err != nil {
+				return 0, err
+			}
+			p.buf.Reset()
+		}
+		if _, err := p.w.Write(b[:i+1]); err != nil {
+			return 0, err
+		}
+		b = b[i+1:]
+	}
+}
+
+// Flush emits any buffered tail (a partial line without a trailing
+// newline) with the prefix, appending a synthetic '\n' so the output
+// stream remains well-formed. Called when the supervised process exits
+// — without this, a worker that crashes mid-line would leave its last
+// fragment hidden.
+func (p *prefixWriter) Flush() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.buf.Len() == 0 {
+		return nil
+	}
+	if _, err := p.w.Write(p.prefix); err != nil {
+		return err
+	}
+	if _, err := p.w.Write(p.buf.Bytes()); err != nil {
+		return err
+	}
+	if _, err := p.w.Write([]byte{'\n'}); err != nil {
+		return err
+	}
+	p.buf.Reset()
+	return nil
+}

--- a/internal/dev/watch/prefix_writer.go
+++ b/internal/dev/watch/prefix_writer.go
@@ -32,34 +32,44 @@ func newPrefixWriter(prefix string, w io.Writer) *prefixWriter {
 }
 
 // Write implements io.Writer. It emits one prefixed line per '\n' in
-// the input and buffers any tail. The returned n always equals len(p)
-// on success — to upstream consumers (cmd.Stdout) it looks like a
-// passthrough writer.
+// the input and buffers any tail.
+//
+// The io.Writer contract: 0 <= n <= len(p), and n < len(p) implies a
+// non-nil error. We track `consumed` = bytes from the original input
+// that have been settled (either flushed downstream as a complete line,
+// or stashed in p.buf). On any sub-write error we return (consumed, err)
+// so callers see a count consistent with what was actually accepted.
+// Synthetic prefix bytes don't map to input bytes and are not counted.
 func (p *prefixWriter) Write(b []byte) (int, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	n := len(b)
+	consumed := 0
 	for {
 		i := bytes.IndexByte(b, '\n')
 		if i < 0 {
-			// No newline left — stash and report full consumption.
+			// No newline left — stash the tail and report full
+			// consumption (buffering counts as accepting the bytes).
 			p.buf.Write(b)
-			return n, nil
+			consumed += len(b)
+			return consumed, nil
 		}
-		// Emit prefix + buffered tail + this line (incl. \n).
+		// Emit prefix + buffered tail + this line (incl. \n). On any
+		// downstream error, return what we've already consumed from
+		// the current input so the io.Writer contract holds.
 		if _, err := p.w.Write(p.prefix); err != nil {
-			return 0, err
+			return consumed, err
 		}
 		if p.buf.Len() > 0 {
 			if _, err := p.w.Write(p.buf.Bytes()); err != nil {
-				return 0, err
+				return consumed, err
 			}
 			p.buf.Reset()
 		}
 		if _, err := p.w.Write(b[:i+1]); err != nil {
-			return 0, err
+			return consumed, err
 		}
+		consumed += i + 1
 		b = b[i+1:]
 	}
 }
@@ -69,6 +79,10 @@ func (p *prefixWriter) Write(b []byte) (int, error) {
 // stream remains well-formed. Called when the supervised process exits
 // — without this, a worker that crashes mid-line would leave its last
 // fragment hidden.
+//
+// On error before all three sub-writes succeed, the buffered tail is
+// left intact so a subsequent Flush could retry. (We can't undo bytes
+// already written to p.w; this is best-effort retryability.)
 func (p *prefixWriter) Flush() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/dev/watch/prefix_writer_test.go
+++ b/internal/dev/watch/prefix_writer_test.go
@@ -1,0 +1,118 @@
+package watch
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrefixWriterSingleLine(t *testing.T) {
+	var buf bytes.Buffer
+	pw := newPrefixWriter("[x] ", &buf)
+	if _, err := pw.Write([]byte("hello\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "[x] hello\n"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestPrefixWriterMultipleLinesOneWrite(t *testing.T) {
+	var buf bytes.Buffer
+	pw := newPrefixWriter("[a] ", &buf)
+	if _, err := pw.Write([]byte("one\ntwo\nthree\n")); err != nil {
+		t.Fatal(err)
+	}
+	want := "[a] one\n[a] two\n[a] three\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestPrefixWriterPartialLineAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	pw := newPrefixWriter("[p] ", &buf)
+	// First write ends without a newline — should buffer.
+	if _, err := pw.Write([]byte("hel")); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no flush yet, got %q", buf.String())
+	}
+	// Second write completes the line.
+	if _, err := pw.Write([]byte("lo\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "[p] hello\n"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestPrefixWriterMixedTail(t *testing.T) {
+	var buf bytes.Buffer
+	pw := newPrefixWriter("[m] ", &buf)
+	// Two complete lines then a partial.
+	if _, err := pw.Write([]byte("a\nb\nc")); err != nil {
+		t.Fatal(err)
+	}
+	want := "[m] a\n[m] b\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("first stage got %q want %q", got, want)
+	}
+	// Tail flushed via Flush — adds a synthetic newline.
+	if err := pw.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	want = "[m] a\n[m] b\n[m] c\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("after flush got %q want %q", got, want)
+	}
+}
+
+func TestPrefixWriterFlushNoop(t *testing.T) {
+	var buf bytes.Buffer
+	pw := newPrefixWriter("[n] ", &buf)
+	if err := pw.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("flush of empty buffer wrote %q", buf.String())
+	}
+	// After a complete line, Flush should still be a no-op.
+	if _, err := pw.Write([]byte("done\n")); err != nil {
+		t.Fatal(err)
+	}
+	before := buf.String()
+	if err := pw.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != before {
+		t.Fatalf("flush after newline modified buffer: %q -> %q", before, buf.String())
+	}
+}
+
+func TestPrefixWriterEmbeddedNewlinesInOneWrite(t *testing.T) {
+	var buf bytes.Buffer
+	pw := newPrefixWriter("> ", &buf)
+	// Worst case: arbitrary chunk boundaries with multiple newlines and a partial.
+	chunks := []string{"line1\nlin", "e2\nline3", "\npartial"}
+	for _, c := range chunks {
+		if _, err := pw.Write([]byte(c)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := pw.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	wantLines := []string{
+		"> line1",
+		"> line2",
+		"> line3",
+		"> partial",
+		"",
+	}
+	if got != strings.Join(wantLines, "\n") {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/dev/watch/scanner.go
+++ b/internal/dev/watch/scanner.go
@@ -1,0 +1,92 @@
+package watch
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// graphSentinel is the substring we look for in candidate Python files
+// to decide whether to spawn a worker for them. Using a substring match
+// (rather than parsing the AST) is intentional: the scan must run on
+// every directory walk and on every fsnotify Write event, so it has to
+// be cheap. False positives are bounded — the worst case is spawning a
+// worker for a file that imports `@Graph(` in a comment, which then
+// fails to register and just exits. False negatives matter more, but
+// any normal Python source that defines a graph will contain the
+// literal string.
+var graphSentinel = []byte("@Graph(")
+
+// HasGraphDecorator reports whether the file at path appears to define
+// a graph (contains the @Graph( substring). Returns (false, nil) for
+// files that exist but lack the sentinel; returns an error only on I/O
+// failure.
+func HasGraphDecorator(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Contains(data, graphSentinel), nil
+}
+
+// ScanGraphs walks dir recursively and returns absolute paths of every
+// `.py` file containing the @Graph( sentinel. Hidden directories (names
+// starting with '.') and __pycache__ are skipped — they're never source
+// the operator wants supervised, and walking them wastes I/O.
+//
+// Returns a non-nil (possibly empty) slice on success. Returns an error
+// only if the root dir can't be read; per-file read errors are skipped
+// with a best-effort policy so one unreadable file doesn't poison the
+// whole scan.
+func ScanGraphs(dir string) ([]string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", dir, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", abs)
+	}
+
+	var found []string
+	walkErr := filepath.WalkDir(abs, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Don't abort the whole walk on a single permission denied;
+			// just skip the entry.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			// Skip hidden + __pycache__. Don't skip the root itself
+			// even if its name starts with '.' — the operator may have
+			// pointed --watch at a hidden dir intentionally.
+			if path != abs && (name[0] == '.' || name == "__pycache__" || name == "node_modules") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(d.Name()) != ".py" {
+			return nil
+		}
+		ok, readErr := HasGraphDecorator(path)
+		if readErr != nil {
+			return nil
+		}
+		if ok {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return found, nil
+}

--- a/internal/dev/watch/scanner_test.go
+++ b/internal/dev/watch/scanner_test.go
@@ -1,0 +1,99 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestScanGraphs(t *testing.T) {
+	dir := t.TempDir()
+
+	// File with the sentinel — should be picked up.
+	mustWrite(t, filepath.Join(dir, "hello.py"), "from duragraph.python import Graph\n@Graph()\nclass H: pass\n")
+
+	// File without the sentinel — should be skipped.
+	mustWrite(t, filepath.Join(dir, "plain.py"), "print('hi')\n")
+
+	// File with sentinel inside a subdir — should be picked up (recursive).
+	subdir := filepath.Join(dir, "agents")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(subdir, "nested.py"), "@Graph(name='x')\nclass N: pass\n")
+
+	// File in a hidden dir — should be skipped.
+	hidden := filepath.Join(dir, ".cache")
+	if err := os.Mkdir(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(hidden, "h.py"), "@Graph()\nclass X: pass\n")
+
+	// File in __pycache__ — should be skipped.
+	pyc := filepath.Join(dir, "__pycache__")
+	if err := os.Mkdir(pyc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(pyc, "c.py"), "@Graph()\nclass C: pass\n")
+
+	// Non-python file with the sentinel — should be skipped (wrong ext).
+	mustWrite(t, filepath.Join(dir, "readme.txt"), "@Graph(\n")
+
+	got, err := ScanGraphs(dir)
+	if err != nil {
+		t.Fatalf("ScanGraphs: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{
+		filepath.Join(dir, "agents", "nested.py"),
+		filepath.Join(dir, "hello.py"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("entry %d: expected %s, got %s", i, want[i], got[i])
+		}
+	}
+}
+
+func TestScanGraphsMissingDir(t *testing.T) {
+	_, err := ScanGraphs(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing dir")
+	}
+}
+
+func TestScanGraphsNotADir(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "file.py")
+	mustWrite(t, f, "@Graph()\n")
+	_, err := ScanGraphs(f)
+	if err == nil {
+		t.Fatal("expected error for non-dir argument")
+	}
+}
+
+func TestHasGraphDecorator(t *testing.T) {
+	dir := t.TempDir()
+	yes := filepath.Join(dir, "yes.py")
+	no := filepath.Join(dir, "no.py")
+	mustWrite(t, yes, "import x\n@Graph(name='a')\n")
+	mustWrite(t, no, "import x\nclass X: pass\n")
+
+	if ok, err := HasGraphDecorator(yes); err != nil || !ok {
+		t.Fatalf("yes.py: ok=%v err=%v", ok, err)
+	}
+	if ok, err := HasGraphDecorator(no); err != nil || ok {
+		t.Fatalf("no.py: ok=%v err=%v", ok, err)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/dev/watch/supervisor.go
+++ b/internal/dev/watch/supervisor.go
@@ -1,0 +1,326 @@
+package watch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// supervisorConfig is the per-file slice of Watcher options the
+// supervisor needs. Pulled out as its own struct to keep WorkerSupervisor
+// constructable from tests without dragging in fsnotify or logger
+// plumbing.
+type supervisorConfig struct {
+	File         string        // absolute path to the .py file
+	EnginePort   int           // for DURAGRAPH_URL env injection
+	SDKPath      string        // optional path to local duragraph-python
+	Stdout       io.Writer     // engine's stdout (will be prefix-wrapped)
+	Stderr       io.Writer     // engine's stderr (will be prefix-wrapped)
+	Logger       *log.Logger   // for supervisor-level messages, not worker output
+	SIGTERMGrace time.Duration // SIGTERM → SIGKILL grace
+}
+
+// reloadSignal is what the watcher sends to a supervisor when the file
+// changes. The supervisor stops the current worker (graceful kill,
+// then respawn) and resets its crash backoff.
+type reloadSignal struct{}
+
+// WorkerSupervisor owns the lifecycle of one worker subprocess for one
+// .py file. A single goroutine (run) loops over: spawn → wait for exit
+// → decide next action (reload? backoff? exit?). Reload signals and
+// shutdown are coordinated via channels; the supervisor never holds a
+// lock across a subprocess call.
+//
+// Crash backoff schedule: 1s, 2s, 4s, 8s, 16s, 32s, 60s (cap). On any
+// reload signal the backoff is reset to zero so a fix-and-save sees
+// the worker come back instantly even after it had been crash-looping.
+type WorkerSupervisor struct {
+	cfg supervisorConfig
+
+	// reload is signalled by the Watcher when the file mtime changes
+	// (after debounce). Buffered size 1 so a Reload() call from the
+	// fsnotify callback never blocks the event loop.
+	reload chan reloadSignal
+	// stop closes when Run should terminate. The supervisor reacts by
+	// killing any live child and returning.
+	stop chan struct{}
+	// done closes after Run returns; lets Watcher.Run wait for clean
+	// shutdown.
+	done chan struct{}
+
+	// stdoutPW / stderrPW are the line-buffered prefix writers. We hold
+	// references so we can Flush() them on subprocess exit.
+	stdoutPW *prefixWriter
+	stderrPW *prefixWriter
+}
+
+// newWorkerSupervisor wires the channels and prefix writers but does
+// not spawn anything. Call Run in a goroutine to start work.
+func newWorkerSupervisor(cfg supervisorConfig) *WorkerSupervisor {
+	prefix := "[" + filepath.Base(cfg.File) + "] "
+	if cfg.SIGTERMGrace == 0 {
+		cfg.SIGTERMGrace = 10 * time.Second
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Default()
+	}
+	if cfg.Stdout == nil {
+		cfg.Stdout = os.Stdout
+	}
+	if cfg.Stderr == nil {
+		cfg.Stderr = os.Stderr
+	}
+	return &WorkerSupervisor{
+		cfg:      cfg,
+		reload:   make(chan reloadSignal, 1),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+		stdoutPW: newPrefixWriter(prefix, cfg.Stdout),
+		stderrPW: newPrefixWriter(prefix, cfg.Stderr),
+	}
+}
+
+// Reload signals the supervisor to kill its current worker and respawn.
+// Non-blocking: if a reload is already pending, this is a no-op (the
+// pending signal already represents "one reload owed").
+func (s *WorkerSupervisor) Reload() {
+	select {
+	case s.reload <- reloadSignal{}:
+	default:
+	}
+}
+
+// Stop signals the supervisor to wind down. Stop is idempotent —
+// closing an already-closed channel would panic, so we guard with a
+// select.
+func (s *WorkerSupervisor) Stop() {
+	select {
+	case <-s.stop:
+		// Already stopped.
+	default:
+		close(s.stop)
+	}
+}
+
+// Wait blocks until Run returns. Safe to call after Stop; intended for
+// the watcher's shutdown path.
+func (s *WorkerSupervisor) Wait() { <-s.done }
+
+// Run is the supervisor's main loop. It spawns the worker, waits for
+// exit, then decides:
+//   - stop signalled  → return
+//   - reload signalled → kill (if alive), reset backoff, respawn now
+//   - clean exit (rc==0)  → back off and respawn (a worker that exits
+//     cleanly without our help usually means a misconfigured `if
+//     __name__ == "__main__":` block; respawning instantly would just
+//     spam the same exit, so we apply the same backoff schedule as for
+//     crashes)
+//   - non-zero exit  → backoff, then respawn
+//
+// One-goroutine design: this loop is the only place that touches
+// s.cmd / s.cmd.Wait, so there's no concurrent access to *exec.Cmd.
+func (s *WorkerSupervisor) Run() {
+	defer close(s.done)
+	defer s.stdoutPW.Flush()
+	defer s.stderrPW.Flush()
+
+	backoff := backoffSequence{}
+	for {
+		// Spawn a fresh subprocess. On success this returns a started
+		// *exec.Cmd plus a channel that will receive its exit error.
+		cmd, exitCh, err := s.spawn()
+		if err != nil {
+			// Spawn-time failures are usually missing `uv` or a bad
+			// SDK path. Don't loop forever on those — log and back off
+			// like a crash so the operator sees the message and the
+			// supervisor stays responsive to file edits.
+			s.cfg.Logger.Printf("watch: spawn failed for %s: %v", s.cfg.File, err)
+			if !s.sleepOrEvent(backoff.next()) {
+				return
+			}
+			continue
+		}
+		s.cfg.Logger.Printf("watch: spawned worker for %s (pid %d)", filepath.Base(s.cfg.File), cmd.Process.Pid)
+
+		// Wait for either: subprocess exits on its own, reload, or stop.
+		select {
+		case err := <-exitCh:
+			// Subprocess exited without our help. Treat as crash if
+			// rc != 0; back off and respawn.
+			rc := exitCode(err)
+			if rc == 0 {
+				s.cfg.Logger.Printf("watch: worker for %s exited cleanly; restarting after backoff", filepath.Base(s.cfg.File))
+			} else {
+				s.cfg.Logger.Printf("watch: worker for %s exited with code %d; restarting after backoff", filepath.Base(s.cfg.File), rc)
+			}
+			s.stdoutPW.Flush()
+			s.stderrPW.Flush()
+			if !s.sleepOrEvent(backoff.next()) {
+				return
+			}
+		case <-s.reload:
+			// File change: kill, drain exit, reset backoff, respawn now.
+			s.cfg.Logger.Printf("watch: reload requested for %s", filepath.Base(s.cfg.File))
+			s.terminate(cmd, exitCh)
+			s.stdoutPW.Flush()
+			s.stderrPW.Flush()
+			backoff.reset()
+			// Spec calls for waiting for the worker_id to deregister.
+			// Doing that properly requires plumbing the engine API +
+			// extracting the worker_id from the Python SDK output.
+			// For Phase 5 we approximate with a 1s settle delay so the
+			// new worker registers cleanly without a duplicate-id
+			// collision against the old one. Operators will see a
+			// short blank gap on reload, which is acceptable.
+			time.Sleep(1 * time.Second)
+		case <-s.stop:
+			s.terminate(cmd, exitCh)
+			return
+		}
+	}
+}
+
+// spawn starts a new subprocess. Returns the started cmd, a channel
+// that will receive its eventual exit error (nil for rc=0, *ExitError
+// otherwise), and a start-time error if the binary couldn't be exec'd.
+//
+// Process group: we set Setpgid so we can signal the entire group
+// (uv → python → user code). Without this, signalling cmd.Process
+// kills only `uv`, which leaves orphan python processes behind.
+func (s *WorkerSupervisor) spawn() (*exec.Cmd, <-chan error, error) {
+	args, err := buildSpawnArgs(s.cfg.SDKPath, s.cfg.File)
+	if err != nil {
+		return nil, nil, err
+	}
+	// NOTE: do NOT use exec.CommandContext here. CommandContext SIGKILLs
+	// on context cancel, defeating our 10s SIGTERM grace. We do our own
+	// signal sequencing in terminate().
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("DURAGRAPH_URL=http://localhost:%d", s.cfg.EnginePort),
+	)
+	cmd.Stdout = s.stdoutPW
+	cmd.Stderr = s.stderrPW
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	exitCh := make(chan error, 1)
+	go func() { exitCh <- cmd.Wait() }()
+	return cmd, exitCh, nil
+}
+
+// terminate sends SIGTERM to the worker's process group, waits up to
+// SIGTERMGrace for the exitCh to fire, then SIGKILLs if needed. Idempotent
+// w.r.t. an already-dead process — if the kill returns ESRCH, fine.
+func (s *WorkerSupervisor) terminate(cmd *exec.Cmd, exitCh <-chan error) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pgid := cmd.Process.Pid
+	// Negative pid = signal the whole process group (uv + child python).
+	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		s.cfg.Logger.Printf("watch: SIGTERM %s: %v", filepath.Base(s.cfg.File), err)
+	}
+	select {
+	case <-exitCh:
+		return
+	case <-time.After(s.cfg.SIGTERMGrace):
+		s.cfg.Logger.Printf("watch: %s did not exit within %s; sending SIGKILL", filepath.Base(s.cfg.File), s.cfg.SIGTERMGrace)
+		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			s.cfg.Logger.Printf("watch: SIGKILL %s: %v", filepath.Base(s.cfg.File), err)
+		}
+		<-exitCh
+	}
+}
+
+// sleepOrEvent sleeps for d unless a stop or reload arrives first.
+// Returns false if stop fired (caller should return), true otherwise.
+// A reload during the sleep is consumed by the channel here and would
+// otherwise be lost — to preserve it, we re-signal Reload before
+// returning so the next iteration sees it and respawns immediately.
+func (s *WorkerSupervisor) sleepOrEvent(d time.Duration) bool {
+	if d <= 0 {
+		select {
+		case <-s.stop:
+			return false
+		default:
+			return true
+		}
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-s.reload:
+		// Re-queue the reload so the loop body sees it.
+		s.Reload()
+		return true
+	case <-s.stop:
+		return false
+	}
+}
+
+// buildSpawnArgs returns the argv for the subprocess. If sdkPath is
+// non-empty, --with-editable points at it; otherwise we fall back to
+// `--with duragraph` and let uv resolve from PyPI. uv's absence is
+// detected here so the operator sees a clear, actionable message
+// instead of a cryptic exec error.
+func buildSpawnArgs(sdkPath, file string) ([]string, error) {
+	if _, err := exec.LookPath("uv"); err != nil {
+		return nil, fmt.Errorf("watch mode requires `uv` (https://docs.astral.sh/uv/). Install it or run without --watch")
+	}
+	if sdkPath != "" {
+		return []string{"uv", "run", "--with-editable", sdkPath, "python", file}, nil
+	}
+	return []string{"uv", "run", "--with", "duragraph", "python", file}, nil
+}
+
+// exitCode extracts the integer exit code from a cmd.Wait() error.
+// Returns 0 for nil (clean exit), the rc for *exec.ExitError, and -1
+// for other errors (e.g. I/O on the pipe — treat as crash).
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
+}
+
+// backoffSequence implements the spec's 1s, 2s, 4s, 8s, 16s, 32s, 60s
+// (cap) crash-backoff schedule. reset() drops the index so the next
+// next() returns 1s — used after a successful reload signal.
+type backoffSequence struct {
+	idx int
+}
+
+var backoffSteps = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	16 * time.Second,
+	32 * time.Second,
+	60 * time.Second,
+}
+
+func (b *backoffSequence) next() time.Duration {
+	d := backoffSteps[b.idx]
+	if b.idx < len(backoffSteps)-1 {
+		b.idx++
+	}
+	return d
+}
+
+func (b *backoffSequence) reset() { b.idx = 0 }

--- a/internal/dev/watch/supervisor_test.go
+++ b/internal/dev/watch/supervisor_test.go
@@ -1,0 +1,77 @@
+package watch
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestBackoffSequence(t *testing.T) {
+	b := backoffSequence{}
+	want := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		60 * time.Second,
+		60 * time.Second, // capped
+		60 * time.Second, // still capped
+	}
+	for i, w := range want {
+		if got := b.next(); got != w {
+			t.Fatalf("step %d: got %s want %s", i, got, w)
+		}
+	}
+	b.reset()
+	if got := b.next(); got != 1*time.Second {
+		t.Fatalf("after reset: got %s want 1s", got)
+	}
+}
+
+func TestBuildSpawnArgsRequiresUv(t *testing.T) {
+	// We can't reliably test the success path without making `uv` a
+	// test runner dependency. The failure path is the contract that
+	// matters for operator UX: we must return a clear error if `uv`
+	// isn't on PATH. Force PATH to a directory that can't contain uv.
+	t.Setenv("PATH", t.TempDir())
+	_, err := buildSpawnArgs("", "/tmp/file.py")
+	if err == nil {
+		t.Fatal("expected error when uv missing")
+	}
+	if got := err.Error(); !contains(got, "uv") {
+		t.Fatalf("error must mention uv: %q", got)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	if got := exitCode(nil); got != 0 {
+		t.Fatalf("nil: got %d want 0", got)
+	}
+	if got := exitCode(errors.New("io broken")); got != -1 {
+		t.Fatalf("non-exit: got %d want -1", got)
+	}
+	// Synthesize a real *exec.ExitError by running a command we know
+	// will exit non-zero. `false` exists on every Linux test runner.
+	if _, err := exec.LookPath("false"); err == nil {
+		err := exec.Command("false").Run()
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Skip("false didn't yield ExitError, skipping")
+		}
+		if got := exitCode(err); got != 1 {
+			t.Fatalf("false exit code: got %d want 1", got)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dev/watch/watch.go
+++ b/internal/dev/watch/watch.go
@@ -88,7 +88,7 @@ type Watcher struct {
 
 	mu          sync.Mutex
 	supervisors map[string]*WorkerSupervisor // file → supervisor
-	debouncers  map[string]*time.Timer       // file → pending reload timer
+	debouncers  map[string]*debounceEntry    // file → pending reload state
 	// closed flips true at the start of shutdown(). Guards against the
 	// narrow race where a debounce timer fires between Stop()ing the
 	// timer and clearing the map: the AfterFunc callback runs, enters
@@ -97,6 +97,18 @@ type Watcher struct {
 	// outlive the watcher with nothing to Stop() it. Checking closed
 	// in spawn/dispatch turns those late callbacks into no-ops.
 	closed bool
+}
+
+// debounceEntry tracks the pending reload state for one file. `generation`
+// is incremented on every fsnotify event for the file; the AfterFunc
+// callback captures the generation it was scheduled at and no-ops when
+// it fires if a newer event has bumped the count. This is more robust
+// than a Stop+Reset pattern because it tolerates the timer-already-firing
+// race (Stop returns false but the callback proceeds): the generation
+// check still rejects the stale callback.
+type debounceEntry struct {
+	timer      *time.Timer
+	generation uint64
 }
 
 // New constructs a Watcher. Returns an error only on options that are
@@ -139,7 +151,7 @@ func New(opts Options) (*Watcher, error) {
 	return &Watcher{
 		opts:        opts,
 		supervisors: make(map[string]*WorkerSupervisor),
-		debouncers:  make(map[string]*time.Timer),
+		debouncers:  make(map[string]*debounceEntry),
 	}, nil
 }
 
@@ -188,6 +200,13 @@ func (w *Watcher) Run(ctx context.Context) error {
 	for _, f := range files {
 		w.spawnSupervisor(f)
 	}
+	// From here on, every return path must tear down the supervisors we
+	// just spawned — including the early-error returns from fsnotify
+	// setup below. Defer guarantees that. shutdown() is idempotent
+	// (closed=true is benign on repeat, the maps are reset on first
+	// call, Stop/Wait on supervisors are idempotent), so it's safe to
+	// run unconditionally.
+	defer w.shutdown()
 
 	// fsnotify setup. Has to recurse manually — Add() each subdir and
 	// add new ones as they appear via Create events on directories.
@@ -203,17 +222,14 @@ func (w *Watcher) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			w.shutdown()
 			return nil
 		case ev, ok := <-fw.Events:
 			if !ok {
-				w.shutdown()
 				return nil
 			}
 			w.handleEvent(fw, ev)
 		case ferr, ok := <-fw.Errors:
 			if !ok {
-				w.shutdown()
 				return nil
 			}
 			w.opts.Logger.Printf("watch: fsnotify error: %v", ferr)
@@ -289,15 +305,39 @@ func (w *Watcher) handleEvent(fw *fsnotify.Watcher, ev fsnotify.Event) {
 // quiet window elapses, dispatchReload re-checks the @Graph( sentinel
 // (so a file the user emptied isn't supervised) and either reloads,
 // spawns, or stops the supervisor accordingly.
+//
+// Per-file generation tokens guard against the time.AfterFunc-already-
+// firing race: each event bumps entry.generation; the callback captures
+// the generation it was scheduled at, and on fire it re-checks under
+// the mutex. If a newer event arrived (generation advanced), the
+// callback no-ops and the newer event's callback will dispatch.
 func (w *Watcher) scheduleReload(file string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if t, ok := w.debouncers[file]; ok {
-		t.Reset(w.opts.DebounceWindow)
-		return
+
+	entry, ok := w.debouncers[file]
+	if !ok {
+		entry = &debounceEntry{}
+		w.debouncers[file] = entry
 	}
-	w.debouncers[file] = time.AfterFunc(w.opts.DebounceWindow, func() {
+	entry.generation++
+	expected := entry.generation
+
+	if entry.timer != nil {
+		// Best-effort cancel; if the timer already fired the callback
+		// will see a mismatched generation and exit cleanly.
+		entry.timer.Stop()
+	}
+	entry.timer = time.AfterFunc(w.opts.DebounceWindow, func() {
 		w.mu.Lock()
+		e, ok := w.debouncers[file]
+		if !ok || e.generation != expected {
+			// Superseded by a newer event (or already cleared by
+			// shutdown). The newer event's callback will dispatch.
+			w.mu.Unlock()
+			return
+		}
+		// We won the race — claim this dispatch by removing the entry.
 		delete(w.debouncers, file)
 		w.mu.Unlock()
 		w.dispatchReload(file)
@@ -394,11 +434,15 @@ func (w *Watcher) shutdown() {
 	w.supervisors = make(map[string]*WorkerSupervisor)
 	// Cancel any pending debounce timers so AfterFunc callbacks don't
 	// fire after Run returns and try to spawn supervisors into a
-	// shutting-down watcher.
-	for _, t := range w.debouncers {
-		t.Stop()
+	// shutting-down watcher. Even if a timer has already fired and the
+	// callback is in flight, the dispatchReload path checks w.closed
+	// and the schedule-side generation check rejects on missing entry.
+	for _, e := range w.debouncers {
+		if e.timer != nil {
+			e.timer.Stop()
+		}
 	}
-	w.debouncers = make(map[string]*time.Timer)
+	w.debouncers = make(map[string]*debounceEntry)
 	w.mu.Unlock()
 
 	var wg sync.WaitGroup

--- a/internal/dev/watch/watch.go
+++ b/internal/dev/watch/watch.go
@@ -1,0 +1,440 @@
+// Package watch implements `duragraph dev`'s watch-mode worker
+// supervision (binary-modes.yml § watch_mode). One Watcher manages a
+// directory tree of Python graph files: it scans for files containing
+// the @Graph( sentinel, spawns one subprocess supervisor per file, and
+// reloads them via SIGTERM+respawn on file change.
+//
+// The package is deliberately small and Go-only — no Python interpreter,
+// no Docker. Subprocesses are launched via `uv run --with-editable …`
+// (or `--with duragraph` if no local SDK path is configured) and their
+// stdout/stderr is line-prefixed with the source filename and forwarded
+// to the engine's stdout/stderr so the operator sees a single unified
+// log stream.
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Options configures a Watcher. Construct with sane defaults via New;
+// fields with zero values get spec-default fillers (200ms debounce,
+// 10s SIGTERM grace, stdlib log.Default()).
+type Options struct {
+	// WatchDir is the directory to watch recursively for `.py` files.
+	// If the directory does not exist, Run returns nil after a warning
+	// — `duragraph dev`'s default of `./agents` should not error out
+	// just because the operator hasn't created the dir yet.
+	WatchDir string
+
+	// EnginePort is injected into worker subprocesses as
+	// DURAGRAPH_URL=http://localhost:<port>.
+	EnginePort int
+
+	// SDKPath is an optional local checkout of duragraph-python. When
+	// set, workers run with `uv run --with-editable <sdkpath>`. When
+	// empty, workers fall back to `uv run --with duragraph` (resolves
+	// from PyPI). Wired from the DURAGRAPH_PYTHON_SDK_PATH env var by
+	// New(); operators rarely set it directly.
+	SDKPath string
+
+	// Stdout / Stderr are the engine's writers. Each supervised worker
+	// gets its own line-prefixed view of these (prefix = "[<basename>] ").
+	// Default to os.Stdout / os.Stderr.
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// Logger receives watcher-level log output (spawned, reload, crash,
+	// fsnotify error). Defaults to log.Default() — matches the rest of
+	// duragraph's logger pattern (no central logger interface; serve.go
+	// uses stdlib log directly).
+	Logger *log.Logger
+
+	// DebounceWindow is the quiet period (per file) before fsnotify
+	// events trigger a reload. Default 200ms (per spec).
+	DebounceWindow time.Duration
+
+	// SIGTERMGrace is how long a worker has to exit after SIGTERM
+	// before SIGKILL. Default 10s (per spec).
+	SIGTERMGrace time.Duration
+
+	// HealthURL is the engine's /health endpoint. The watcher polls
+	// this until it returns 200 before scanning for graphs (otherwise
+	// every spawned worker fails to register and crash-loops). Default
+	// is http://localhost:<EnginePort>/health.
+	HealthURL string
+
+	// HealthTimeout caps how long Run waits for /health. Default 30s.
+	HealthTimeout time.Duration
+}
+
+// Watcher is the public type returned by New. Run is the only exported
+// method intended for external callers; Stop is implicit via context
+// cancellation.
+type Watcher struct {
+	opts Options
+
+	mu          sync.Mutex
+	supervisors map[string]*WorkerSupervisor // file → supervisor
+	debouncers  map[string]*time.Timer       // file → pending reload timer
+	// closed flips true at the start of shutdown(). Guards against the
+	// narrow race where a debounce timer fires between Stop()ing the
+	// timer and clearing the map: the AfterFunc callback runs, enters
+	// dispatchReload → spawnSupervisor, and inserts a brand-new
+	// supervisor into the cleared map — its `uv` process would then
+	// outlive the watcher with nothing to Stop() it. Checking closed
+	// in spawn/dispatch turns those late callbacks into no-ops.
+	closed bool
+}
+
+// New constructs a Watcher. Returns an error only on options that are
+// invariably fatal (e.g. missing WatchDir + EnginePort = 0). Filesystem
+// state and `uv` availability are deliberately checked at Run time so
+// the operator sees errors in the engine's normal startup output.
+func New(opts Options) (*Watcher, error) {
+	if opts.EnginePort == 0 {
+		return nil, errors.New("watch: EnginePort must be set")
+	}
+	if opts.WatchDir == "" {
+		return nil, errors.New("watch: WatchDir must be set")
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	if opts.Logger == nil {
+		opts.Logger = log.Default()
+	}
+	if opts.DebounceWindow == 0 {
+		opts.DebounceWindow = 200 * time.Millisecond
+	}
+	if opts.SIGTERMGrace == 0 {
+		opts.SIGTERMGrace = 10 * time.Second
+	}
+	if opts.HealthURL == "" {
+		opts.HealthURL = fmt.Sprintf("http://localhost:%d/health", opts.EnginePort)
+	}
+	if opts.HealthTimeout == 0 {
+		opts.HealthTimeout = 30 * time.Second
+	}
+	if opts.SDKPath == "" {
+		// Allow override via env so operators developing the SDK can
+		// point at their checkout without a CLI flag.
+		opts.SDKPath = os.Getenv("DURAGRAPH_PYTHON_SDK_PATH")
+	}
+	return &Watcher{
+		opts:        opts,
+		supervisors: make(map[string]*WorkerSupervisor),
+		debouncers:  make(map[string]*time.Timer),
+	}, nil
+}
+
+// Run blocks until ctx is cancelled (typically when the engine's main
+// loop receives SIGINT/SIGTERM and we cancel its context). Returns nil
+// on clean shutdown; any returned error is fatal (couldn't initialise
+// fsnotify, couldn't reach engine /health within timeout, etc.).
+//
+// Phases:
+//  1. Wait for the engine's /health to return 200 — otherwise every
+//     worker we spawn fails to register against an unreachable port.
+//  2. Resolve and stat the watch dir. Missing dir → log + return nil.
+//  3. Initial scan: ScanGraphs the dir, spawn one supervisor per hit.
+//  4. Start fsnotify, walk the tree to add every subdirectory (fsnotify
+//     doesn't recurse — we manage that ourselves), and loop on events.
+//  5. On ctx.Done: stop every supervisor, close fsnotify, return.
+func (w *Watcher) Run(ctx context.Context) error {
+	if err := w.waitForEngine(ctx); err != nil {
+		return err
+	}
+
+	absDir, err := filepath.Abs(w.opts.WatchDir)
+	if err != nil {
+		return fmt.Errorf("resolve watch dir: %w", err)
+	}
+	info, statErr := os.Stat(absDir)
+	if errors.Is(statErr, fs.ErrNotExist) {
+		w.opts.Logger.Printf("watch: directory %s does not exist; skipping watch mode", absDir)
+		<-ctx.Done()
+		return nil
+	}
+	if statErr != nil {
+		return fmt.Errorf("stat watch dir: %w", statErr)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("watch: %s is not a directory", absDir)
+	}
+
+	fmt.Printf("🔍 Watch mode: scanning %s\n", absDir)
+
+	// Initial scan.
+	files, err := ScanGraphs(absDir)
+	if err != nil {
+		return fmt.Errorf("scan graphs: %w", err)
+	}
+	for _, f := range files {
+		w.spawnSupervisor(f)
+	}
+
+	// fsnotify setup. Has to recurse manually — Add() each subdir and
+	// add new ones as they appear via Create events on directories.
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("fsnotify init: %w", err)
+	}
+	defer fw.Close()
+	if err := addRecursive(fw, absDir); err != nil {
+		return fmt.Errorf("fsnotify add %s: %w", absDir, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.shutdown()
+			return nil
+		case ev, ok := <-fw.Events:
+			if !ok {
+				w.shutdown()
+				return nil
+			}
+			w.handleEvent(fw, ev)
+		case ferr, ok := <-fw.Errors:
+			if !ok {
+				w.shutdown()
+				return nil
+			}
+			w.opts.Logger.Printf("watch: fsnotify error: %v", ferr)
+		}
+	}
+}
+
+// waitForEngine polls /health until it returns 200, ctx is cancelled,
+// or the timeout elapses. 200ms poll interval keeps the overhead
+// negligible (~150 requests over 30s) without making the operator
+// wait noticeably after the engine is up. Per-request timeout of 1s
+// prevents a hung connect from soaking the whole budget.
+func (w *Watcher) waitForEngine(ctx context.Context) error {
+	deadline := time.Now().Add(w.opts.HealthTimeout)
+	client := &http.Client{Timeout: time.Second}
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.opts.HealthURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("watch: engine /health did not return 200 within %s (last url: %s)", w.opts.HealthTimeout, w.opts.HealthURL)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// handleEvent routes one fsnotify event. Directory creates are added
+// to the watcher (so newly-mkdir'd subdirs aren't blind spots). File
+// removes terminate any matching supervisor immediately. File writes
+// and creates schedule a debounced reload — vim's atomic-rename pattern
+// emits Rename+Create+Write for one save, and the 200ms quiet window
+// collapses those into one reload action.
+func (w *Watcher) handleEvent(fw *fsnotify.Watcher, ev fsnotify.Event) {
+	// Directory create → recurse-add.
+	if ev.Has(fsnotify.Create) {
+		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+			if err := addRecursive(fw, ev.Name); err != nil {
+				w.opts.Logger.Printf("watch: add subdir %s: %v", ev.Name, err)
+			}
+			return
+		}
+	}
+
+	if filepath.Ext(ev.Name) != ".py" {
+		return
+	}
+
+	// Remove / Rename of a tracked file → stop the supervisor.
+	if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
+		w.stopSupervisor(ev.Name)
+		return
+	}
+
+	// Write / Create / Chmod → debounced reload.
+	if ev.Has(fsnotify.Write) || ev.Has(fsnotify.Create) || ev.Has(fsnotify.Chmod) {
+		w.scheduleReload(ev.Name)
+	}
+}
+
+// scheduleReload (re)starts the per-file debounce timer. After the
+// quiet window elapses, dispatchReload re-checks the @Graph( sentinel
+// (so a file the user emptied isn't supervised) and either reloads,
+// spawns, or stops the supervisor accordingly.
+func (w *Watcher) scheduleReload(file string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if t, ok := w.debouncers[file]; ok {
+		t.Reset(w.opts.DebounceWindow)
+		return
+	}
+	w.debouncers[file] = time.AfterFunc(w.opts.DebounceWindow, func() {
+		w.mu.Lock()
+		delete(w.debouncers, file)
+		w.mu.Unlock()
+		w.dispatchReload(file)
+	})
+}
+
+// dispatchReload is the post-debounce action: re-check sentinel, then
+// reload / spawn / stop. Held outside the lock so we don't call into
+// supervisor channels while holding the watcher mutex.
+func (w *Watcher) dispatchReload(file string) {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	sup, exists := w.supervisors[file]
+	w.mu.Unlock()
+
+	hasGraph, err := HasGraphDecorator(file)
+	if err != nil {
+		// File deleted between debounce schedule and fire, or unreadable.
+		if exists {
+			w.stopSupervisor(file)
+		}
+		return
+	}
+	if !hasGraph {
+		if exists {
+			w.stopSupervisor(file)
+		}
+		return
+	}
+	if exists {
+		sup.Reload()
+		return
+	}
+	w.spawnSupervisor(file)
+}
+
+// spawnSupervisor wires up a new supervisor for a file and starts its
+// Run goroutine. Caller must NOT already hold the lock for this file.
+// No-op if the watcher is shutting down (see Watcher.closed).
+func (w *Watcher) spawnSupervisor(file string) {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	if _, exists := w.supervisors[file]; exists {
+		w.mu.Unlock()
+		return
+	}
+	sup := newWorkerSupervisor(supervisorConfig{
+		File:         file,
+		EnginePort:   w.opts.EnginePort,
+		SDKPath:      w.opts.SDKPath,
+		Stdout:       w.opts.Stdout,
+		Stderr:       w.opts.Stderr,
+		Logger:       w.opts.Logger,
+		SIGTERMGrace: w.opts.SIGTERMGrace,
+	})
+	w.supervisors[file] = sup
+	w.mu.Unlock()
+	go sup.Run()
+}
+
+// stopSupervisor removes the supervisor for file (if any), signals it
+// to stop, and waits for it to drain. Synchronous so a quick
+// remove-then-create sequence doesn't race the new spawn against the
+// old kill.
+func (w *Watcher) stopSupervisor(file string) {
+	w.mu.Lock()
+	sup, ok := w.supervisors[file]
+	if ok {
+		delete(w.supervisors, file)
+	}
+	w.mu.Unlock()
+	if !ok {
+		return
+	}
+	sup.Stop()
+	sup.Wait()
+}
+
+// shutdown stops every supervisor in parallel and waits for all to
+// drain. Called from Run when ctx is cancelled.
+func (w *Watcher) shutdown() {
+	w.mu.Lock()
+	w.closed = true
+	sups := make([]*WorkerSupervisor, 0, len(w.supervisors))
+	for _, s := range w.supervisors {
+		sups = append(sups, s)
+	}
+	w.supervisors = make(map[string]*WorkerSupervisor)
+	// Cancel any pending debounce timers so AfterFunc callbacks don't
+	// fire after Run returns and try to spawn supervisors into a
+	// shutting-down watcher.
+	for _, t := range w.debouncers {
+		t.Stop()
+	}
+	w.debouncers = make(map[string]*time.Timer)
+	w.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, s := range sups {
+		s.Stop()
+	}
+	for _, s := range sups {
+		wg.Add(1)
+		go func(s *WorkerSupervisor) { defer wg.Done(); s.Wait() }(s)
+	}
+	wg.Wait()
+}
+
+// addRecursive walks root and Add()s every directory to fw. fsnotify
+// doesn't recurse on its own; without this, edits to files in
+// subdirectories silently never trigger reloads. Hidden / __pycache__
+// dirs are skipped to avoid burning watcher slots on noise (matches
+// scanner skip list).
+func addRecursive(fw *fsnotify.Watcher, root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if path != root && (strings.HasPrefix(name, ".") || name == "__pycache__" || name == "node_modules") {
+			return fs.SkipDir
+		}
+		if err := fw.Add(path); err != nil {
+			return fmt.Errorf("fsnotify add %s: %w", path, err)
+		}
+		return nil
+	})
+}

--- a/internal/dev/watch/watch_test.go
+++ b/internal/dev/watch/watch_test.go
@@ -107,7 +107,7 @@ func TestWatcherDebouncesEvents(t *testing.T) {
 
 	// Inject a stub supervisor into the map so dispatchReload calls
 	// Reload() on it instead of trying to spawn `uv`.
-	stub := newStubSupervisor()
+	stub := newStubSupervisor(t)
 	w.supervisors[file] = stub.real
 
 	// Three rapid events should collapse to one Reload call.
@@ -133,31 +133,100 @@ func TestWatcherDebouncesEvents(t *testing.T) {
 	}
 }
 
+// TestWatcherDebounceTightBurst stresses the generation-token logic
+// in scheduleReload: a tight burst of N events with tiny inter-arrival
+// times exercises the path where time.AfterFunc may already be firing
+// when the next Stop() arrives. The contract is: at most one
+// dispatchReload per debounce window, regardless of burst size.
+func TestWatcherDebounceTightBurst(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "graph.py")
+	if err := os.WriteFile(file, []byte("@Graph()\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w, err := New(Options{
+		WatchDir:       dir,
+		EnginePort:     9999,
+		HealthURL:      srv.URL,
+		HealthTimeout:  2 * time.Second,
+		Stdout:         io.Discard,
+		Stderr:         io.Discard,
+		Logger:         log.New(io.Discard, "", 0),
+		DebounceWindow: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stub := newStubSupervisor(t)
+	w.supervisors[file] = stub.real
+
+	// Fire a tight burst of events with no sleeps between them. The
+	// first call schedules a timer; subsequent calls bump the
+	// generation and Stop()/replace the timer. Some Stop() calls may
+	// hit a timer that's already firing — the generation check must
+	// reject those callbacks.
+	const burst = 200
+	for i := 0; i < burst; i++ {
+		w.scheduleReload(file)
+	}
+
+	// Wait several debounce windows to let any in-flight callbacks
+	// settle (the last-scheduled timer needs DebounceWindow to fire).
+	time.Sleep(150 * time.Millisecond)
+
+	got := stub.reloadCount()
+	if got != 1 {
+		t.Fatalf("expected exactly 1 reload after %d-event burst, got %d", burst, got)
+	}
+}
+
 // stubSupervisor records Reload() invocations on a real
 // *WorkerSupervisor without spawning subprocesses. We do this by
 // constructing the supervisor and counting from a wrapper goroutine
 // that drains its reload channel. The supervisor's Run() is never
 // started, so no `uv` process exists.
+//
+// The drain goroutine selects on a done channel registered via
+// t.Cleanup so the goroutine exits with the test instead of leaking
+// for the lifetime of the test process. We can't close s.real.reload
+// directly because Reload() does a non-blocking send and closing under
+// it would panic.
 type stubSupervisor struct {
 	real *WorkerSupervisor
 	mu   sync.Mutex
 	n    int
+	done chan struct{}
 }
 
-func newStubSupervisor() *stubSupervisor {
+func newStubSupervisor(t *testing.T) *stubSupervisor {
+	t.Helper()
 	s := &stubSupervisor{
 		real: newWorkerSupervisor(supervisorConfig{
 			File:       "/tmp/stub.py",
 			EnginePort: 9999,
 		}),
+		done: make(chan struct{}),
 	}
 	go func() {
-		for range s.real.reload {
-			s.mu.Lock()
-			s.n++
-			s.mu.Unlock()
+		for {
+			select {
+			case <-s.done:
+				return
+			case <-s.real.reload:
+				s.mu.Lock()
+				s.n++
+				s.mu.Unlock()
+			}
 		}
 	}()
+	t.Cleanup(func() { close(s.done) })
 	return s
 }
 

--- a/internal/dev/watch/watch_test.go
+++ b/internal/dev/watch/watch_test.go
@@ -1,0 +1,168 @@
+package watch
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewValidation(t *testing.T) {
+	if _, err := New(Options{WatchDir: "/tmp"}); err == nil {
+		t.Fatal("expected error: missing EnginePort")
+	}
+	if _, err := New(Options{EnginePort: 8081}); err == nil {
+		t.Fatal("expected error: missing WatchDir")
+	}
+}
+
+func TestWatcherMissingDirReturnsCleanly(t *testing.T) {
+	// /health stub that immediately returns 200 so waitForEngine passes.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w, err := New(Options{
+		WatchDir:      filepath.Join(t.TempDir(), "does-not-exist"),
+		EnginePort:    9999,
+		HealthURL:     srv.URL,
+		HealthTimeout: 2 * time.Second,
+		Stdout:        io.Discard,
+		Stderr:        io.Discard,
+		Logger:        log.New(io.Discard, "", 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	if err := w.Run(ctx); err != nil {
+		t.Fatalf("Run on missing dir: %v", err)
+	}
+}
+
+func TestWatcherHealthTimeout(t *testing.T) {
+	// Bind a closed server so the watcher can't reach /health.
+	w, err := New(Options{
+		WatchDir:      t.TempDir(),
+		EnginePort:    1, // unprivileged; never bound
+		HealthURL:     "http://127.0.0.1:1/health",
+		HealthTimeout: 100 * time.Millisecond,
+		Stdout:        io.Discard,
+		Stderr:        io.Discard,
+		Logger:        log.New(io.Discard, "", 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected health timeout error")
+	}
+}
+
+func TestWatcherDebouncesEvents(t *testing.T) {
+	// We exercise scheduleReload + dispatchReload directly rather than
+	// stand up a real watcher loop — the dispatch path is what
+	// determines reload semantics. We arrange dispatchReload to spawn
+	// a recorded supervisor stand-in via spawnSupervisor; since
+	// spawnSupervisor calls newWorkerSupervisor which kicks off Run(),
+	// we'd actually try to exec uv. So instead we pre-populate the
+	// supervisors map with a stub that records Reload() calls.
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "graph.py")
+	if err := os.WriteFile(file, []byte("@Graph()\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w, err := New(Options{
+		WatchDir:       dir,
+		EnginePort:     9999,
+		HealthURL:      srv.URL,
+		HealthTimeout:  2 * time.Second,
+		Stdout:         io.Discard,
+		Stderr:         io.Discard,
+		Logger:         log.New(io.Discard, "", 0),
+		DebounceWindow: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject a stub supervisor into the map so dispatchReload calls
+	// Reload() on it instead of trying to spawn `uv`.
+	stub := newStubSupervisor()
+	w.supervisors[file] = stub.real
+
+	// Three rapid events should collapse to one Reload call.
+	for i := 0; i < 3; i++ {
+		w.scheduleReload(file)
+		time.Sleep(10 * time.Millisecond) // shorter than debounce
+	}
+
+	// Wait past the debounce window for the timer to fire.
+	time.Sleep(120 * time.Millisecond)
+
+	got := stub.reloadCount()
+	if got != 1 {
+		t.Fatalf("expected 1 reload after debounce, got %d", got)
+	}
+
+	// A subsequent event after the window has lapsed → another reload.
+	w.scheduleReload(file)
+	time.Sleep(120 * time.Millisecond)
+	got = stub.reloadCount()
+	if got != 2 {
+		t.Fatalf("expected 2 reloads after second debounce, got %d", got)
+	}
+}
+
+// stubSupervisor records Reload() invocations on a real
+// *WorkerSupervisor without spawning subprocesses. We do this by
+// constructing the supervisor and counting from a wrapper goroutine
+// that drains its reload channel. The supervisor's Run() is never
+// started, so no `uv` process exists.
+type stubSupervisor struct {
+	real *WorkerSupervisor
+	mu   sync.Mutex
+	n    int
+}
+
+func newStubSupervisor() *stubSupervisor {
+	s := &stubSupervisor{
+		real: newWorkerSupervisor(supervisorConfig{
+			File:       "/tmp/stub.py",
+			EnginePort: 9999,
+		}),
+	}
+	go func() {
+		for range s.real.reload {
+			s.mu.Lock()
+			s.n++
+			s.mu.Unlock()
+		}
+	}()
+	return s
+}
+
+func (s *stubSupervisor) reloadCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.n
+}


### PR DESCRIPTION
## Summary

Implements `binary-modes.yml § watch_mode` for `duragraph dev --watch`. Closes the gap between Phase 4 (which stubbed `--watch` as a no-op flag) and the spec.

The watcher recursively scans `<watch_dir>` for `.py` files containing the `@Graph(` substring, then supervises one subprocess per file:

```
uv run --with-editable <DURAGRAPH_PYTHON_SDK_PATH> python <file>
# or, if DURAGRAPH_PYTHON_SDK_PATH is unset:
uv run --with duragraph python <file>
```

with `DURAGRAPH_URL=http://localhost:<--port>` injected into each worker's env. Subprocess stdout/stderr is line-buffered, prefixed with `[<basename>] `, and forwarded to the engine's stdout/stderr.

## What's in the PR

New package `internal/dev/watch/`:

| File | Purpose |
|------|---------|
| `watch.go` | `Watcher` type. Polls engine `/health` (200ms interval, 30s cap) before initial scan. Walks the dir to add fsnotify watches per subdirectory (fsnotify doesn't recurse). Routes events into per-file 200ms debouncers. |
| `scanner.go` | `ScanGraphs` walks the tree at startup, skipping hidden dirs / `__pycache__` / non-`.py` / `node_modules`. |
| `supervisor.go` | `WorkerSupervisor`: one goroutine loops over spawn → wait → reload/backoff/stop. Subprocess runs in its own process group (`Setpgid`) so SIGTERM/SIGKILL hit `uv` AND its child python. Crash backoff: `1s,2s,4s,8s,16s,32s,60s` (capped); reset to 0 on file-change reload. SIGTERM grace 10s, then SIGKILL. Does NOT use `exec.CommandContext` — that would SIGKILL on ctx cancel and defeat the grace window. |
| `prefix_writer.go` | Line-buffered `io.Writer` wrapper. Holds partial lines until `\n` or `Flush()`. |

Wiring in `cmd/duragraph/cmd/dev.go`:

- Watcher started in a goroutine BEFORE `serveCmd.RunE` (which blocks on SIGINT/SIGTERM). On serve return we cancel the watcher's ctx and wait for clean drain.
- No `serve.go` refactor needed — the pattern keeps Phase 5 entirely behind `--watch`.
- `--watch=""` disables the feature; default stays `./agents`.
- Missing watch dir → log warning + idle (don't fail dev startup).

## Supervisor flow

```
spawn worker (uv run … python <file>)
  ↓
select {
  case <-exitCh:    log rc, backoff (1s,2s,…,60s), respawn
  case <-reload:    SIGTERM (group), wait grace, SIGKILL if needed,
                    flush, reset backoff, sleep 1s settle, respawn
  case <-stop:      SIGTERM (group), wait grace, SIGKILL if needed, return
}
```

## Env vars

- `DURAGRAPH_URL` — injected into each worker as `http://localhost:<--port>`.
- `DURAGRAPH_PYTHON_SDK_PATH` (operator-set) — selects `--with-editable` over the PyPI fallback.

## Engine-up wait

`Watcher.Run` polls `http://localhost:<port>/health` every 200ms with a 1s per-request timeout, capped at 30s total. Returns a clear error if the engine never comes up. Without this, every spawned worker would race the engine binding the port and crash-loop on connection refused.

## Spec approximation (called out in code)

`binary-modes.yml § watch_mode.reload` step 2 calls for waiting for the `worker_id` to deregister from the control plane after SIGTERM. Properly plumbing that requires extracting the SDK-side `worker_id` and querying `/api/v1/workers/<id>`. For Phase 5 we approximate with a `time.Sleep(1*time.Second)` settle delay before respawn. Documented inline.

## Still stubbed

- `--studio` (Phase 8 — bundle Studio under `/studio/`).

## Tests

17 tests in `internal/dev/watch/` (all pass under `-race`):

- Scanner: sentinel match, skip rules (hidden dirs, `__pycache__`, non-`.py`), missing-dir error, file-not-dir error.
- prefixWriter: single line, multiple lines in one write, partial line across writes, mixed tail + flush, flush no-op, embedded newlines worst-case.
- Supervisor: backoff sequence + reset (incl. cap), `buildSpawnArgs` returns clear error when `uv` not on PATH, `exitCode` for nil/ExitError/other.
- Watcher: `New` validation, missing-dir grace path, `/health` timeout, debounce collapses three rapid events into one reload.

No integration tests that exec `uv` — out of scope (slow, requires `uv` on the test runner).

## Manual smoke (operator-run; not in CI)

```bash
# Set up agents dir
mkdir -p /tmp/dg-agents
cat > /tmp/dg-agents/hello.py <<'PY'
from duragraph.python import Graph

@Graph()
class Hello:
    pass
PY

# Build + run
go build -o /tmp/duragraph ./cmd/duragraph
/tmp/duragraph dev --port 8081 --watch /tmp/dg-agents

# Expected:
#   ... engine startup ...
#   ✅ Embedded Postgres started
#   ✅ Embedded NATS started
#   🌐 Server listening on 0.0.0.0:8081
#   🔍 Watch mode: scanning /tmp/dg-agents
#   watch: spawned worker for hello.py (pid …)

# Modify hello.py:
echo "# changed" >> /tmp/dg-agents/hello.py
# Expected: watch: reload requested for hello.py … spawned worker for hello.py

# Ctrl+C: clean shutdown of all workers + postgres + NATS.
```

## Spec coupling

Spec-aligned (`binary-modes.yml § watch_mode`). No `[spec-skip:]` trailer needed.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/dev/... -count=1 -short` — 17 tests pass
- [x] `go test ./internal/dev/... -race` — clean
- [x] `go vet ./...` clean
- [ ] Manual smoke (operator) — see commands above