### PR TITLE
feat(cli): runs (tail/get/trigger) + events tail subcommands (v0.7 Phase 7)

### DIFF
--- a/cmd/duragraph/cmd/events.go
+++ b/cmd/duragraph/cmd/events.go
@@ -1,28 +1,95 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
-// eventsCmd is a subcommand group like `runs`. `events tail` is the
-// only child today; future PRs may add `events search` etc.
+	"github.com/duragraph/duragraph/internal/dev/cli"
+	"github.com/spf13/cobra"
+)
+
+// Phase 7 (binary-modes.yml § subcommands.duragraph_events): live-tail
+// the event-sourcing trail via NATS subscription.
+//
+// The CLI subscribes via core NATS (not JetStream) because the engine
+// publishes JetStream-backed messages that also fan out to plain
+// subscribers. Going through plain pub/sub means short-lived `events
+// tail` invocations don't leave durable consumer state on the broker —
+// matches the "live-only, best-effort" expectation for an interactive
+// inspector.
+
+var (
+	eventsTailNATSURL     string
+	eventsTailAggregate   string
+	eventsTailAggregateID string
+)
+
 var eventsCmd = &cobra.Command{
 	Use:   "events",
-	Short: "CLI access to the event sourcing trail (stub — not yet implemented)",
-	Long: `Inspect the immutable event log via NATS subscription.
-
-Not yet implemented. Tracking phase 7 of binary-modes.yml § migration.phasing.phase_7_runs_events_tail.`,
+	Short: "Inspect the event-sourcing trail",
+	Long: `events talks to NATS to live-tail or query the engine's domain event
+log. Phase 7 ships only the "tail" subcommand; future phases will add
+search/replay surfaces.`,
 }
 
 var eventsTailCmd = &cobra.Command{
 	Use:   "tail",
-	Short: "Live-tail the events table via NATS",
-	Long: `Subscribe to the event sourcing trail and print event_type + payload as
-they arrive. Optional filtering by aggregate type (run|thread|workflow) and id.
+	Short: "Live-tail the events table via NATS subscription",
+	Long: `Subscribe to the engine's NATS event subject and pretty-print each
+event envelope (event_type + payload) as it is published.
 
-Not yet implemented.`,
-	RunE: notYetImplemented("events tail"),
+Filter by aggregate type with --aggregate (run | execution | thread |
+workflow | tenant | user). Filter further by aggregate id with --id.
+
+The NATS URL defaults to nats://localhost:4222 and is overridable via
+$DURAGRAPH_NATS_URL or --nats. Press Ctrl+C to stop.`,
+	RunE: runEventsTail,
 }
 
 func init() {
+	eventsTailCmd.Flags().StringVar(&eventsTailNATSURL, "nats", "",
+		"NATS URL (defaults to $DURAGRAPH_NATS_URL or "+cli.DefaultNATSURL+")")
+	eventsTailCmd.Flags().StringVar(&eventsTailAggregate, "aggregate", "",
+		"Filter by aggregate type: run | execution | thread | workflow | tenant | user")
+	eventsTailCmd.Flags().StringVar(&eventsTailAggregateID, "id", "",
+		"Filter by aggregate id (applied client-side after subject filter)")
+
 	eventsCmd.AddCommand(eventsTailCmd)
 	rootCmd.AddCommand(eventsCmd)
+}
+
+func runEventsTail(cmd *cobra.Command, _ []string) error {
+	subject, err := cli.SubjectFor(eventsTailAggregate)
+	if err != nil {
+		return err
+	}
+
+	natsURL := eventsTailNATSURL
+	if natsURL == "" {
+		if v := os.Getenv("DURAGRAPH_NATS_URL"); v != "" {
+			natsURL = v
+		} else {
+			natsURL = cli.DefaultNATSURL
+		}
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(cmd.ErrOrStderr(), "tailing events via NATS %s subject=%s", natsURL, subject)
+	if eventsTailAggregateID != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), " id=%s", eventsTailAggregateID)
+	}
+	fmt.Fprintln(cmd.ErrOrStderr())
+
+	err = cli.SubscribeEvents(ctx, natsURL, subject, eventsTailAggregateID, func(env cli.EventEnvelope) error {
+		return cli.PrintEvent(out, env.EventType, env)
+	})
+	if err != nil && ctx.Err() == nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/duragraph/cmd/events.go
+++ b/cmd/duragraph/cmd/events.go
@@ -45,6 +45,7 @@ workflow | tenant | user). Filter further by aggregate id with --id.
 
 The NATS URL defaults to nats://localhost:4222 and is overridable via
 $DURAGRAPH_NATS_URL or --nats. Press Ctrl+C to stop.`,
+	Args: cobra.NoArgs,
 	RunE: runEventsTail,
 }
 

--- a/cmd/duragraph/cmd/runs.go
+++ b/cmd/duragraph/cmd/runs.go
@@ -1,48 +1,277 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
-// runsCmd is a subcommand group, not a leaf — `duragraph runs` with
-// no further argument should show the help block listing tail/get/
-// trigger. cobra does this by default when a parent command has no
-// Run / RunE.
+	"github.com/duragraph/duragraph/internal/dev/cli"
+	"github.com/spf13/cobra"
+)
+
+// Phase 7 (binary-modes.yml § subcommands.duragraph_runs) implementation.
+//
+// All four `runs *` subcommands are CLIENTS — they target a running
+// `duragraph serve` (or `duragraph dev`) instance over the network.
+// They never embed engine internals or open a database connection
+// directly, so they remain safe to ship in a CI image without DB drivers.
+//
+// Configuration:
+//   - DURAGRAPH_URL       — engine base URL (default http://localhost:8081),
+//                           overridable per-invocation via --engine.
+//   - DURAGRAPH_NATS_URL  — NATS URL for `runs tail` no-arg fallback
+//                           (default nats://localhost:4222), overridable via --nats.
+//
+// Default behaviour rationale: NATS-subscribing for "all threads" tail
+// rather than polling /api/v1/runs. The engine already publishes run
+// lifecycle events to the `duragraph.runs.run.>` subject family for
+// the SSE bridge — re-using that surface keeps latency near-zero and
+// avoids a separate poll loop. Engine SSE has no "all threads"
+// endpoint, so polling would be the only HTTP alternative.
+
+// Per-command flags. Defined as package vars rather than closure-captured
+// inside RunE so they show up in `--help` output the same way the rest
+// of this package does.
+var (
+	runsEngineURL      string
+	runsTriggerInput   string
+	runsTriggerWait    bool
+	runsTailNATSURL    string
+	runsTriggerThread  string // optional thread_id override; usually let server allocate
+	runsTriggerTimeout time.Duration
+)
+
 var runsCmd = &cobra.Command{
 	Use:   "runs",
-	Short: "CLI access to the runs API (stub — not yet implemented)",
-	Long: `Inspect, stream, and trigger runs via the duragraph control plane API.
+	Short: "Inspect, stream, and trigger runs via the engine API",
+	Long: `runs talks to a running duragraph engine over HTTP/SSE/NATS to inspect,
+stream, and trigger workflow runs. The engine URL defaults to
+http://localhost:8081 and is overridable via DURAGRAPH_URL or --engine.
 
-Not yet implemented. Tracking phase 7 of binary-modes.yml § migration.phasing.phase_7_runs_events_tail.`,
+This is a thin client — start the engine first with "duragraph serve"
+or "duragraph dev" in another terminal.`,
 }
 
 var runsTailCmd = &cobra.Command{
-	Use:   "tail [<thread_id>]",
+	Use:   "tail [thread_id]",
 	Short: "Stream new runs across all threads (or a single thread)",
-	Long: `Subscribe to the run-lifecycle SSE stream and print events as they happen.
+	Long: `Live-tail run lifecycle events.
 
-Not yet implemented.`,
-	RunE: notYetImplemented("runs tail"),
+With a thread_id argument, subscribes to the engine's per-thread SSE
+endpoint (/api/v1/threads/<thread_id>/stream). Without an argument,
+subscribes directly to the NATS run-event subject — the engine has no
+"all threads" SSE endpoint, so NATS is the only zero-latency option.
+
+Press Ctrl+C to stop.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRunsTail,
 }
 
 var runsGetCmd = &cobra.Command{
 	Use:   "get <run_id>",
 	Short: "Print a run's current state and output as JSON",
-	Long: `Fetch a single run by ID and print the full state + output as JSON.
-
-Not yet implemented.`,
-	RunE: notYetImplemented("runs get"),
+	Long: `Fetch a single run by ID via GET /api/v1/runs/<run_id> and pretty-print
+the response. Exits non-zero with a clear message if the run does not
+exist.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunsGet,
 }
 
 var runsTriggerCmd = &cobra.Command{
 	Use:   "trigger <assistant_id>",
 	Short: "Create a one-shot run against an assistant",
-	Long: `Create a stateless run with the given input. With --wait, block until
-the run reaches a terminal state and print the final output.
+	Long: `Create a stateless run via POST /api/v1/runs and print the engine's
+response (run_id, thread_id, status). The engine allocates an ephemeral
+thread automatically; pass --thread to attach the run to a specific
+thread instead.
 
-Not yet implemented.`,
-	RunE: notYetImplemented("runs trigger"),
+With --wait, polls the run until it reaches a terminal state
+(completed | failed | cancelled) and prints the final state. Without
+--wait, returns immediately after the run is queued.
+
+The --input flag must be a JSON object — it's validated client-side
+before sending so a typo doesn't cost a round-trip.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunsTrigger,
 }
 
 func init() {
+	runsCmd.PersistentFlags().StringVar(&runsEngineURL, "engine", "",
+		"Engine base URL (defaults to $DURAGRAPH_URL or "+cli.DefaultEngineURL+")")
+
+	runsTailCmd.Flags().StringVar(&runsTailNATSURL, "nats", "",
+		"NATS URL for no-arg tail (defaults to $DURAGRAPH_NATS_URL or "+cli.DefaultNATSURL+")")
+
+	runsTriggerCmd.Flags().StringVar(&runsTriggerInput, "input", "{}",
+		"Run input as a JSON object (default {})")
+	runsTriggerCmd.Flags().BoolVar(&runsTriggerWait, "wait", false,
+		"Block until the run reaches a terminal state and print the final state")
+	runsTriggerCmd.Flags().StringVar(&runsTriggerThread, "thread", "",
+		"Optional existing thread_id; if empty the engine allocates an ephemeral one")
+	runsTriggerCmd.Flags().DurationVar(&runsTriggerTimeout, "timeout", 5*time.Minute,
+		"Maximum duration to wait when --wait is set")
+
 	runsCmd.AddCommand(runsTailCmd, runsGetCmd, runsTriggerCmd)
 	rootCmd.AddCommand(runsCmd)
+}
+
+// resolveEngineURL picks the engine URL with the documented precedence:
+// --engine flag > $DURAGRAPH_URL > built-in default. Centralised so each
+// subcommand RunE doesn't reproduce the same lookup.
+func resolveEngineURL() string {
+	if runsEngineURL != "" {
+		return runsEngineURL
+	}
+	if v := os.Getenv("DURAGRAPH_URL"); v != "" {
+		return v
+	}
+	return cli.DefaultEngineURL
+}
+
+func resolveNATSURL(flagVal string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	if v := os.Getenv("DURAGRAPH_NATS_URL"); v != "" {
+		return v
+	}
+	return cli.DefaultNATSURL
+}
+
+// runRunsGet implements `duragraph runs get <run_id>`.
+func runRunsGet(cmd *cobra.Command, args []string) error {
+	runID := args[0]
+	c := cli.NewClient(resolveEngineURL())
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	body, err := c.GetRun(ctx, runID)
+	if err != nil {
+		if errors.Is(err, cli.ErrRunNotFound) {
+			return fmt.Errorf("run %s not found at %s", runID, c.EngineURL())
+		}
+		return err
+	}
+	// Re-decode → re-encode so the output is consistently indented
+	// regardless of how the engine formatted its body.
+	var v any
+	if err := json.Unmarshal(body, &v); err != nil {
+		// Fall back to printing raw — engine sent something we can't
+		// decode but the operator deserves to see it.
+		_, werr := fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return werr
+	}
+	return cli.PrintJSON(cmd.OutOrStdout(), v)
+}
+
+// runRunsTrigger implements `duragraph runs trigger <assistant_id>`.
+func runRunsTrigger(cmd *cobra.Command, args []string) error {
+	assistantID := args[0]
+
+	// Validate --input is a JSON object client-side. This catches the
+	// common operator typo (single-quote vs double-quote, missing
+	// braces) before the round-trip. Note: the engine's CreateRun
+	// expects an object specifically (input fields are merged with
+	// stream/interrupt config server-side), so a top-level JSON array
+	// or scalar is rejected here even though it would be parseable.
+	var input map[string]any
+	if err := json.Unmarshal([]byte(runsTriggerInput), &input); err != nil {
+		return fmt.Errorf("--input must be a JSON object: %w", err)
+	}
+
+	body := map[string]any{
+		"assistant_id": assistantID,
+		"input":        input,
+	}
+	if runsTriggerThread != "" {
+		body["thread_id"] = runsTriggerThread
+	}
+
+	c := cli.NewClient(resolveEngineURL())
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	resp, err := c.CreateRun(ctx, body)
+	if err != nil {
+		return err
+	}
+
+	// Always emit the trigger response on stderr first so an operator
+	// can see the run_id even if --wait is used and the long poll is
+	// still in flight when they hit Ctrl+C.
+	fmt.Fprintf(cmd.ErrOrStderr(), "queued run_id=%s thread_id=%s status=%s\n",
+		resp.RunID, resp.ThreadID, resp.Status)
+
+	if !runsTriggerWait {
+		// Fire-and-forget mode: print structured response on stdout
+		// for downstream tooling and exit.
+		return cli.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+
+	// --wait: long-poll the run until it terminates.
+	waitCtx, waitCancel := context.WithTimeout(cmd.Context(), runsTriggerTimeout)
+	defer waitCancel()
+
+	final, err := c.WaitForRun(waitCtx, resp.RunID, time.Second)
+	if err != nil {
+		return fmt.Errorf("wait for run %s: %w", resp.RunID, err)
+	}
+	var v any
+	if err := json.Unmarshal(final, &v); err != nil {
+		_, werr := fmt.Fprintln(cmd.OutOrStdout(), string(final))
+		return werr
+	}
+	return cli.PrintJSON(cmd.OutOrStdout(), v)
+}
+
+// runRunsTail implements `duragraph runs tail [thread_id]`.
+func runRunsTail(cmd *cobra.Command, args []string) error {
+	// Wire SIGINT/SIGTERM into the cobra context so Ctrl+C cleanly
+	// drains the SSE / NATS subscription rather than dropping mid-frame.
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	out := cmd.OutOrStdout()
+
+	if len(args) == 1 {
+		// Per-thread SSE path. Endpoint exists in the engine
+		// (cmd/duragraph/cmd/serve.go: "/threads/:thread_id/stream").
+		threadID := args[0]
+		c := cli.NewClient(resolveEngineURL())
+		fmt.Fprintf(cmd.ErrOrStderr(), "tailing thread=%s via SSE at %s\n", threadID, c.EngineURL())
+		err := c.StreamRuns(ctx, threadID, func(ev cli.SSEEvent) error {
+			var payload any
+			if err := json.Unmarshal(ev.Data, &payload); err != nil {
+				// Print raw on decode error.
+				_, werr := fmt.Fprintf(out, "// %s\n%s\n", ev.Type, string(ev.Data))
+				return werr
+			}
+			return cli.PrintEvent(out, ev.Type, payload)
+		})
+		// ctx-cancel produces a connection-closed error from Go's HTTP
+		// stack rather than ctx.Err — treat that as clean exit.
+		if err != nil && ctx.Err() == nil {
+			return err
+		}
+		return nil
+	}
+
+	// No thread_id: subscribe directly to NATS for run lifecycle
+	// events across all threads. Subject `duragraph.runs.run.>`
+	// matches outbox_relay.buildTopic for aggregateType="run".
+	natsURL := resolveNATSURL(runsTailNATSURL)
+	const subject = "duragraph.runs.run.>"
+	fmt.Fprintf(cmd.ErrOrStderr(), "tailing all runs via NATS %s subject=%s\n", natsURL, subject)
+	err := cli.SubscribeEvents(ctx, natsURL, subject, "", func(env cli.EventEnvelope) error {
+		return cli.PrintEvent(out, env.EventType, env)
+	})
+	if err != nil && ctx.Err() == nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/duragraph/cmd/runs.go
+++ b/cmd/duragraph/cmd/runs.go
@@ -262,12 +262,18 @@ func runRunsTail(cmd *cobra.Command, args []string) error {
 	}
 
 	// No thread_id: subscribe directly to NATS for run lifecycle
-	// events across all threads. Subject `duragraph.runs.run.>`
-	// matches outbox_relay.buildTopic for aggregateType="run".
+	// events across all threads. Delegate subject construction to
+	// cli.SubjectFor so this stays in sync with the `events tail`
+	// mapping (and with outbox_relay.buildTopic).
 	natsURL := resolveNATSURL(runsTailNATSURL)
-	const subject = "duragraph.runs.run.>"
+	subject, err := cli.SubjectFor("run")
+	if err != nil {
+		// Unreachable: "run" is a known aggregate. Defensive in case
+		// SubjectFor's allow-list ever changes underneath us.
+		return fmt.Errorf("resolve runs-tail subject: %w", err)
+	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "tailing all runs via NATS %s subject=%s\n", natsURL, subject)
-	err := cli.SubscribeEvents(ctx, natsURL, subject, "", func(env cli.EventEnvelope) error {
+	err = cli.SubscribeEvents(ctx, natsURL, subject, "", func(env cli.EventEnvelope) error {
 		return cli.PrintEvent(out, env.EventType, env)
 	})
 	if err != nil && ctx.Err() == nil {

--- a/internal/dev/cli/client.go
+++ b/internal/dev/cli/client.go
@@ -1,0 +1,300 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultEngineURL is the engine URL the CLI assumes when neither the
+// --engine flag nor the DURAGRAPH_URL environment variable is set. Mirrors
+// the port `duragraph dev` defaults to (binary-modes.yml § subcommands.dev).
+const DefaultEngineURL = "http://localhost:8081"
+
+// Client is a thin HTTP wrapper around the engine's REST + SSE API. It
+// is intentionally minimal — no retries, no auth header injection
+// (Phase 7 targets the no-auth `duragraph dev` flow), no connection
+// pooling beyond Go's default. Future PRs can layer tenant-JWT auth or
+// retry policy on top without changing call sites.
+type Client struct {
+	http   *http.Client
+	engine string
+}
+
+// NewClient returns a Client targeting engineURL. The URL is normalised
+// (trailing slash trimmed) so callers can append paths starting with
+// "/api/v1/..." without worrying about double slashes.
+func NewClient(engineURL string) *Client {
+	return &Client{
+		// No timeout on the http.Client itself: the SSE call needs a
+		// long-lived connection and per-call timeouts are applied via
+		// context.Context instead.
+		http:   &http.Client{},
+		engine: strings.TrimRight(engineURL, "/"),
+	}
+}
+
+// EngineURL returns the normalised base URL the client targets. Useful
+// for log messages that orient the operator on which engine they hit.
+func (c *Client) EngineURL() string { return c.engine }
+
+// GetRun fetches `GET /api/v1/runs/<runID>` and returns the raw JSON
+// body. The body is returned undecoded so the caller can pretty-print it
+// straight to stdout — `runs get` does not need a typed view.
+//
+// A 404 is surfaced as a sentinel error so callers can render a clean
+// "run not found" message rather than dumping the raw error envelope.
+func (c *Client) GetRun(ctx context.Context, runID string) ([]byte, error) {
+	url := c.engine + "/api/v1/runs/" + runID
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build GET %s: %w", url, err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("read GET %s body: %w", url, readErr)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrRunNotFound
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("GET %s: %s: %s", url, resp.Status, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// ErrRunNotFound is returned by GetRun when the engine responds 404.
+// Sentinel rather than a typed error because the caller only needs to
+// distinguish "missing" from "other failure".
+var ErrRunNotFound = errors.New("run not found")
+
+// CreateRunResponse mirrors dto.CreateRunResponse for the fields the CLI
+// surfaces. Defined locally rather than importing the dto package to
+// keep this CLI helper from picking up the engine's transitive deps
+// (echo, persistence, etc.) and inflating the binary.
+type CreateRunResponse struct {
+	RunID       string `json:"run_id"`
+	ThreadID    string `json:"thread_id"`
+	AssistantID string `json:"assistant_id"`
+	Status      string `json:"status"`
+}
+
+// CreateRun POSTs `/api/v1/runs` with the given body and returns the
+// decoded response. The engine accepts a raw JSON object here — the
+// caller is responsible for shape-validating `body` before sending so
+// invalid inputs fail fast on the client side rather than producing a
+// 400 round-trip.
+func (c *Client) CreateRun(ctx context.Context, body any) (*CreateRunResponse, error) {
+	url := c.engine + "/api/v1/runs"
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create-run body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build POST %s: %w", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("read POST %s body: %w", url, readErr)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("POST %s: %s: %s", url, resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	var out CreateRunResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode create-run response: %w", err)
+	}
+	return &out, nil
+}
+
+// terminalStatuses are the run states at which `runs trigger --wait`
+// stops polling. Mirrors the run-aggregate state machine in
+// internal/domain/run/.
+var terminalStatuses = map[string]struct{}{
+	"completed": {},
+	"failed":    {},
+	"cancelled": {},
+}
+
+// WaitForRun polls GetRun every interval until the run reaches a
+// terminal state (completed | failed | cancelled) or ctx is cancelled.
+// Returns the final raw JSON body so the caller can print the same
+// payload `runs get` would.
+//
+// Polling is deliberately simple — no exponential backoff, no event
+// subscription. `runs trigger --wait` is an interactive convenience for
+// `duragraph dev`, not a production polling loop. If a future workflow
+// needs sub-second latency, switching to NATS-subscribe is a one-line
+// change at the call site.
+func (c *Client) WaitForRun(ctx context.Context, runID string, interval time.Duration) ([]byte, error) {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		body, err := c.GetRun(ctx, runID)
+		if err != nil {
+			return nil, err
+		}
+		var probe struct {
+			Status string `json:"status"`
+		}
+		// A failed decode here is non-fatal: keep polling. The body is
+		// still returned at terminal time, so the operator sees the
+		// real shape regardless.
+		_ = json.Unmarshal(body, &probe)
+		if _, terminal := terminalStatuses[probe.Status]; terminal {
+			return body, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// SSEEvent is one parsed Server-Sent Events frame. The engine's SSE
+// stream uses only the `event:` and `data:` fields (formatter.go:55),
+// so id/retry are intentionally ignored.
+type SSEEvent struct {
+	Type string
+	Data []byte
+}
+
+// StreamRuns opens an SSE connection to the engine's run-event stream
+// for threadID and invokes fn for each parsed event. Blocks until ctx
+// is cancelled, the connection drops, or fn returns an error.
+//
+// Hand-rolled rather than pulling in github.com/r3labs/sse: the wire
+// format here is trivial (line-prefixed event:/data:, blank-line frame
+// separator) and we don't need reconnect-with-backoff or last-event-id
+// resume — both of those are valuable for a real client SDK, but the
+// CLI is operator-facing and the operator can re-run the command if
+// the engine restarts.
+//
+// Endpoint: /api/v1/threads/<threadID>/stream — see stream.go's
+// JoinThreadStream. There is no engine-side "all threads" SSE endpoint;
+// for that flow the CLI uses NATS instead (see SubscribeRunEvents).
+func (c *Client) StreamRuns(ctx context.Context, threadID string, fn func(SSEEvent) error) error {
+	if threadID == "" {
+		return errors.New("StreamRuns: threadID is required (use NATS path for all-threads tail)")
+	}
+	url := c.engine + "/api/v1/threads/" + threadID + "/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build SSE GET %s: %w", url, err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("SSE GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("SSE GET %s: %s: %s", url, resp.Status, strings.TrimSpace(string(body)))
+	}
+	return parseSSE(resp.Body, fn)
+}
+
+// parseSSE reads the SSE byte stream from r and dispatches one SSEEvent
+// to fn per `event:`/`data:` block (delimited by a blank line). Pulled
+// out as a free function so the test can drive it with an in-memory
+// buffer without spinning up an httptest server.
+//
+// The engine never splits a single logical event across multiple data:
+// lines — the formatter writes one data: line per frame (formatter.go:55) —
+// but parseSSE handles multi-line data: anyway (joined with '\n', per
+// the W3C SSE spec) so the helper is reusable for other SSE producers.
+func parseSSE(r io.Reader, fn func(SSEEvent) error) error {
+	scanner := bufio.NewScanner(r)
+	// Default 64KiB buffer is too small for large workflow state
+	// payloads. Bump to 1MiB which matches the engine's HTTP body size
+	// cap on the producer side.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		eventType string
+		dataLines [][]byte
+	)
+	dispatch := func() error {
+		if eventType == "" && len(dataLines) == 0 {
+			return nil
+		}
+		ev := SSEEvent{
+			Type: eventType,
+			Data: bytes.Join(dataLines, []byte("\n")),
+		}
+		eventType = ""
+		dataLines = dataLines[:0]
+		return fn(ev)
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			if err := dispatch(); err != nil {
+				return err
+			}
+			continue
+		}
+		// Comment lines (": keepalive") — ignore.
+		if line[0] == ':' {
+			continue
+		}
+		// `field: value` (with optional space after colon).
+		colon := bytes.IndexByte(line, ':')
+		var field, value string
+		if colon < 0 {
+			field = string(line)
+			value = ""
+		} else {
+			field = string(line[:colon])
+			v := line[colon+1:]
+			if len(v) > 0 && v[0] == ' ' {
+				v = v[1:]
+			}
+			value = string(v)
+		}
+		switch field {
+		case "event":
+			eventType = value
+		case "data":
+			dataLines = append(dataLines, []byte(value))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read SSE: %w", err)
+	}
+	// Flush a trailing event that wasn't followed by a blank line.
+	return dispatch()
+}

--- a/internal/dev/cli/client.go
+++ b/internal/dev/cli/client.go
@@ -238,9 +238,13 @@ func (c *Client) StreamRuns(ctx context.Context, threadID string, fn func(SSEEve
 func parseSSE(r io.Reader, fn func(SSEEvent) error) error {
 	scanner := bufio.NewScanner(r)
 	// Default 64KiB buffer is too small for large workflow state
-	// payloads. Bump to 1MiB which matches the engine's HTTP body size
-	// cap on the producer side.
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	// payloads. The engine's SSE formatter emits the entire JSON
+	// payload on a single `data:` line (formatter.go:55), so a verbose
+	// run with rich tool outputs / intermediate state can blow past
+	// 1MiB. Bump the per-line cap to 16MiB to give comfortable
+	// headroom — typical run payloads stay well under 1MB but the
+	// limit only matters at the tail.
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 
 	var (
 		eventType string

--- a/internal/dev/cli/client_test.go
+++ b/internal/dev/cli/client_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetRun_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/runs/abc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"run_id":"abc","status":"completed"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	body, err := c.GetRun(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if !strings.Contains(string(body), `"run_id":"abc"`) {
+		t.Fatalf("GetRun body: %s", body)
+	}
+}
+
+func TestGetRun_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"not_found"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.GetRun(context.Background(), "missing")
+	if !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("GetRun(missing): expected ErrRunNotFound, got %v", err)
+	}
+}
+
+func TestCreateRun_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/runs" {
+			t.Errorf("unexpected req: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["assistant_id"] != "asst_1" {
+			t.Errorf("unexpected body: %v", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"run_id":"r1","thread_id":"t1","assistant_id":"asst_1","status":"queued"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.CreateRun(context.Background(), map[string]any{
+		"assistant_id": "asst_1",
+		"input":        map[string]any{"x": 1},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if resp.RunID != "r1" || resp.ThreadID != "t1" || resp.Status != "queued" {
+		t.Fatalf("CreateRun response: %+v", resp)
+	}
+}
+
+func TestCreateRun_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":"boom"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.CreateRun(context.Background(), map[string]any{"assistant_id": "x"})
+	if err == nil {
+		t.Fatal("CreateRun: expected error on 500")
+	}
+}
+
+func TestWaitForRun_PollsUntilTerminal(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 3 {
+			fmt.Fprint(w, `{"run_id":"r1","status":"in_progress"}`)
+			return
+		}
+		fmt.Fprint(w, `{"run_id":"r1","status":"completed","output":{"ok":true}}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	body, err := c.WaitForRun(context.Background(), "r1", 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForRun: %v", err)
+	}
+	if !strings.Contains(string(body), `"status":"completed"`) {
+		t.Fatalf("WaitForRun: expected completed body, got %s", body)
+	}
+	if atomic.LoadInt32(&hits) < 3 {
+		t.Fatalf("WaitForRun: expected at least 3 polls, got %d", hits)
+	}
+}
+
+func TestWaitForRun_CancelledContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"run_id":"r1","status":"in_progress"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err := c.WaitForRun(ctx, "r1", 10*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForRun: expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestStreamRuns_ParsesEvents(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/threads/t1/stream" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprint(w, "event: run.started\ndata: {\"run_id\":\"r1\"}\n\n")
+		fmt.Fprint(w, ": keepalive\n\n")
+		fmt.Fprint(w, "event: run.completed\ndata: {\"run_id\":\"r1\",\"status\":\"ok\"}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var got []SSEEvent
+	err := c.StreamRuns(ctx, "t1", func(ev SSEEvent) error {
+		got = append(got, ev)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("StreamRuns: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("StreamRuns: expected 2 events, got %d (%+v)", len(got), got)
+	}
+	if got[0].Type != "run.started" || !strings.Contains(string(got[0].Data), `"run_id":"r1"`) {
+		t.Fatalf("StreamRuns event[0]: %+v", got[0])
+	}
+	if got[1].Type != "run.completed" {
+		t.Fatalf("StreamRuns event[1]: %+v", got[1])
+	}
+}
+
+func TestStreamRuns_RequiresThreadID(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1")
+	err := c.StreamRuns(context.Background(), "", func(SSEEvent) error { return nil })
+	if err == nil {
+		t.Fatal("StreamRuns: expected error for empty threadID")
+	}
+}
+
+func TestParseSSE_MultiLineData(t *testing.T) {
+	// W3C SSE: multiple data: lines join with '\n'. The engine never
+	// produces this shape but the parser should handle it.
+	in := strings.NewReader("event: x\ndata: line1\ndata: line2\n\n")
+	var got []SSEEvent
+	err := parseSSE(in, func(ev SSEEvent) error {
+		got = append(got, ev)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("parseSSE: %v", err)
+	}
+	if len(got) != 1 || string(got[0].Data) != "line1\nline2" {
+		t.Fatalf("parseSSE multi-line: %+v", got)
+	}
+}

--- a/internal/dev/cli/nats.go
+++ b/internal/dev/cli/nats.go
@@ -22,18 +22,26 @@ const DefaultNATSURL = "nats://localhost:4222"
 // routed to a non-`events` category in outbox_relay.go must be added
 // here as well.
 //
-// Note: `--aggregate run` maps to `duragraph.runs.>`, NOT
-// `duragraph.events.run.>`. The outbox relay routes runs to the
-// `duragraph.runs.<aggregate>.<event>` subject family because the
-// stream is also used for the per-run SSE bridge in
-// internal/infrastructure/streaming/bridge.go.
+// outbox_relay.buildTopic produces:
 //
-// Unfiltered subscription uses `duragraph.>` so all three subject
-// families (events / runs / executions) are covered.
+//	aggregateType="run"        → duragraph.runs.run.<event>
+//	aggregateType="execution"  → duragraph.executions.execution.<event>
+//	aggregateType=<other>      → duragraph.events.<other>.<event>
+//
+// We deliberately match the FULL three-segment prefix (e.g.
+// `duragraph.runs.run.>`) rather than the looser `duragraph.runs.>` so
+// the CLI doesn't accidentally pick up unrelated traffic that other
+// engine subsystems publish under `duragraph.runs.*` — notably the
+// task-queue (internal/infrastructure/messaging/nats/task_queue.go,
+// `duragraph.runs.<runID>.<eventType>`) and the per-run SSE bridge
+// (internal/infrastructure/streaming/bridge.go, `duragraph.stream.*`).
+//
+// Unfiltered subscription uses `duragraph.>` so all subject families
+// (events / runs / executions / stream / tasks) are covered.
 const (
 	subjectAll        = "duragraph.>"
-	subjectRunsAll    = "duragraph.runs.>"
-	subjectExecAll    = "duragraph.executions.>"
+	subjectRunsAll    = "duragraph.runs.run.>"
+	subjectExecAll    = "duragraph.executions.execution.>"
 	subjectEventsRoot = "duragraph.events"
 )
 

--- a/internal/dev/cli/nats.go
+++ b/internal/dev/cli/nats.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	wnats "github.com/ThreeDotsLabs/watermill-nats/v2/pkg/nats"
+	natsgo "github.com/nats-io/nats.go"
+)
+
+// DefaultNATSURL is the NATS URL the CLI assumes when neither the --nats
+// flag nor the DURAGRAPH_NATS_URL environment variable is set. Mirrors
+// the embedded-NATS port the `dev` command starts on (binary-modes.yml
+// § subcommands.dev).
+const DefaultNATSURL = "nats://localhost:4222"
+
+// NATS subject mapping for `events tail --aggregate` filtering. Mirrors
+// the routing in internal/infrastructure/messaging/outbox_relay.go's
+// buildTopic — keep these in sync. Any new aggregate-type that gets
+// routed to a non-`events` category in outbox_relay.go must be added
+// here as well.
+//
+// Note: `--aggregate run` maps to `duragraph.runs.>`, NOT
+// `duragraph.events.run.>`. The outbox relay routes runs to the
+// `duragraph.runs.<aggregate>.<event>` subject family because the
+// stream is also used for the per-run SSE bridge in
+// internal/infrastructure/streaming/bridge.go.
+//
+// Unfiltered subscription uses `duragraph.>` so all three subject
+// families (events / runs / executions) are covered.
+const (
+	subjectAll        = "duragraph.>"
+	subjectRunsAll    = "duragraph.runs.>"
+	subjectExecAll    = "duragraph.executions.>"
+	subjectEventsRoot = "duragraph.events"
+)
+
+// SubjectFor returns the NATS wildcard subject the CLI subscribes to
+// for the given --aggregate filter. Empty filter ("") returns the
+// catch-all `duragraph.>`. An unknown filter is an error rather than a
+// silent fall-through to the catch-all so typos don't quietly produce
+// "subscribed but never receive anything".
+func SubjectFor(aggregate string) (string, error) {
+	switch aggregate {
+	case "":
+		return subjectAll, nil
+	case "run":
+		return subjectRunsAll, nil
+	case "execution":
+		return subjectExecAll, nil
+	case "thread", "workflow", "tenant", "user":
+		return subjectEventsRoot + "." + aggregate + ".>", nil
+	default:
+		return "", fmt.Errorf("unknown aggregate filter %q (expected one of: run, execution, thread, workflow, tenant, user)", aggregate)
+	}
+}
+
+// EventEnvelope mirrors the JSON shape the OutboxRelay publishes to
+// NATS (see internal/infrastructure/messaging/outbox_relay.go's
+// publishMessage). Fields use `any` for forward-compat — the CLI does
+// not depend on payload schema and just pretty-prints it.
+//
+// The wire format is gob-wrapped: outbox_relay marshals this struct as
+// JSON, hands it to Watermill which gob-encodes the message envelope
+// (UUID + payload + metadata), and the gob bytes ride NATS. So a
+// receiver must (1) gob-decode the watermill message, (2) JSON-decode
+// the resulting Payload back into this struct.
+type EventEnvelope struct {
+	EventID       string         `json:"event_id"`
+	AggregateType string         `json:"aggregate_type"`
+	AggregateID   string         `json:"aggregate_id"`
+	EventType     string         `json:"event_type"`
+	Payload       any            `json:"payload"`
+	Metadata      map[string]any `json:"metadata"`
+	Timestamp     any            `json:"timestamp"`
+}
+
+// SubscribeEvents connects to NATS at natsURL, subscribes to subject,
+// and invokes fn for each decoded event envelope. Blocks until ctx is
+// cancelled. Optional aggregateID filters messages client-side (since
+// thread/workflow IDs are not part of the NATS subject hierarchy).
+//
+// Implementation detail — gob unwrap:
+//
+//	The publisher (internal/infrastructure/messaging/nats/publisher.go)
+//	uses watermill-nats v2's GobMarshaler. So the on-the-wire bytes
+//	are NOT raw JSON — they are a gob-encoded *watermill.Message
+//	whose .Payload field is the JSON-serialised EventEnvelope. We
+//	reuse wnats.GobMarshaler.Unmarshal here so the producer/consumer
+//	wire format stays single-sourced. The same pattern is used by
+//	internal/infrastructure/messaging/nats/jetstream_subscriber.go.
+//
+// Implementation detail — core NATS vs JetStream:
+//
+//	JetStream-published messages also fan out to plain core-NATS
+//	subscribers (it's just a stream layered on top of pub/sub). Using
+//	core nc.Subscribe avoids leaving durable consumer state on the
+//	broker every time someone runs `events tail` — the CLI is
+//	short-lived and best-effort, so live-only delivery is correct.
+func SubscribeEvents(ctx context.Context, natsURL, subject, aggregateID string, fn func(EventEnvelope) error) error {
+	if natsURL == "" {
+		return errors.New("SubscribeEvents: natsURL is required")
+	}
+	if subject == "" {
+		return errors.New("SubscribeEvents: subject is required")
+	}
+
+	nc, err := natsgo.Connect(natsURL)
+	if err != nil {
+		return fmt.Errorf("connect NATS %s: %w", natsURL, err)
+	}
+	defer nc.Drain()
+
+	um := wnats.GobMarshaler{}
+
+	// Buffered errCh so a slow caller-side fn doesn't block the NATS
+	// dispatcher goroutine. The first error wins and unblocks the
+	// outer select.
+	errCh := make(chan error, 1)
+
+	sub, err := nc.Subscribe(subject, func(m *natsgo.Msg) {
+		// Step 1: gob → watermill.Message.
+		wmMsg, decodeErr := um.Unmarshal(m)
+		if decodeErr != nil {
+			// Not all messages on a wildcard subject are
+			// guaranteed to be watermill-encoded — be lenient and
+			// drop undecodable frames rather than aborting the
+			// whole tail.
+			return
+		}
+		// Step 2: JSON → EventEnvelope.
+		var env EventEnvelope
+		if err := json.Unmarshal(wmMsg.Payload, &env); err != nil {
+			return
+		}
+		// Optional client-side aggregate-id filter.
+		if aggregateID != "" && env.AggregateID != aggregateID {
+			return
+		}
+		if err := fn(env); err != nil {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("subscribe %q on %s: %w", subject, natsURL, err)
+	}
+	defer sub.Unsubscribe()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}

--- a/internal/dev/cli/nats_test.go
+++ b/internal/dev/cli/nats_test.go
@@ -13,8 +13,8 @@ func TestSubjectFor(t *testing.T) {
 		ok   bool
 	}{
 		{"", "duragraph.>", true},
-		{"run", "duragraph.runs.>", true},
-		{"execution", "duragraph.executions.>", true},
+		{"run", "duragraph.runs.run.>", true},
+		{"execution", "duragraph.executions.execution.>", true},
 		{"thread", "duragraph.events.thread.>", true},
 		{"workflow", "duragraph.events.workflow.>", true},
 		{"tenant", "duragraph.events.tenant.>", true},

--- a/internal/dev/cli/nats_test.go
+++ b/internal/dev/cli/nats_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import "testing"
+
+// TestSubjectFor pins the --aggregate → NATS-subject mapping. This is
+// load-bearing: a wrong subject yields "subscribed but no events" with
+// no error, which is hard to debug. The mapping must stay in sync with
+// internal/infrastructure/messaging/outbox_relay.go's buildTopic.
+func TestSubjectFor(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"", "duragraph.>", true},
+		{"run", "duragraph.runs.>", true},
+		{"execution", "duragraph.executions.>", true},
+		{"thread", "duragraph.events.thread.>", true},
+		{"workflow", "duragraph.events.workflow.>", true},
+		{"tenant", "duragraph.events.tenant.>", true},
+		{"user", "duragraph.events.user.>", true},
+		{"bogus", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := SubjectFor(tc.in)
+			if tc.ok && err != nil {
+				t.Fatalf("SubjectFor(%q): unexpected err %v", tc.in, err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("SubjectFor(%q): expected err, got %q", tc.in, got)
+			}
+			if got != tc.want {
+				t.Fatalf("SubjectFor(%q): got %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dev/cli/printer.go
+++ b/internal/dev/cli/printer.go
@@ -1,0 +1,56 @@
+// Package cli holds the client-side helpers used by the duragraph CLI
+// subcommands (`runs *`, `events tail`). These commands talk over the
+// network to a running engine — they don't embed engine internals — so
+// the helpers here are deliberately thin: an HTTP wrapper, a SSE line
+// reader, and a NATS event decoder.
+//
+// Implements binary-modes.yml § subcommands.duragraph_runs and
+// § subcommands.duragraph_events (v0.7 Phase 7 of the single-binary DX
+// track).
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// PrintJSON pretty-prints v as indented JSON followed by a newline.
+//
+// Output is monochrome by design: the project does not currently depend
+// on any ANSI color library, and Phase 7 is not the right place to
+// introduce one. If a future PR wires a logger with color, the right
+// move is to swap fmt.Fprintln here for that logger's structured
+// printer, not to bolt a second color dep onto the binary.
+//
+// Errors from json.MarshalIndent are surfaced rather than swallowed —
+// the CLI is a thin wrapper over arbitrary engine responses, and a
+// marshal failure usually indicates an unexpected payload shape that
+// the operator needs to see.
+func PrintJSON(w io.Writer, v any) error {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, string(out)); err != nil {
+		return fmt.Errorf("write json: %w", err)
+	}
+	return nil
+}
+
+// PrintEvent prints a single SSE / NATS event with a leading event-type
+// prefix line, then the payload as indented JSON. Used by both `runs
+// tail` and `events tail` so their on-screen format is identical.
+//
+// The prefix line is a comment-style marker (// event_type) that grep
+// can match on but a JSON parser will skip — operators piping to `jq`
+// commonly want the JSON portion only, which they get with
+// `grep -v '^// '`.
+func PrintEvent(w io.Writer, eventType string, payload any) error {
+	if eventType != "" {
+		if _, err := fmt.Fprintf(w, "// %s\n", eventType); err != nil {
+			return fmt.Errorf("write event-type prefix: %w", err)
+		}
+	}
+	return PrintJSON(w, payload)
+}

--- a/internal/dev/cli/printer_test.go
+++ b/internal/dev/cli/printer_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintJSON_Indented(t *testing.T) {
+	var buf bytes.Buffer
+	if err := PrintJSON(&buf, map[string]any{"k": "v", "n": 1}); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+	got := buf.String()
+	// MarshalIndent sorts map keys alphabetically — assert the literal
+	// indented shape so a future "compact mode" doesn't silently break
+	// the operator-facing format without a test failure.
+	want := "{\n  \"k\": \"v\",\n  \"n\": 1\n}\n"
+	if got != want {
+		t.Fatalf("PrintJSON output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestPrintJSON_Error(t *testing.T) {
+	// Channels are not JSON-marshalable; PrintJSON should return the
+	// underlying marshal error rather than panicking or writing garbage.
+	if err := PrintJSON(&bytes.Buffer{}, make(chan int)); err == nil {
+		t.Fatal("PrintJSON(chan): expected error, got nil")
+	}
+}
+
+func TestPrintEvent_PrefixesType(t *testing.T) {
+	var buf bytes.Buffer
+	if err := PrintEvent(&buf, "run.started", map[string]any{"run_id": "abc"}); err != nil {
+		t.Fatalf("PrintEvent: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "// run.started\n") {
+		t.Fatalf("PrintEvent: expected prefix line, got: %q", out)
+	}
+	if !strings.Contains(out, `"run_id": "abc"`) {
+		t.Fatalf("PrintEvent: expected payload, got: %q", out)
+	}
+}
+
+func TestPrintEvent_NoTypeOmitsPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	if err := PrintEvent(&buf, "", map[string]any{"x": 1}); err != nil {
+		t.Fatalf("PrintEvent: %v", err)
+	}
+	if strings.HasPrefix(buf.String(), "//") {
+		t.Fatalf("PrintEvent: expected no prefix line for empty type, got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the Phase 1 stubs with real CLI client implementations for v0.7 Phase 7. Aligned with `duragraph-spec/backend/binary-modes.yml § subcommands.duragraph_runs` and `§ subcommands.duragraph_events`.

Four new operator surfaces, all client-only (talk to a running engine over HTTP/SSE/NATS — no engine internals embedded):

- `duragraph runs get <run_id>` — `GET /api/v1/runs/<id>`, pretty-print JSON
- `duragraph runs trigger <assistant_id> [--input '{...}'] [--wait] [--thread] [--timeout]` — `POST /api/v1/runs`, optionally poll until terminal
- `duragraph runs tail [<thread_id>]` — SSE per-thread (`/api/v1/threads/<tid>/stream`) when given an id; NATS subscription to `duragraph.runs.run.>` when not (engine has no all-threads SSE endpoint)
- `duragraph events tail [--aggregate run|execution|thread|workflow|tenant|user] [--id <uuid>] [--nats <url>]` — NATS subscription with subject mapping that mirrors `outbox_relay.buildTopic` exactly

## Configuration

| Var | Default | Override |
|---|---|---|
| `DURAGRAPH_URL` | `http://localhost:8081` | `--engine` |
| `DURAGRAPH_NATS_URL` | `nats://localhost:4222` | `--nats` |

## Implementation notes

- New `internal/dev/cli` package hosts shared helpers (`Client`, `parseSSE`, `SubscribeEvents`, `SubjectFor`, `PrintJSON`, `PrintEvent`).
- SSE is hand-rolled (~30 LOC); no `r3labs/sse` added.
- Color is monochrome — no `fatih/color` in `go.mod` and no plan to add one in this PR.
- NATS payload decode is two-step: the engine's publisher uses Watermill's `GobMarshaler`, so a plain `json.Unmarshal(m.Data, ...)` fails. The CLI gob-unwraps first (mirroring `jetstream_subscriber.go`), then JSON-decodes the resulting `EventEnvelope`.
- The CLI uses **core NATS** (not JetStream consumers) so short-lived `events tail` runs don't leave durable consumer state on the broker.

## Trade-offs called out

- **Unfiltered `events tail` subscribes to `duragraph.>`** to cover all three subject families (`events.>`, `runs.>`, `executions.>`). This also captures the streaming-bridge fanout (`duragraph.stream.<run_id>.>`); strictly speaking those aren't event-sourced rows, but the alternative (`duragraph.events.>`) misses runs/executions entirely. Documented in `nats.go`.
- **`runs tail <thread_id>` shows mapped stream-mode types** (`values`, `updates`, ...) because the engine's `JoinThreadStream` runs `mapEventType` before SSE emission. The no-arg NATS path shows raw `event_type` strings (`run.started`, `run.completed`). Asymmetric — not changed in this PR.
- **`--input` must be a JSON object** (not any JSON value). Matches the engine's `CreateStatelessRun` shape, which merges stream/interrupt config into the input map server-side.
- **`runs trigger` thread_id**: never generated client-side. The engine allocates an ephemeral thread for stateless runs (`run.go:174-189`) and returns it in the response — printed on stderr so the operator can chain `runs tail <thread_id>`.

## Test plan

- [x] `go test ./internal/dev/cli/... -count=1 -short` — passes (8 unit tests covering GetRun, CreateRun, WaitForRun, StreamRuns SSE parse, multi-line `data:`, SubjectFor mapping, printer)
- [x] `go test ./cmd/duragraph/... -count=1 -short` — passes
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean; no new go.mod / go.sum changes
- [x] `duragraph runs --help`, `runs get --help`, `runs trigger --help`, `runs tail --help`, `events --help`, `events tail --help` — all render
- [ ] Manual smoke (operator-side): with `duragraph dev` running in another terminal:
  - `duragraph runs tail` (no args) — connects to NATS and idles
  - `duragraph runs trigger <assistant_id> --input '{"x":1}' --wait` — creates + waits, prints final state
  - `duragraph runs get <run_id>` — prints the same final state
  - `duragraph events tail --aggregate run` — sees lifecycle events for the trigger above
  - `duragraph events tail --aggregate run --id <run_id>` — filters to that run only

NATS integration tests are deliberately out of scope (would require a running nats-server in CI).