### PR TITLE
feat(config): bump embedded postgres + NATS defaults to high ports

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -91,8 +91,8 @@ go run ./cmd/duragraph dev
 
 That single command brings up:
 
-- **Embedded PostgreSQL** on `:5435` (data dir `./data/pg`)
-- **Embedded NATS JetStream** on `:4222` (data dir `./data/nats`)
+- **Embedded PostgreSQL** on `:15435` (data dir `./data/pg`)
+- **Embedded NATS JetStream** on `:14222` (data dir `./data/nats`)
 - **Engine + dashboard** on `:8081`
 - Schema migrations applied automatically on first start
 
@@ -232,8 +232,8 @@ go run ./cmd/duragraph dev
 
 What you get:
 
-- Embedded PostgreSQL on `:5435` (data: `${data-dir}/pg`)
-- Embedded NATS JetStream on `:4222` (data: `${data-dir}/nats`)
+- Embedded PostgreSQL on `:15435` (data: `${data-dir}/pg`)
+- Embedded NATS JetStream on `:14222` (data: `${data-dir}/nats`)
 - Engine + embedded dashboard on `http://localhost:8081/`
 - Optional embedded Studio at `http://localhost:8081/studio/` (with `--studio`)
 - Migrations applied automatically; no Docker, no `task up`, no manual `db:migrate`

--- a/cmd/duragraph/cmd/events.go
+++ b/cmd/duragraph/cmd/events.go
@@ -43,7 +43,7 @@ event envelope (event_type + payload) as it is published.
 Filter by aggregate type with --aggregate (run | execution | thread |
 workflow | tenant | user). Filter further by aggregate id with --id.
 
-The NATS URL defaults to nats://localhost:4222 and is overridable via
+The NATS URL defaults to nats://localhost:14222 and is overridable via
 $DURAGRAPH_NATS_URL or --nats. Press Ctrl+C to stop.`,
 	Args: cobra.NoArgs,
 	RunE: runEventsTail,

--- a/cmd/duragraph/cmd/runs.go
+++ b/cmd/duragraph/cmd/runs.go
@@ -25,7 +25,7 @@ import (
 //   - DURAGRAPH_URL       — engine base URL (default http://localhost:8081),
 //                           overridable per-invocation via --engine.
 //   - DURAGRAPH_NATS_URL  — NATS URL for `runs tail` no-arg fallback
-//                           (default nats://localhost:4222), overridable via --nats.
+//                           (default nats://localhost:14222), overridable via --nats.
 //
 // Default behaviour rationale: NATS-subscribing for "all threads" tail
 // rather than polling /api/v1/runs. The engine already publishes run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,10 @@ type ServerConfig struct {
 // per binary-modes.yml § embedded_components.postgres).
 //
 // When Mode == "embedded", Host/Port are forced to 127.0.0.1 and the
-// embedded port (default 5435) regardless of DB_HOST / DB_PORT env vars.
+// embedded port (default 15435) regardless of DB_HOST / DB_PORT env vars.
+// Default chosen high (>10000) so `duragraph dev` zero-config never
+// collides with system Postgres (5432), prod-postgres (5432), or the
+// docker-compose local-dev stack (5435).
 // This is intentional — silent host/port overrides would defeat the
 // "engine reaches its own embedded child process" guarantee. See
 // binary-modes.yml § no_silent_mode_changes for the contract.
@@ -99,17 +102,24 @@ type NATSConfig struct {
 // embedded server only listens on 127.0.0.1 and never holds production
 // data — the password is functionally a placeholder, not a secret.
 const (
-	defaultEmbeddedPort         = 5435
+	// 15435 is intentionally far from the canonical Postgres port (5432)
+	// AND from the docker-compose local-dev stack's 5435 — `duragraph dev`
+	// is the "first 5 minutes" zero-config command and must never collide
+	// with anything common. Operators wanting the legacy 5435 set
+	// DB_EMBEDDED_PORT=5435 explicitly.
+	defaultEmbeddedPort         = 15435
 	defaultEmbeddedVersion      = "15" // matches prod-postgres major
 	defaultEmbeddedDBName       = "duragraph"
 	defaultEmbeddedStartTimeout = 60 * time.Second
 
-	// NATS-specific embedded defaults. 4222 is the canonical NATS
-	// client port. Monitor port intentionally defaults to 0 (disabled)
-	// per binary-modes.yml § nats_jetstream.port — the HTTP /varz
-	// endpoint is a security surface and the embedded mode is opt-in
-	// for ops who explicitly want it.
-	defaultNATSEmbeddedPort         = 4222
+	// 14222 is intentionally far from canonical NATS (4222), which collides
+	// with anyone running NATS locally. Same reasoning as defaultEmbeddedPort
+	// above — zero-collision for zero-config dev. Override with
+	// NATS_EMBEDDED_PORT=4222 if you need the canonical port. Monitor port
+	// intentionally defaults to 0 (disabled) per binary-modes.yml
+	// § nats_jetstream.port — the HTTP /varz endpoint is a security
+	// surface and the embedded mode is opt-in for ops who want it.
+	defaultNATSEmbeddedPort         = 14222
 	defaultNATSEmbeddedStartTimeout = 10 * time.Second
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,7 +67,7 @@ func TestLoad_Defaults(t *testing.T) {
 }
 
 // TestLoad_EmbeddedDefaults verifies that DB_MODE=embedded picks up the
-// spec-defined defaults: 127.0.0.1, port 5435, version 15, and the
+// spec-defined defaults: 127.0.0.1, port 15435, version 15, and the
 // duragraph/duragraph/duragraph credential triple.
 func TestLoad_EmbeddedDefaults(t *testing.T) {
 	t.Setenv("DB_MODE", "embedded")
@@ -95,11 +95,11 @@ func TestLoad_EmbeddedDefaults(t *testing.T) {
 	if got := cfg.Database.Host; got != "127.0.0.1" {
 		t.Errorf("Host: got %q, want 127.0.0.1 (forced in embedded mode)", got)
 	}
-	if got := cfg.Database.Port; got != 5435 {
-		t.Errorf("Port: got %d, want 5435 (default embedded port)", got)
+	if got := cfg.Database.Port; got != 15435 {
+		t.Errorf("Port: got %d, want 15435 (default embedded port)", got)
 	}
-	if got := cfg.Database.EmbeddedPort; got != 5435 {
-		t.Errorf("EmbeddedPort: got %d, want 5435", got)
+	if got := cfg.Database.EmbeddedPort; got != 15435 {
+		t.Errorf("EmbeddedPort: got %d, want 15435", got)
 	}
 	if got := cfg.Database.User; got != "duragraph" {
 		t.Errorf("User: got %q, want duragraph", got)
@@ -389,7 +389,7 @@ func TestLoad_InvalidPort(t *testing.T) {
 }
 
 // TestLoad_EmbeddedNATSDefaults verifies that NATS_MODE=embedded picks
-// up the spec-defined defaults: 127.0.0.1, port 4222, monitoring off,
+// up the spec-defined defaults: 127.0.0.1, port 14222, monitoring off,
 // and the XDG-derived data directory.
 func TestLoad_EmbeddedNATSDefaults(t *testing.T) {
 	t.Setenv("NATS_MODE", "embedded")
@@ -410,11 +410,11 @@ func TestLoad_EmbeddedNATSDefaults(t *testing.T) {
 	if got := cfg.NATS.Mode; got != "embedded" {
 		t.Errorf("Mode: got %q, want embedded", got)
 	}
-	if got := cfg.NATS.EmbeddedPort; got != 4222 {
-		t.Errorf("EmbeddedPort: got %d, want 4222", got)
+	if got := cfg.NATS.EmbeddedPort; got != 14222 {
+		t.Errorf("EmbeddedPort: got %d, want 14222", got)
 	}
-	if got := cfg.NATS.URL; got != "nats://127.0.0.1:4222" {
-		t.Errorf("URL: got %q, want nats://127.0.0.1:4222 (forced in embedded mode)", got)
+	if got := cfg.NATS.URL; got != "nats://127.0.0.1:14222" {
+		t.Errorf("URL: got %q, want nats://127.0.0.1:14222 (forced in embedded mode)", got)
 	}
 	if got := cfg.NATS.EmbeddedMonitorPort; got != 0 {
 		t.Errorf("EmbeddedMonitorPort: got %d, want 0 (disabled by default)", got)

--- a/internal/dev/cli/nats.go
+++ b/internal/dev/cli/nats.go
@@ -13,8 +13,10 @@ import (
 // DefaultNATSURL is the NATS URL the CLI assumes when neither the --nats
 // flag nor the DURAGRAPH_NATS_URL environment variable is set. Mirrors
 // the embedded-NATS port the `dev` command starts on (binary-modes.yml
-// § subcommands.dev).
-const DefaultNATSURL = "nats://localhost:4222"
+// § subcommands.dev) — defaultNATSEmbeddedPort in internal/config/config.go.
+// Operators connecting to a canonical/external NATS at 4222 should pass
+// --nats nats://localhost:4222 or set DURAGRAPH_NATS_URL.
+const DefaultNATSURL = "nats://localhost:14222"
 
 // NATS subject mapping for `events tail --aggregate` filtering. Mirrors
 // the routing in internal/infrastructure/messaging/outbox_relay.go's


### PR DESCRIPTION
## Summary

Change the embedded data plane defaults so `duragraph dev` zero-config never collides with common services:

| | Before | After |
|---|---|---|
| `DB_EMBEDDED_PORT` | `5435` | **`15435`** |
| `NATS_EMBEDDED_PORT` | `4222` | **`14222`** |
| Engine `PORT` | `8081` | unchanged (documented API surface) |

## Why

Real footgun observed in this repo today: running `task up` (the demo stack's docker-compose maps host port `5435` to its containerized postgres) AND `duragraph dev` (default embedded postgres on `5435`) collide. Same story for NATS `4222` — collides with anyone running a NATS server locally.

`binary-modes.yml § modes.dev` calls out the "first 5 minutes" experience as the whole point of `duragraph dev`. A port collision on first run defeats that goal entirely. High ports (>10000) cost the operator nothing — they don't visit the data-plane ports directly, they hit the engine on `:8081` and let it talk to its embedded children.

The legacy ports remain available via env var: `DB_EMBEDDED_PORT=5435` / `NATS_EMBEDDED_PORT=4222`.

## Scope

- `internal/config/config.go` — bumped defaults + extended comments documenting the rationale
- `internal/config/config_test.go` — `TestLoad_EmbeddedDefaults` + `TestLoad_EmbeddedNATSDefaults` updated for new asserts
- `RUNBOOK.md` — port references in Quick Start + Development Workflow sections

External NATS URL default (`NATS_URL=nats://localhost:4222`, used in `NATS_MODE=external`) is unchanged. That's a connection-string default for a separately-managed NATS server, not the embedded listen port.

## Spec coupling

`binary-modes.yml § embedded_components.postgres.port` and `§ embedded_components.nats_jetstream.port` document the old defaults but **the file is uncommitted in `Duragraph/duragraph-spec`** (local-only draft per project memory 2026-05-06). When the spec PR lands, this rationale + new defaults need to be reflected there.

Tagged with `[spec-skip: binary-modes.yml uncommitted in duragraph-spec]` per the engine repo's spec-first rule.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/config/...` passes (4 embedded-default tests now assert 15435 / 14222)
- [ ] Operator: `duragraph dev` starts without env-var overrides; verify embedded postgres on 15435, embedded NATS on 14222