### PR TITLE
fix(release): bump Docker node to 22, absorb built dists for GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,18 @@ jobs:
           pnpm -C studio install --frozen-lockfile
           pnpm -C studio build
 
+      - name: Absorb built dists
+        # `pnpm build` overwrites the committed placeholder dist/index.html
+        # files, leaving the working tree dirty. GoReleaser refuses to
+        # release from a dirty tree (https://goreleaser.com/errors/dirty).
+        # Make a local-only commit so the tree is clean. This commit
+        # exists only on the runner and is never pushed.
+        run: |
+          git config user.email actions@github.com
+          git config user.name github-actions
+          git add dashboard/dist studio/dist
+          git diff --cached --quiet || git commit -m "build: dashboard+studio dists [ci]"
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -6,7 +6,8 @@
 # module root).
 
 # --- Stage 1a: build the React dashboard ---
-FROM node:20-alpine AS dashboard-builder
+# node:22-alpine: corepack pulls pnpm 11.x, which uses node:sqlite (a Node 22+ builtin).
+FROM node:22-alpine AS dashboard-builder
 
 RUN corepack enable
 
@@ -19,7 +20,7 @@ COPY dashboard/ ./
 RUN pnpm build
 
 # --- Stage 1b: build the React Studio UI ---
-FROM node:20-alpine AS studio-builder
+FROM node:22-alpine AS studio-builder
 
 RUN corepack enable
 


### PR DESCRIPTION
## Summary

The v0.7.0 release pipeline hit two failures that this PR fixes. After this merges, we'll cut **v0.7.1** since v0.7.0 is now an unusable artifact (its tarballs embed the placeholder UI from a bad-tag run).

## Failure 1 — Docker Hub: `node:sqlite` not found

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
Node.js v20.20.2
```

Corepack pulls pnpm 11.0.9 inside `studio-builder`, which uses the `node:sqlite` builtin introduced in Node 22. **Fix:** bump both `dashboard-builder` and `studio-builder` stages from `node:20-alpine` → `node:22-alpine`.

## Failure 2 — GoReleaser: dirty git state

```
git is in a dirty state
 M dashboard/dist/index.html
 M studio/dist/index.html
```

`pnpm build` overwrites the committed placeholder `dist/index.html` files. GoReleaser refuses to release from a dirty tree. **Fix:** add a local-only "Absorb built dists" step that commits the regenerated dist artifacts on the runner before GoReleaser inspects git state. The commit lives only on the runner and is never pushed.

## Test plan

- [ ] Merge with `--admin --squash`
- [ ] Tag `v0.7.1` from new HEAD and push
- [ ] Verify `release` workflow → GitHub Release published with real (non-placeholder) UI in tarballs
- [ ] Verify `DuraGraph Release` workflow → Docker Hub image `duragraph/duragraph:v0.7.1` exists
- [ ] Verify Homebrew tap formula bumped to v0.7.1

[spec-skip: ci/release pipeline plumbing only]