### PR TITLE
fix(python): correct Documentation URL to duragraph.ai/docs, bump 0.3.2

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-10
+
+### Fixed
+- `Documentation` URL in `[project.urls]` corrected from
+  `https://docs.duragraph.ai` (non-canonical) to `https://duragraph.ai/docs`.
+  The PyPI sidebar's Documentation link now resolves.
+  Metadata-only release; no code changes.
+
 ## [0.3.1] - 2026-05-10
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "duragraph"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python SDK for DuraGraph - Reliable AI Workflow Orchestration"
 readme = "README.md"
 license = "Apache-2.0"
@@ -71,7 +71,7 @@ duragraph = "duragraph.cli.main:main"
 
 [project.urls]
 Homepage = "https://duragraph.ai"
-Documentation = "https://docs.duragraph.ai"
+Documentation = "https://duragraph.ai/docs"
 Repository = "https://github.com/Duragraph/duragraph"
 Issues = "https://github.com/Duragraph/duragraph/issues"
 Changelog = "https://github.com/Duragraph/duragraph/blob/main/python/CHANGELOG.md"

--- a/python/src/duragraph/__init__.py
+++ b/python/src/duragraph/__init__.py
@@ -71,7 +71,7 @@ try:
 except ImportError:
     _has_dspy = False
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     # Client


### PR DESCRIPTION
## Summary

PyPI sidebar's Documentation link for `duragraph` 0.3.1 pointed at `https://docs.duragraph.ai` (non-canonical — doesn't resolve). The actual docs site is `https://duragraph.ai/docs`. Update `[project.urls]` and bump 0.3.1 → 0.3.2 (PATCH per SemVer — metadata-only).

## Changes

- `python/pyproject.toml`
  - `version`: 0.3.1 → 0.3.2
  - `Documentation`: `https://docs.duragraph.ai` → `https://duragraph.ai/docs`
- `python/src/duragraph/__init__.py`: `__version__` 0.3.1 → 0.3.2
- `python/CHANGELOG.md`: 0.3.2 entry

## After merge

Trigger `pypi.yml` (`workflow_dispatch`) to publish 0.3.2.

[spec-skip: metadata-only PyPI URL fix]