### PR TITLE
fix(release): pin Docker pnpm@9, mask placeholder dists from git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,23 @@ jobs:
         with:
           version: 9
 
+      - name: Mask placeholder dists from git
+        # `pnpm build` overwrites the committed placeholder
+        # dashboard/dist/index.html and studio/dist/index.html. That
+        # leaves the working tree dirty, and GoReleaser refuses to
+        # release from a dirty tree. We can't simply commit the change
+        # either — that would advance HEAD past the release tag, and
+        # GoReleaser also rejects "tag not made against HEAD".
+        #
+        # `git update-index --skip-worktree` tells git to ignore
+        # subsequent local changes to these tracked files. Vite still
+        # rewrites them on disk (so go:embed picks up the real UI), but
+        # `git status` stays clean. New files Vite produces under dist/
+        # are already covered by `dist/*` in each .gitignore, so they
+        # don't show as untracked either.
+        run: |
+          git update-index --skip-worktree dashboard/dist/index.html studio/dist/index.html
+
       - name: Build dashboard
         # GoReleaser builds the engine binary which embeds dashboard/dist
         # via go:embed. The placeholder index.html ships in git for local
@@ -56,18 +73,6 @@ jobs:
         run: |
           pnpm -C studio install --frozen-lockfile
           pnpm -C studio build
-
-      - name: Absorb built dists
-        # `pnpm build` overwrites the committed placeholder dist/index.html
-        # files, leaving the working tree dirty. GoReleaser refuses to
-        # release from a dirty tree (https://goreleaser.com/errors/dirty).
-        # Make a local-only commit so the tree is clean. This commit
-        # exists only on the runner and is never pushed.
-        run: |
-          git config user.email actions@github.com
-          git config user.name github-actions
-          git add dashboard/dist studio/dist
-          git diff --cached --quiet || git commit -m "build: dashboard+studio dists [ci]"
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -6,10 +6,14 @@
 # module root).
 
 # --- Stage 1a: build the React dashboard ---
-# node:22-alpine: corepack pulls pnpm 11.x, which uses node:sqlite (a Node 22+ builtin).
+# node:22-alpine + pnpm 9 pinned via corepack: pnpm 10+ requires explicit
+# build-script approval (ERR_PNPM_IGNORED_BUILDS) which doesn't fit
+# `--frozen-lockfile` CI; pnpm 11 also depends on the node:sqlite builtin
+# (Node 22+). Pinning to pnpm 9 keeps install behavior aligned with the
+# release.yml workflow (which uses pnpm/action-setup@v4 with version: 9).
 FROM node:22-alpine AS dashboard-builder
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app/dashboard
 
@@ -22,7 +26,7 @@ RUN pnpm build
 # --- Stage 1b: build the React Studio UI ---
 FROM node:22-alpine AS studio-builder
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app/studio
 


### PR DESCRIPTION
## Summary

Follow-up to #182. Two failures on the v0.7.1 tag run revealed bugs in those fixes:

1. **GoReleaser** rejected the release because the "Absorb built dists" commit advanced HEAD past the tag (`git tag v0.7.1 was not made against commit d7ebf31...`).
2. **Docker Hub** still failed because `corepack enable` resolved pnpm to 11.x, which now errors on `--frozen-lockfile` installs with `ERR_PNPM_IGNORED_BUILDS: esbuild@0.25.12`.

## Changes

- `release.yml`: replace the commit-based "Absorb built dists" step with `git update-index --skip-worktree dashboard/dist/index.html studio/dist/index.html` *before* `pnpm build`. Vite still overwrites the placeholders on disk so `go:embed` picks up the real UI, but git treats them as unchanged → clean tree AND tag still on HEAD.
- `Dockerfile.server`: pin pnpm explicitly via `corepack prepare pnpm@9.15.0 --activate` (matches what release.yml's `pnpm/action-setup` uses).
- Updated the stage-header comment to describe the real reason both stages stay on `node:22-alpine` + pnpm 9.

## Test plan

- [ ] Merge with `--admin --squash`
- [ ] Tag `v0.7.2` from the new HEAD and push
- [ ] Verify both workflows complete green
- [ ] Verify GitHub Release v0.7.2 tarballs contain the real (non-placeholder) UI
- [ ] Verify Docker Hub `duragraph/duragraph:v0.7.2` exists
- [ ] Verify Homebrew tap formula bumped

[spec-skip: ci/release pipeline plumbing only]