### PR TITLE
feat(init): scaffold-from-template subcommand (v0.7 Phase 6)

### DIFF
--- a/cmd/duragraph/cmd/init.go
+++ b/cmd/duragraph/cmd/init.go
@@ -65,11 +65,23 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// cd hint: prefer a path relative to the user's cwd so the printed
+	// `cd <hint>` is copy-pasteable. If target is outside cwd (e.g. user
+	// passed an absolute --dir), or os.Getwd / filepath.Rel fail, fall
+	// back to the absolute target — that always works even if it's
+	// uglier.
+	cdHint := target
+	if cwd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(cwd, target); err == nil && !strings.HasPrefix(rel, "..") {
+			cdHint = rel
+		}
+	}
+
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Created %s/ from %q template.\n", target, tmpl)
+	fmt.Fprintf(out, "Created %s from %q template.\n", target, tmpl)
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Next steps:")
-	fmt.Fprintf(out, "  cd %s\n", filepath.Base(target))
+	fmt.Fprintf(out, "  cd %s\n", cdHint)
 	fmt.Fprintln(out, "  uv sync")
 	fmt.Fprintln(out, "  duragraph dev --watch ./agents")
 	return nil

--- a/cmd/duragraph/cmd/init.go
+++ b/cmd/duragraph/cmd/init.go
@@ -1,22 +1,85 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
-// initCmd scaffolds a new duragraph project. Stub for now — template
-// pull-from-duragraph-examples wiring lands in phase 6 of the v0.7
-// single-binary DX track (binary-modes.yml § migration.phasing.phase_6_init_template).
+	initpkg "github.com/duragraph/duragraph/internal/dev/init"
+	"github.com/spf13/cobra"
+)
+
+// initCmd scaffolds a new duragraph project from an embedded template.
+//
+// Implements binary-modes.yml § subcommands.duragraph_init (v0.7 Phase 6
+// of the single-binary DX track). Templates ship inside the binary via
+// //go:embed in internal/dev/init — the scaffold operation is offline.
+//
+// The duragraph.yaml shape written into the new project is invented by
+// this PR (the spec only says "graph paths, worker config" without
+// prescribing fields). A future spec PR can codify the schema; until
+// then the format is intentionally minimal.
 var initCmd = &cobra.Command{
 	Use:   "init <project-name>",
-	Short: "Scaffold a new duragraph project (stub — not yet implemented)",
-	Long: `Create a new duragraph project directory with starter agent code, project
-config, and run instructions.
+	Short: "Scaffold a new duragraph project",
+	Long: `Create a new duragraph project directory with starter agent code,
+project config, and run instructions.
 
-Templates: hello-world | chatbot | rag | tool-use (pulled from duragraph-examples/python).
+Templates: hello-world | chatbot | rag | tool-use
 
-Not yet implemented. Tracking phase 6 of binary-modes.yml § migration.phasing.`,
-	RunE: notYetImplemented("init"),
+By default the project is scaffolded into ./<project-name>; pass --dir
+to override. The target directory must not exist or must be empty.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runInit,
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	tmpl, _ := cmd.Flags().GetString("template")
+	target, _ := cmd.Flags().GetString("dir")
+
+	if target == "" {
+		// Default to ./<project-name> resolved against PWD so the
+		// printed message can show an absolute path back to the user.
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get working directory: %w", err)
+		}
+		target = filepath.Join(cwd, name)
+	} else if !filepath.IsAbs(target) {
+		// Resolve relative --dir against PWD so the package's "absolute
+		// path" requirement is satisfied without surprising the user.
+		abs, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("resolve --dir %q: %w", target, err)
+		}
+		target = abs
+	}
+
+	if err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: name,
+		Template:    tmpl,
+		TargetDir:   target,
+	}); err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Created %s/ from %q template.\n", target, tmpl)
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Next steps:")
+	fmt.Fprintf(out, "  cd %s\n", filepath.Base(target))
+	fmt.Fprintln(out, "  uv sync")
+	fmt.Fprintln(out, "  duragraph dev --watch ./agents")
+	return nil
 }
 
 func init() {
+	initCmd.Flags().StringP("template", "t", "hello-world",
+		fmt.Sprintf("Template to scaffold from (%s)",
+			strings.Join(initpkg.ListTemplates(), "|")))
+	initCmd.Flags().StringP("dir", "d", "",
+		"Target directory (default ./<project-name>)")
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/dev/init/init.go
+++ b/internal/dev/init/init.go
@@ -1,0 +1,214 @@
+// Package initpkg scaffolds new duragraph projects from embedded templates.
+//
+// The Go package name is `initpkg` rather than `init` because `init` is a
+// special identifier (every Go package has implicit `init()` functions),
+// and using it as a package name shadows that keyword inside callers.
+// The on-disk directory is still `internal/dev/init/` to match the
+// "duragraph init" subcommand it implements.
+//
+// Implements binary-modes.yml § subcommands.duragraph_init (v0.7 Phase 6
+// of the single-binary DX track). Templates are embedded at build time via
+// //go:embed so the binary is self-contained — no GitHub fetch at runtime.
+//
+// Each template is a minimal, runnable scaffold mirroring the canonical
+// example in duragraph-examples/python/. The intent is "starter you'd
+// edit", not "production reference" — keep templates small.
+//
+// Files ending in `.tmpl` are rendered through text/template with the
+// project name available as `{{.ProjectName}}`. The `.tmpl` extension is
+// stripped on output. All other files are copied verbatim. Directory
+// structure under `templates/<name>/` is preserved 1:1 in the target.
+package initpkg
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+// templates holds the embedded scaffold sources. The `all:` prefix is
+// required so dotfiles and underscored files (none today, but future
+// .gitignore etc.) get included.
+//
+//go:embed all:templates
+var templates embed.FS
+
+// Options controls a single Scaffold invocation.
+type Options struct {
+	// ProjectName is the user-supplied identifier for the new project.
+	// Validated as PEP-503-ish: lowercase letters/digits/dashes, must
+	// not start with a digit or dash, ≤64 chars. Used in rendered files
+	// (pyproject name, README title, duragraph.yaml project.name).
+	ProjectName string
+
+	// Template selects the scaffold variant. Must be one of the values
+	// returned by ListTemplates(). Defaults are the caller's job (the
+	// CLI defaults to "hello-world").
+	Template string
+
+	// TargetDir is the absolute directory the scaffold is written into.
+	// May be a non-existent path (will be created) or an existing empty
+	// directory. Non-empty existing directories are rejected.
+	TargetDir string
+}
+
+// projectNamePattern is the validation regex for ProjectName: lowercase
+// letters/digits/dashes, must start with a letter, ≤64 chars total.
+// Underscores are intentionally rejected — the value flows into a
+// pyproject.toml `name` field, where PEP-503 normalizes underscores to
+// dashes anyway, so we just reject upfront for clarity.
+var projectNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+
+// ListTemplates returns the whitelist of supported template names, in
+// stable order. The CLI uses this for both --template validation and
+// the help string.
+func ListTemplates() []string {
+	return []string{"hello-world", "chatbot", "rag", "tool-use"}
+}
+
+// Scaffold writes a new project tree to opts.TargetDir using the
+// embedded template selected by opts.Template. Returns a clear error on
+// any validation failure or filesystem mishap; partial scaffolds are
+// NOT cleaned up automatically (the caller can `rm -rf` if needed —
+// matching `cargo new` / `npm init` behaviour).
+func Scaffold(opts Options) error {
+	if err := validateProjectName(opts.ProjectName); err != nil {
+		return err
+	}
+	if err := validateTemplate(opts.Template); err != nil {
+		return err
+	}
+	if opts.TargetDir == "" {
+		return errors.New("target directory must not be empty")
+	}
+	if err := validateTargetDir(opts.TargetDir); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(opts.TargetDir, 0o755); err != nil {
+		return fmt.Errorf("create target directory: %w", err)
+	}
+
+	root := path("templates", opts.Template)
+	data := struct{ ProjectName string }{ProjectName: opts.ProjectName}
+
+	walkErr := fs.WalkDir(templates, root, func(srcPath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		// Compute the path inside the project tree by stripping the
+		// embed prefix `templates/<template>/`.
+		rel, err := filepath.Rel(root, srcPath)
+		if err != nil {
+			return fmt.Errorf("compute relative path for %q: %w", srcPath, err)
+		}
+		if rel == "." {
+			// Root of the embedded template — TargetDir already exists.
+			return nil
+		}
+
+		dstPath := filepath.Join(opts.TargetDir, strings.TrimSuffix(rel, ".tmpl"))
+
+		if d.IsDir() {
+			if err := os.MkdirAll(dstPath, 0o755); err != nil {
+				return fmt.Errorf("mkdir %q: %w", dstPath, err)
+			}
+			return nil
+		}
+
+		raw, err := templates.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("read embedded template %q: %w", srcPath, err)
+		}
+
+		var out []byte
+		if strings.HasSuffix(srcPath, ".tmpl") {
+			tmpl, err := template.New(filepath.Base(srcPath)).Parse(string(raw))
+			if err != nil {
+				return fmt.Errorf("parse template %q: %w", srcPath, err)
+			}
+			var buf strings.Builder
+			if err := tmpl.Execute(&buf, data); err != nil {
+				return fmt.Errorf("render template %q: %w", srcPath, err)
+			}
+			out = []byte(buf.String())
+		} else {
+			out = raw
+		}
+
+		if err := os.WriteFile(dstPath, out, 0o644); err != nil {
+			return fmt.Errorf("write %q: %w", dstPath, err)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	return nil
+}
+
+// validateProjectName enforces the PEP-503-ish naming rule documented
+// on Options.ProjectName. The error message is shown verbatim to the
+// user, so it explains the rule rather than just saying "invalid".
+func validateProjectName(name string) error {
+	if name == "" {
+		return errors.New("project name must not be empty")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("project name %q is longer than 64 characters", name)
+	}
+	if !projectNamePattern.MatchString(name) {
+		return fmt.Errorf(
+			"project name %q is invalid: must start with a lowercase letter and "+
+				"contain only lowercase letters, digits, and dashes",
+			name,
+		)
+	}
+	return nil
+}
+
+// validateTemplate checks that the requested template is in the
+// whitelist. Phrased as "unknown template" so the error reads like
+// `cargo new --vcs <bad>` ("invalid value …").
+func validateTemplate(name string) error {
+	for _, t := range ListTemplates() {
+		if t == name {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"unknown template %q. Supported: %s",
+		name,
+		strings.Join(ListTemplates(), ", "),
+	)
+}
+
+// validateTargetDir rejects an existing non-empty directory; missing
+// paths and empty existing directories are both accepted.
+func validateTargetDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect target directory %q: %w", dir, err)
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("target directory %q exists and is non-empty", dir)
+	}
+	return nil
+}
+
+// path joins embed.FS path segments. We deliberately use forward
+// slashes (not filepath.Join) because embed.FS paths are always
+// slash-separated, even on Windows.
+func path(parts ...string) string {
+	return strings.Join(parts, "/")
+}

--- a/internal/dev/init/init.go
+++ b/internal/dev/init/init.go
@@ -129,7 +129,14 @@ func Scaffold(opts Options) error {
 
 		var out []byte
 		if strings.HasSuffix(srcPath, ".tmpl") {
-			tmpl, err := template.New(filepath.Base(srcPath)).Parse(string(raw))
+			// missingkey=error turns silent `<no value>` substitution into
+			// a hard failure. Without it, a typo like {{.Projct}} would
+			// emit a broken file with no warning to either the user or
+			// the maintainer of the template; with it, scaffolding fails
+			// loudly with the file path that needs fixing.
+			tmpl, err := template.New(filepath.Base(srcPath)).
+				Option("missingkey=error").
+				Parse(string(raw))
 			if err != nil {
 				return fmt.Errorf("parse template %q: %w", srcPath, err)
 			}

--- a/internal/dev/init/init_test.go
+++ b/internal/dev/init/init_test.go
@@ -1,0 +1,239 @@
+package initpkg_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	initpkg "github.com/duragraph/duragraph/internal/dev/init"
+)
+
+func TestListTemplates_ReturnsWhitelist(t *testing.T) {
+	got := initpkg.ListTemplates()
+	want := []string{"hello-world", "chatbot", "rag", "tool-use"}
+	if len(got) != len(want) {
+		t.Fatalf("ListTemplates() returned %d entries, want %d (%v)", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Errorf("ListTemplates()[%d] = %q, want %q", i, got[i], name)
+		}
+	}
+}
+
+func TestScaffold_HelloWorld_CreatesExpectedFiles(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "myproj")
+	if err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: "myproj",
+		Template:    "hello-world",
+		TargetDir:   target,
+	}); err != nil {
+		t.Fatalf("Scaffold returned error: %v", err)
+	}
+
+	// Required files; none of these should be empty.
+	required := []string{
+		"duragraph.yaml",
+		"pyproject.toml",
+		"README.md",
+		filepath.Join("agents", "hello.py"),
+	}
+	for _, rel := range required {
+		full := filepath.Join(target, rel)
+		info, err := os.Stat(full)
+		if err != nil {
+			t.Errorf("expected %s to exist: %v", rel, err)
+			continue
+		}
+		if info.IsDir() {
+			t.Errorf("expected %s to be a file, got directory", rel)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("expected %s to be non-empty", rel)
+		}
+		// .tmpl extension must be stripped on output.
+		if strings.HasSuffix(full, ".tmpl") {
+			t.Errorf("output file %s should not have .tmpl suffix", full)
+		}
+	}
+
+	// No stray .tmpl files should leak into the output.
+	walkErr := filepath.Walk(target, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".tmpl") {
+			t.Errorf("found .tmpl file in scaffold output: %s", path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk error: %v", walkErr)
+	}
+}
+
+func TestScaffold_AllTemplatesProduceCoreFiles(t *testing.T) {
+	for _, tmpl := range initpkg.ListTemplates() {
+		tmpl := tmpl
+		t.Run(tmpl, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "proj-"+tmpl)
+			if err := initpkg.Scaffold(initpkg.Options{
+				ProjectName: "proj-" + strings.ReplaceAll(tmpl, "-", ""),
+				Template:    tmpl,
+				TargetDir:   target,
+			}); err != nil {
+				t.Fatalf("Scaffold(%s) error: %v", tmpl, err)
+			}
+			for _, rel := range []string{"duragraph.yaml", "pyproject.toml", "README.md"} {
+				if _, err := os.Stat(filepath.Join(target, rel)); err != nil {
+					t.Errorf("[%s] missing %s: %v", tmpl, rel, err)
+				}
+			}
+			// Each template must ship at least one .py under agents/.
+			agentsDir := filepath.Join(target, "agents")
+			entries, err := os.ReadDir(agentsDir)
+			if err != nil {
+				t.Fatalf("[%s] read agents/: %v", tmpl, err)
+			}
+			pyFound := false
+			for _, e := range entries {
+				if strings.HasSuffix(e.Name(), ".py") {
+					pyFound = true
+					break
+				}
+			}
+			if !pyFound {
+				t.Errorf("[%s] no .py file in agents/", tmpl)
+			}
+		})
+	}
+}
+
+func TestScaffold_RejectsBadTemplate(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "proj")
+	err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: "proj",
+		Template:    "does-not-exist",
+		TargetDir:   target,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown template, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown template") {
+		t.Errorf("error %q does not mention 'unknown template'", err)
+	}
+}
+
+func TestScaffold_RejectsBadProjectName(t *testing.T) {
+	cases := []struct {
+		name    string
+		project string
+	}{
+		{"empty", ""},
+		{"digit-start", "1proj"},
+		{"dash-start", "-proj"},
+		{"uppercase", "Proj"},
+		{"underscore", "my_proj"},
+		{"space", "my proj"},
+		{"too-long", strings.Repeat("a", 65)},
+		{"special", "proj!"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "out")
+			err := initpkg.Scaffold(initpkg.Options{
+				ProjectName: tc.project,
+				Template:    "hello-world",
+				TargetDir:   target,
+			})
+			if err == nil {
+				t.Fatalf("expected error for project name %q, got nil", tc.project)
+			}
+		})
+	}
+}
+
+func TestScaffold_RejectsNonEmptyTargetDir(t *testing.T) {
+	target := t.TempDir()
+	// Drop a sentinel file so the dir is non-empty.
+	if err := os.WriteFile(filepath.Join(target, "preexisting"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: "proj",
+		Template:    "hello-world",
+		TargetDir:   target,
+	})
+	if err == nil {
+		t.Fatal("expected error for non-empty target dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-empty") {
+		t.Errorf("error %q does not mention 'non-empty'", err)
+	}
+}
+
+func TestScaffold_AcceptsMissingTargetDir(t *testing.T) {
+	// Missing path should be created.
+	target := filepath.Join(t.TempDir(), "missing", "nested", "proj")
+	if err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: "proj",
+		Template:    "hello-world",
+		TargetDir:   target,
+	}); err != nil {
+		t.Fatalf("Scaffold to missing dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "duragraph.yaml")); err != nil {
+		t.Errorf("missing scaffolded file: %v", err)
+	}
+}
+
+func TestScaffold_AcceptsEmptyExistingTargetDir(t *testing.T) {
+	target := t.TempDir() // empty tempdir
+	if err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: "proj",
+		Template:    "hello-world",
+		TargetDir:   target,
+	}); err != nil {
+		t.Fatalf("Scaffold into empty dir: %v", err)
+	}
+}
+
+func TestScaffold_TemplateRenderingSubstitutesProjectName(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "out")
+	const projectName = "cool-proj"
+	if err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: projectName,
+		Template:    "hello-world",
+		TargetDir:   target,
+	}); err != nil {
+		t.Fatalf("Scaffold: %v", err)
+	}
+
+	for _, rel := range []string{"pyproject.toml", "README.md", "duragraph.yaml"} {
+		body, err := os.ReadFile(filepath.Join(target, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !strings.Contains(string(body), projectName) {
+			t.Errorf("%s does not contain project name %q. Body:\n%s", rel, projectName, body)
+		}
+		// No raw `{{.ProjectName}}` markers should remain.
+		if strings.Contains(string(body), "{{") {
+			t.Errorf("%s still contains template markers (`{{`):\n%s", rel, body)
+		}
+	}
+}
+
+func TestScaffold_RejectsEmptyTargetDir(t *testing.T) {
+	err := initpkg.Scaffold(initpkg.Options{
+		ProjectName: "proj",
+		Template:    "hello-world",
+		TargetDir:   "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty TargetDir, got nil")
+	}
+}

--- a/internal/dev/init/init_test.go
+++ b/internal/dev/init/init_test.go
@@ -5,9 +5,31 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"text/template"
 
 	initpkg "github.com/duragraph/duragraph/internal/dev/init"
 )
+
+// TestTemplateRendering_FailsOnMissingKey is a unit-level guard for the
+// `missingkey=error` option used inside Scaffold's text/template setup.
+// It exists so a future refactor that drops the option (e.g. via an
+// extracted helper) gets caught immediately. We test the option at the
+// text/template level rather than via Scaffold because the embedded
+// templates are intentionally typo-free; the package-internal contract
+// is "every template parsed by this package uses missingkey=error".
+func TestTemplateRendering_FailsOnMissingKey(t *testing.T) {
+	tmpl, err := template.New("typo.tmpl").
+		Option("missingkey=error").
+		Parse(`hello {{.NotAField}}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	data := struct{ ProjectName string }{ProjectName: "x"}
+	var sink strings.Builder
+	if err := tmpl.Execute(&sink, data); err == nil {
+		t.Fatalf("expected execute to fail on missing key, got output %q", sink.String())
+	}
+}
 
 func TestListTemplates_ReturnsWhitelist(t *testing.T) {
 	got := initpkg.ListTemplates()

--- a/internal/dev/init/templates/chatbot/README.md.tmpl
+++ b/internal/dev/init/templates/chatbot/README.md.tmpl
@@ -1,0 +1,29 @@
+# {{.ProjectName}}
+
+A duragraph project, scaffolded from the `chatbot` template.
+
+## Quick start
+
+```bash
+uv sync
+duragraph dev --watch ./agents
+```
+
+Set an OpenAI key for a real LLM reply (otherwise the bot echoes):
+
+```bash
+export OPENAI_API_KEY=sk-...
+duragraph dev --watch ./agents
+```
+
+## What's here
+
+- `agents/chatbot.py` — single-node `@Graph` that takes either Studio
+  `{"messages": [...]}` or curl-style `{"input": "..."}` and replies.
+- `duragraph.yaml` — project config (graph dir, worker command).
+- `pyproject.toml` — Python deps managed by `uv`.
+
+## Next steps
+
+- Add memory (per-thread history) — see `duragraph-examples/python/02-chatbot`.
+- Add tool use — see `duragraph-examples/python/06-tool-use`.

--- a/internal/dev/init/templates/chatbot/agents/chatbot.py
+++ b/internal/dev/init/templates/chatbot/agents/chatbot.py
@@ -1,0 +1,46 @@
+"""Minimal chatbot graph. Accepts both LangChain/Studio message shape
+and a legacy {"input": "..."} shape.
+
+Set OPENAI_API_KEY to use a real LLM; otherwise a rule-based responder
+is used so the demo runs offline.
+"""
+
+import os
+
+from duragraph import Graph, entrypoint, node
+
+
+@Graph(id="chatbot", description="Minimal echo/LLM chatbot")
+class Chatbot:
+    @entrypoint
+    @node()
+    async def respond(self, state: dict) -> dict:
+        # Studio sends {"messages": [{role, content}, ...]}; curl demos
+        # often send {"input": "..."}. Support both.
+        messages = state.get("messages") or []
+        if messages:
+            user_text = messages[-1].get("content", "")
+        else:
+            user_text = state.get("input", "")
+
+        if not os.getenv("OPENAI_API_KEY"):
+            state["response"] = f"You said: {user_text!r}. (Set OPENAI_API_KEY for an LLM reply.)"
+            return state
+
+        # Real LLM path — kept tiny on purpose. Extend with system
+        # prompts, tools, etc. as needed.
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI()
+        resp = await client.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            messages=[{"role": "user", "content": user_text}],
+        )
+        state["response"] = resp.choices[0].message.content or ""
+        return state
+
+
+if __name__ == "__main__":
+    agent = Chatbot()
+    control_plane = os.getenv("DURAGRAPH_URL", "http://localhost:8081")
+    agent.serve(control_plane, worker_name="chatbot-worker")

--- a/internal/dev/init/templates/chatbot/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/chatbot/duragraph.yaml.tmpl
@@ -1,4 +1,12 @@
 # {{.ProjectName}} — duragraph project config
+#
+# This file is currently NOT read by the duragraph binary. It's a
+# placeholder for future project-level configuration (graph paths,
+# worker command, etc.). Treat it as documentation for now.
+#
+# When duragraph adds project-config support, this schema will be
+# specified in duragraph-spec/backend/. Until then, the keys below
+# are advisory.
 
 project:
   name: {{.ProjectName}}

--- a/internal/dev/init/templates/chatbot/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/chatbot/duragraph.yaml.tmpl
@@ -1,0 +1,11 @@
+# {{.ProjectName}} — duragraph project config
+
+project:
+  name: {{.ProjectName}}
+
+agents:
+  dir: ./agents
+  language: python
+
+worker:
+  command: ["uv", "run", "python", "agents/chatbot.py"]

--- a/internal/dev/init/templates/chatbot/pyproject.toml.tmpl
+++ b/internal/dev/init/templates/chatbot/pyproject.toml.tmpl
@@ -1,0 +1,12 @@
+[project]
+name = "{{.ProjectName}}"
+version = "0.1.0"
+description = "A duragraph chatbot project."
+requires-python = ">=3.11"
+dependencies = [
+    "duragraph>=0.7.0",
+    "openai>=1.40.0",
+]
+
+[tool.uv]
+package = false

--- a/internal/dev/init/templates/hello-world/README.md.tmpl
+++ b/internal/dev/init/templates/hello-world/README.md.tmpl
@@ -1,0 +1,34 @@
+# {{.ProjectName}}
+
+A duragraph project, scaffolded from the `hello-world` template.
+
+## Quick start
+
+```bash
+# Install Python deps (uv-managed)
+uv sync
+
+# Run the engine + dashboard, watch ./agents, and supervise the worker.
+# This is the recommended dev loop — the worker hot-reloads on file changes.
+duragraph dev --watch ./agents
+```
+
+You can also run a single graph standalone (no engine), useful for unit
+work on the graph itself:
+
+```bash
+uv run python agents/hello.py
+```
+
+## What's here
+
+- `agents/hello.py` — the starter `@Graph`. Edit it, save, and `duragraph
+  dev` will reload.
+- `duragraph.yaml` — project config (graph dir, worker command).
+- `pyproject.toml` — Python dependencies, managed by `uv`.
+
+## Next steps
+
+- Add more nodes to the graph in `agents/hello.py`.
+- Add more graphs as new files in `agents/`.
+- Hit the engine's REST API at <http://localhost:8081> to invoke runs.

--- a/internal/dev/init/templates/hello-world/agents/hello.py
+++ b/internal/dev/init/templates/hello-world/agents/hello.py
@@ -1,0 +1,25 @@
+"""Minimal hello-world graph. Edit this file and `duragraph dev` will
+hot-reload the worker automatically.
+"""
+
+import os
+
+from duragraph import Graph, entrypoint, node
+
+
+@Graph(id="hello_world")
+class HelloWorld:
+    """A graph that greets whatever name you pass in."""
+
+    @entrypoint
+    @node()
+    async def greet(self, state: dict) -> dict:
+        name = state.get("name", "world")
+        state["greeting"] = f"Hello, {name}!"
+        return state
+
+
+if __name__ == "__main__":
+    agent = HelloWorld()
+    control_plane = os.getenv("DURAGRAPH_URL", "http://localhost:8081")
+    agent.serve(control_plane, worker_name="hello-world-worker")

--- a/internal/dev/init/templates/hello-world/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/hello-world/duragraph.yaml.tmpl
@@ -1,7 +1,12 @@
 # {{.ProjectName}} — duragraph project config
 #
-# Schema is intentionally minimal in v0.7. Future versions of duragraph-spec
-# may codify additional fields; until then, only the keys below are read.
+# This file is currently NOT read by the duragraph binary. It's a
+# placeholder for future project-level configuration (graph paths,
+# worker command, etc.). Treat it as documentation for now.
+#
+# When duragraph adds project-config support, this schema will be
+# specified in duragraph-spec/backend/. Until then, the keys below
+# are advisory.
 
 project:
   name: {{.ProjectName}}

--- a/internal/dev/init/templates/hello-world/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/hello-world/duragraph.yaml.tmpl
@@ -1,0 +1,14 @@
+# {{.ProjectName}} — duragraph project config
+#
+# Schema is intentionally minimal in v0.7. Future versions of duragraph-spec
+# may codify additional fields; until then, only the keys below are read.
+
+project:
+  name: {{.ProjectName}}
+
+agents:
+  dir: ./agents
+  language: python
+
+worker:
+  command: ["uv", "run", "python", "agents/hello.py"]

--- a/internal/dev/init/templates/hello-world/pyproject.toml.tmpl
+++ b/internal/dev/init/templates/hello-world/pyproject.toml.tmpl
@@ -1,0 +1,11 @@
+[project]
+name = "{{.ProjectName}}"
+version = "0.1.0"
+description = "A duragraph project scaffolded from the hello-world template."
+requires-python = ">=3.11"
+dependencies = [
+    "duragraph>=0.7.0",
+]
+
+[tool.uv]
+package = false

--- a/internal/dev/init/templates/rag/README.md.tmpl
+++ b/internal/dev/init/templates/rag/README.md.tmpl
@@ -1,0 +1,27 @@
+# {{.ProjectName}}
+
+A duragraph project, scaffolded from the `rag` template.
+
+## Quick start
+
+```bash
+uv sync
+duragraph dev --watch ./agents
+```
+
+The starter uses an in-memory vector store and a toy embedder so it
+works offline. Swap them out for real embeddings + Qdrant when you're
+ready.
+
+## What's here
+
+- `agents/rag.py` — `ingest >> retrieve` graph over a 3-sentence KB.
+- `duragraph.yaml` — project config.
+- `pyproject.toml` — Python deps managed by `uv`.
+
+## Next steps
+
+- Replace `SimpleEmbedding` with `OpenAIEmbeddingProvider`.
+- Replace `InMemoryVectorStore` with `QdrantVectorStore`.
+- Add an LLM `generate_response` node — see
+  `duragraph-examples/python/03-rag-agent`.

--- a/internal/dev/init/templates/rag/agents/rag.py
+++ b/internal/dev/init/templates/rag/agents/rag.py
@@ -1,0 +1,67 @@
+"""Minimal retrieval-augmented generation (RAG) graph.
+
+Uses an in-memory vector store and a hash-based embedder so the demo
+runs with zero external services. Replace `SimpleEmbedding` and
+`InMemoryVectorStore` with real backends (OpenAI embeddings + Qdrant)
+in production.
+"""
+
+import os
+
+from duragraph import Graph, entrypoint, node
+from duragraph.vectorstores.base import Document
+from duragraph.vectorstores.memory import InMemoryVectorStore
+
+
+class SimpleEmbedding:
+    """Bag-of-words embedding for offline demos."""
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed(text)
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed(t) for t in texts]
+
+    def _embed(self, text: str) -> list[float]:
+        vec = [0.0] * 128
+        for w in text.lower().split():
+            vec[hash(w) % 128] += 1.0
+        return vec
+
+
+KB = [
+    "DuraGraph orchestrates AI workflows with event sourcing and CQRS.",
+    "Graphs are defined with @Graph and connected nodes via the >> operator.",
+    "Workers register with the control plane and poll for runs to execute.",
+]
+
+store = InMemoryVectorStore(embedding_function=SimpleEmbedding())
+
+
+@Graph(id="rag", description="Retrieval-augmented generation over an in-memory KB")
+class RAG:
+    @entrypoint
+    @node()
+    async def ingest(self, state: dict) -> dict:
+        if not state.get("_ingested"):
+            await store.aadd_documents([Document(page_content=d) for d in KB])
+            state["_ingested"] = True
+        return state
+
+    @node()
+    async def retrieve(self, state: dict) -> dict:
+        query = state.get("query") or ""
+        if not query and (msgs := state.get("messages") or []):
+            query = next((m["content"] for m in reversed(msgs) if m.get("role") == "user"), "")
+        results = await store.asimilarity_search(query, k=2) if query else []
+        state["context"] = "\n".join(d.page_content for d in results)
+        state["response"] = f"Q: {query}\nContext:\n{state['context']}" if query else "(no query)"
+        return state
+
+    ingest >> retrieve
+
+
+if __name__ == "__main__":
+    agent = RAG()
+    control_plane = os.getenv("DURAGRAPH_URL", "http://localhost:8081")
+    agent.serve(control_plane, worker_name="rag-worker")

--- a/internal/dev/init/templates/rag/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/rag/duragraph.yaml.tmpl
@@ -1,4 +1,12 @@
 # {{.ProjectName}} — duragraph project config
+#
+# This file is currently NOT read by the duragraph binary. It's a
+# placeholder for future project-level configuration (graph paths,
+# worker command, etc.). Treat it as documentation for now.
+#
+# When duragraph adds project-config support, this schema will be
+# specified in duragraph-spec/backend/. Until then, the keys below
+# are advisory.
 
 project:
   name: {{.ProjectName}}

--- a/internal/dev/init/templates/rag/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/rag/duragraph.yaml.tmpl
@@ -1,0 +1,11 @@
+# {{.ProjectName}} — duragraph project config
+
+project:
+  name: {{.ProjectName}}
+
+agents:
+  dir: ./agents
+  language: python
+
+worker:
+  command: ["uv", "run", "python", "agents/rag.py"]

--- a/internal/dev/init/templates/rag/pyproject.toml.tmpl
+++ b/internal/dev/init/templates/rag/pyproject.toml.tmpl
@@ -1,0 +1,11 @@
+[project]
+name = "{{.ProjectName}}"
+version = "0.1.0"
+description = "A duragraph RAG project."
+requires-python = ">=3.11"
+dependencies = [
+    "duragraph>=0.7.0",
+]
+
+[tool.uv]
+package = false

--- a/internal/dev/init/templates/tool-use/README.md.tmpl
+++ b/internal/dev/init/templates/tool-use/README.md.tmpl
@@ -1,0 +1,23 @@
+# {{.ProjectName}}
+
+A duragraph project, scaffolded from the `tool-use` template.
+
+## Quick start
+
+```bash
+uv sync
+duragraph dev --watch ./agents
+```
+
+## What's here
+
+- `agents/tools_agent.py` — two `@tool` functions plus a `prepare >>
+  run_tools >> synthesize` pipeline that picks a tool by keyword.
+- `duragraph.yaml` — project config.
+- `pyproject.toml` — Python deps managed by `uv`.
+
+## Next steps
+
+- Add more `@tool` functions; the registry auto-discovers them.
+- Replace the keyword router with `@llm_node(tools=[...])` so the LLM
+  decides which tool to call. See `duragraph-examples/python/06-tool-use`.

--- a/internal/dev/init/templates/tool-use/agents/tools_agent.py
+++ b/internal/dev/init/templates/tool-use/agents/tools_agent.py
@@ -1,0 +1,55 @@
+"""Minimal tool-use graph. Demonstrates @tool registration and a
+prepare → run_tools → synthesize pipeline.
+
+Extend by adding more @tool functions and routing on the user query.
+"""
+
+import os
+
+from duragraph import Graph, entrypoint, node, tool, tool_node
+
+
+@tool(description="Add two numbers.")
+def add(a: float, b: float) -> str:
+    return f"{a} + {b} = {a + b}"
+
+
+@tool(description="Echo a string back, uppercased.")
+def shout(text: str) -> str:
+    return text.upper()
+
+
+@Graph(id="tools_agent", description="Tiny agent that picks a tool by keyword")
+class ToolsAgent:
+    @entrypoint
+    @node()
+    async def prepare(self, state: dict) -> dict:
+        msgs = state.get("messages") or []
+        user = state.get("input") or (msgs[-1].get("content", "") if msgs else "")
+        state["input"] = user
+        state["tools_used"] = []
+        return state
+
+    @tool_node()
+    async def run_tools(self, state: dict) -> dict:
+        q = state.get("input", "").lower()
+        if "add" in q or "+" in q:
+            state["tool_results"] = [add(1, 2)]
+            state["tools_used"].append("add")
+        else:
+            state["tool_results"] = [shout(state.get("input", ""))]
+            state["tools_used"].append("shout")
+        return state
+
+    @node()
+    async def synthesize(self, state: dict) -> dict:
+        state["response"] = "\n".join(state.get("tool_results", []))
+        return state
+
+    prepare >> run_tools >> synthesize
+
+
+if __name__ == "__main__":
+    agent = ToolsAgent()
+    control_plane = os.getenv("DURAGRAPH_URL", "http://localhost:8081")
+    agent.serve(control_plane, worker_name="tools-worker")

--- a/internal/dev/init/templates/tool-use/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/tool-use/duragraph.yaml.tmpl
@@ -1,4 +1,12 @@
 # {{.ProjectName}} — duragraph project config
+#
+# This file is currently NOT read by the duragraph binary. It's a
+# placeholder for future project-level configuration (graph paths,
+# worker command, etc.). Treat it as documentation for now.
+#
+# When duragraph adds project-config support, this schema will be
+# specified in duragraph-spec/backend/. Until then, the keys below
+# are advisory.
 
 project:
   name: {{.ProjectName}}

--- a/internal/dev/init/templates/tool-use/duragraph.yaml.tmpl
+++ b/internal/dev/init/templates/tool-use/duragraph.yaml.tmpl
@@ -1,0 +1,11 @@
+# {{.ProjectName}} — duragraph project config
+
+project:
+  name: {{.ProjectName}}
+
+agents:
+  dir: ./agents
+  language: python
+
+worker:
+  command: ["uv", "run", "python", "agents/tools_agent.py"]

--- a/internal/dev/init/templates/tool-use/pyproject.toml.tmpl
+++ b/internal/dev/init/templates/tool-use/pyproject.toml.tmpl
@@ -1,0 +1,11 @@
+[project]
+name = "{{.ProjectName}}"
+version = "0.1.0"
+description = "A duragraph tool-use project."
+requires-python = ">=3.11"
+dependencies = [
+    "duragraph>=0.7.0",
+]
+
+[tool.uv]
+package = false


### PR DESCRIPTION
## Summary

Replaces the v0.7 Phase 1 stub of `duragraph init` with a real implementation that scaffolds a runnable Python project from one of four embedded templates. Implements `duragraph-spec/backend/binary-modes.yml § subcommands.duragraph_init`.

## Templates supported

Selected via `-t/--template` (default `hello-world`):

| Template      | Shape                                                |
|---------------|------------------------------------------------------|
| `hello-world` | single-node `@Graph`                                 |
| `chatbot`     | single-node responder, optional OpenAI backend       |
| `rag`         | `ingest >> retrieve` over an in-memory KB            |
| `tool-use`    | `@tool` registry + `prepare >> run_tools >> synthesize` |

## Scaffold output structure

Every template writes 4 files into `TargetDir` (default `./<project-name>`):

```
<project-name>/
├── agents/<name>.py   # minimal @Graph (≤25 lines per spec constraint)
├── duragraph.yaml     # project config
├── pyproject.toml     # uv-managed deps, pinned to duragraph>=0.7.0
└── README.md          # quick-start with `duragraph dev --watch ./agents`
```

## duragraph.yaml shape (invented, not yet specified)

The spec only says "project config — graph paths, worker config" without prescribing fields. This PR invents a minimal, additive shape:

```yaml
project:
  name: <name>
agents:
  dir: ./agents
  language: python
worker:
  command: ["uv", "run", "python", "agents/<name>.py"]
```

**Nothing in the engine reads this file today.** Consumption (e.g. `duragraph dev` discovering the worker command from `worker.command` rather than scanning for `@Graph(`) is a follow-up. A future spec PR can codify the schema; the format is kept minimal so it doesn't overcommit.

## Implementation notes

- `internal/dev/init/init.go` — public `Scaffold(Options) error` + `ListTemplates() []string`. Templates embedded via `//go:embed all:templates`, so the binary is self-contained (no GitHub fetch at runtime).
- `.tmpl` files render through `text/template` with `{{.ProjectName}}`; the extension is stripped on output. Plain files copy verbatim.
- Validation: `ProjectName` must match `^[a-z][a-z0-9-]{0,63}$` (PEP-503-ish — underscores rejected since pyproject.toml normalizes them anyway). `Template` must be in the whitelist. `TargetDir` must be missing or empty.
- Go package name is `initpkg` (dir is still `init/`) to avoid shadowing Go's special `init()` function.
- No auto-`uv sync`. Hint is printed at the end: `cd <name> && uv sync && duragraph dev --watch ./agents`.

## Manual smoke (verified locally)

```
go build -o /tmp/dg-init ./cmd/duragraph
mkdir /tmp/scaffold-test && cd /tmp/scaffold-test
/tmp/dg-init init demo --template hello-world
ls demo/        # should show: agents/  duragraph.yaml  pyproject.toml  README.md
cat demo/duragraph.yaml | head
rm -rf /tmp/scaffold-test
```

Output matches expectations; all four templates produce 4 files each.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/dev/init/... ./cmd/duragraph/... -count=1 -short` all green
- [x] Smoke: scaffold each of the 4 templates → expected 4 files each
- [x] Reject: bad template name, bad project name (digit-start, uppercase, underscore, special, too-long), non-empty target dir
- [x] Render: project name appears in `pyproject.toml`, `README.md`, `duragraph.yaml`; no raw `{{` markers leak through
- [ ] Follow-up PR: wire `duragraph dev` to read `duragraph.yaml`'s `worker.command` (out of scope here)