### PR TITLE
fix(python): point [project.urls] at monorepo, bump to 0.3.1

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - TBD
+## [0.3.1] - 2026-05-10
+
+### Fixed
+- `[project.urls]` in `pyproject.toml` now points at the monorepo
+  (`Duragraph/duragraph`) instead of the archived standalone
+  `duragraph-python` repo. The links shown on PyPI's project page
+  (Repository / Issues / Changelog) now resolve correctly.
+  Metadata-only release; no code changes.
+
+## [0.3.0] - 2026-05-09
 
 ### Changed
 - **Distribution name renamed from `duragraph-python` to `duragraph`** to

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "duragraph"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python SDK for DuraGraph - Reliable AI Workflow Orchestration"
 readme = "README.md"
 license = "Apache-2.0"
@@ -72,9 +72,9 @@ duragraph = "duragraph.cli.main:main"
 [project.urls]
 Homepage = "https://duragraph.ai"
 Documentation = "https://docs.duragraph.ai"
-Repository = "https://github.com/duragraph/duragraph-python"
-Issues = "https://github.com/duragraph/duragraph-python/issues"
-Changelog = "https://github.com/duragraph/duragraph-python/blob/main/CHANGELOG.md"
+Repository = "https://github.com/Duragraph/duragraph"
+Issues = "https://github.com/Duragraph/duragraph/issues"
+Changelog = "https://github.com/Duragraph/duragraph/blob/main/python/CHANGELOG.md"
 
 [project.entry-points."duragraph"]
 # Allows discovery of this package as a duragraph implementation

--- a/python/src/duragraph/__init__.py
+++ b/python/src/duragraph/__init__.py
@@ -71,7 +71,7 @@ try:
 except ImportError:
     _has_dspy = False
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     # Client


### PR DESCRIPTION
## Summary

Follow-up to the `duragraph` 0.3.0 PyPI publish. The PyPI project page still surfaces the archived `Duragraph/duragraph-python` repo URLs under Repository, Issues, and Changelog. Update `[project.urls]` to the monorepo and cut a metadata-only patch release.

## Changes

- `python/pyproject.toml`
  - `version`: `0.3.0` → `0.3.1`
  - `[project.urls]` Repository / Issues / Changelog now point at `Duragraph/duragraph` (Changelog at `python/CHANGELOG.md`)
- `python/src/duragraph/__init__.py`: `__version__` 0.3.0 → 0.3.1 (keeps runtime version in sync — we already had a fix in 0.2.1 for a stale `__version__`)
- `python/CHANGELOG.md`: insert 0.3.1 entry; pin 0.3.0 date to 2026-05-09 (was "TBD") since it shipped today on PyPI

PATCH per SemVer — metadata-only, no behavior change.

## After merge

Trigger `pypi.yml` (`workflow_dispatch`) to publish 0.3.1.

[spec-skip: metadata-only PyPI URL fix]