### PR TITLE
docs(monorepo): drop dead links to now-private sibling repos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,19 +79,21 @@ description: Post description
 Content here...
 ```
 
-## Related Repositories
+## Related modules
 
-| Repository                                                                    | Description      |
-| ----------------------------------------------------------------------------- | ---------------- |
-| [duragraph](https://github.com/Duragraph/duragraph)                           | Core API server  |
-| [duragraph-python](https://github.com/Duragraph/duragraph-python)             | Python SDK       |
-| [Go SDK (`go-sdk/`)](https://github.com/Duragraph/duragraph/tree/main/go-sdk) | Go SDK           |
-| [duragraph-examples](https://github.com/Duragraph/duragraph-examples)         | Example projects |
-| [duragraph-studio](https://github.com/Duragraph/duragraph-studio)             | Interactive UI   |
+The docs site source lives in the [`duragraph`](https://github.com/Duragraph/duragraph) monorepo alongside the engine and SDKs:
+
+| Path                                                                             | Description                  |
+| -------------------------------------------------------------------------------- | ---------------------------- |
+| [`/`](https://github.com/Duragraph/duragraph)                                    | Core engine (Go)             |
+| [`python/`](https://github.com/Duragraph/duragraph/tree/main/python)             | Python SDK                   |
+| [`go-sdk/`](https://github.com/Duragraph/duragraph/tree/main/go-sdk)             | Go SDK                       |
+| [`studio/`](https://github.com/Duragraph/duragraph/tree/main/studio)             | Visual workflow editor       |
+| [`examples/`](https://github.com/Duragraph/duragraph/tree/main/examples)         | Runnable example projects    |
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/Duragraph/.github/blob/main/CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](https://github.com/Duragraph/duragraph/blob/main/CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,24 +96,27 @@ duragraph-examples/
 └── README.md
 ```
 
-## Related Repositories
+## Related modules
 
-| Repository | Description |
-|------------|-------------|
-| [duragraph](https://github.com/Duragraph/duragraph) | Core API server |
-| [duragraph-python](https://github.com/Duragraph/duragraph-python) | Python SDK |
-| [Go SDK (`go-sdk/`)](https://github.com/Duragraph/duragraph/tree/main/go-sdk) | Go SDK |
-| [duragraph-docs](https://github.com/Duragraph/duragraph-docs) | Documentation |
+Examples live in the [`duragraph`](https://github.com/Duragraph/duragraph) monorepo alongside the engine and SDKs:
+
+| Path | Description |
+|------|-------------|
+| [`/`](https://github.com/Duragraph/duragraph) | Core engine (Go) |
+| [`python/`](https://github.com/Duragraph/duragraph/tree/main/python) | Python SDK — PyPI: [`duragraph`](https://pypi.org/project/duragraph/) |
+| [`go-sdk/`](https://github.com/Duragraph/duragraph/tree/main/go-sdk) | Go SDK — [`pkg.go.dev`](https://pkg.go.dev/github.com/duragraph/duragraph/go-sdk) |
+| [`studio/`](https://github.com/Duragraph/duragraph/tree/main/studio) | Visual workflow editor |
+| [`docs/`](https://github.com/Duragraph/duragraph/tree/main/docs) | Documentation site source |
 
 ## Documentation
 
 - [Full Documentation](https://duragraph.ai/docs)
-- [Python SDK](https://github.com/Duragraph/duragraph-python)
-- [Go SDK](https://github.com/Duragraph/duragraph/tree/main/go-sdk)
+- [Python SDK (`python/`)](https://github.com/Duragraph/duragraph/tree/main/python)
+- [Go SDK (`go-sdk/`)](https://github.com/Duragraph/duragraph/tree/main/go-sdk)
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/Duragraph/.github/blob/main/CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](https://github.com/Duragraph/duragraph/blob/main/CONTRIBUTING.md) for guidelines.
 
 ### Adding a New Example
 


### PR DESCRIPTION
## Summary

The standalone `duragraph-{python,go,studio,docs}` repos were merged into this monorepo, then archived, and have now been made private. Two READMEs in this repo still link to them in "Related Repositories" tables — those URLs now 404 for any unauthenticated visitor.

Replace with monorepo-aware "Related modules" tables pointing at in-tree paths (same pattern used in `python/README.md` and the org profile README). Also fix two `CONTRIBUTING.md` links that pointed at the `Duragraph/.github` org repo instead of the monorepo root.

Files: `docs/README.md`, `examples/README.md`. No code changes.

[spec-skip: docs-only — link rot cleanup]