### PR TITLE
docs: drop studio/ rows + remove private duragraph-spec mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ DuraGraph is a monorepo. The control plane, SDKs, dashboard, and docs all live h
 |------|------------|
 | `cmd/duragraph` | The control-plane binary — engine, embedded dashboard, dev-mode bootstrapper |
 | `internal/` | Domain / application / infrastructure layers (DDD + event sourcing + CQRS) |
-| `dashboard/` | React + TanStack Router + xyflow dashboard, embedded in the binary at build time |
+| `dashboard/` | React + TanStack Router + xyflow dashboard (incl. visual workflow editor), embedded in the binary at build time |
 | `python/` | Python worker SDK (`duragraph` on PyPI) |
 | `go-sdk/` | Go worker SDK |
-| `studio/` | Visual workflow editor (alpha) |
 | `docs/` | Astro Starlight documentation site |
 | `examples/` | Reference agents in Go and Python |
 | `deploy/` | Docker, SQL migrations, Helm charts |
@@ -135,7 +134,7 @@ What works today:
 - Python and Go worker SDKs
 - OpenTelemetry-friendly Prometheus metrics
 
-In flight (see [`spec/roadmap.yml`](spec/roadmap.yml)):
+In flight:
 
 - Per-node REST spans endpoint (currently SSE-only)
 - Multi-tenant + NATS Accounts isolation
@@ -153,7 +152,7 @@ task dev   # runs the engine + dashboard against a local Postgres + NATS
 task test  # unit + integration suite
 ```
 
-The spec is the source of truth — behavioural changes update [`spec/`](spec/) first, then the implementation. See [`CLAUDE.md`](CLAUDE.md) for the full development workflow.
+See [`CLAUDE.md`](CLAUDE.md) for the full development workflow.
 
 ## License
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -69,13 +69,9 @@ dashboard/
 └── public/
 ```
 
-## Specifications
+## Design system
 
-The full design spec lives in [duragraph-spec/frontend/](https://github.com/Duragraph/duragraph-spec/tree/main/frontend):
-
-- `frontend.yml` — overview, stack, routing
-- `components.yml` — shadcn component inventory
-- `wireframes.yml` — ASCII wireframes for every screen
-- `design-system.yml` — tokens (zero border-radius, Space Grotesk, coral accent)
-- `user-flows.yml`, `user-journeys.yml` — UX flows
-- `graph-builder.yml`, `graph-visualization.yml` — visual editor specs (deferred)
+- Zero border-radius, Space Grotesk display font, coral accent
+- shadcn/ui primitives + sidebar-07 block; xyflow for graph viz
+- React 19 + TypeScript strict, no `any`
+- The visual workflow editor (formerly a standalone `studio/` app) is folded into this dashboard as of #190

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,6 @@ The docs site source lives in the [`duragraph`](https://github.com/Duragraph/dur
 | [`/`](https://github.com/Duragraph/duragraph)                            | Core engine (Go)          |
 | [`python/`](https://github.com/Duragraph/duragraph/tree/main/python)     | Python SDK                |
 | [`go-sdk/`](https://github.com/Duragraph/duragraph/tree/main/go-sdk)     | Go SDK                    |
-| [`studio/`](https://github.com/Duragraph/duragraph/tree/main/studio)     | Visual workflow editor    |
 | [`examples/`](https://github.com/Duragraph/duragraph/tree/main/examples) | Runnable example projects |
 
 ## Contributing

--- a/docs/src/content/docs/docs/architecture/async-events.mdx
+++ b/docs/src/content/docs/docs/architecture/async-events.mdx
@@ -3,9 +3,9 @@ title: Async Event Architecture
 description: NATS JetStream event taxonomy, multi-tenant Accounts, streams, and consumers. The canonical contract that every implementation follows.
 ---
 
-DuraGraph's runtime is event-driven. Every cross-process boundary — control plane to workers, workers back to the control plane, platform onboarding workflows, audit logging, real-time client streaming — is an event published to NATS JetStream. The complete contract is defined in [`duragraph-spec/async/asyncapi.yml`](https://github.com/duragraph/duragraph-spec/blob/main/async/asyncapi.yml) (AsyncAPI 3.0).
+DuraGraph's runtime is event-driven. Every cross-process boundary — control plane to workers, workers back to the control plane, platform onboarding workflows, audit logging, real-time client streaming — is an event published to NATS JetStream.
 
-This page is a guided tour of that spec. It is the most architecture-revealing artifact in the project: the [REST API](/docs/api-reference) tells you what clients can call, the AsyncAPI tells you how the system actually breathes.
+This page describes the live event taxonomy. The [REST API](/docs/api-reference) tells you what clients can call; the events on this page tell you how the system actually breathes between processes.
 
 ---
 
@@ -317,5 +317,3 @@ The contract is in the spec; the wiring is in the Go and Python implementations.
 - [Components](/docs/architecture/components) — Run aggregate, event store, graph engine
 - [Architecture Overview](/docs/architecture/overview) — Horizontal scaling and concurrency
 - [Security Model](/docs/architecture/security-model) — Auth, rate limiting, threat model
-- [`asyncapi.yml`](https://github.com/duragraph/duragraph-spec/blob/main/async/asyncapi.yml) — Full machine-readable spec
-- [`models/events.yml`](https://github.com/duragraph/duragraph-spec/blob/main/models/events.yml) — Canonical event payload schemas

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,7 +105,6 @@ Examples live in the [`duragraph`](https://github.com/Duragraph/duragraph) monor
 | [`/`](https://github.com/Duragraph/duragraph) | Core engine (Go) |
 | [`python/`](https://github.com/Duragraph/duragraph/tree/main/python) | Python SDK — PyPI: [`duragraph`](https://pypi.org/project/duragraph/) |
 | [`go-sdk/`](https://github.com/Duragraph/duragraph/tree/main/go-sdk) | Go SDK — [`pkg.go.dev`](https://pkg.go.dev/github.com/duragraph/duragraph/go-sdk) |
-| [`studio/`](https://github.com/Duragraph/duragraph/tree/main/studio) | Visual workflow editor |
 | [`docs/`](https://github.com/Duragraph/duragraph/tree/main/docs) | Documentation site source |
 
 ## Documentation

--- a/internal/infrastructure/persistence/postgres/migrations/platform/README.md
+++ b/internal/infrastructure/persistence/postgres/migrations/platform/README.md
@@ -27,7 +27,5 @@ file-source format as the tenant migrations next door.
 ## Why this lives next to the engine code
 
 `go:embed` only reads files inside or below the package directory. The SQL
-files were originally at `deploy/sql/{platform,tenant}/` per the
-`duragraph-spec` `backend/development-guide.yml` convention, but to keep
-embedding straightforward they now live alongside the migrator. A follow-up
-update PR to `Duragraph/duragraph-spec` will revise the spec to match.
+files were originally at `deploy/sql/{platform,tenant}/`, but to keep
+embedding straightforward they now live alongside the migrator.

--- a/python/README.md
+++ b/python/README.md
@@ -133,11 +133,10 @@ The Python SDK lives in the [`duragraph`](https://github.com/Duragraph/duragraph
 
 | Path | Description |
 |------|-------------|
-| [`/`](https://github.com/Duragraph/duragraph) | Core engine (Go, embeds dashboard + Studio) |
+| [`/`](https://github.com/Duragraph/duragraph) | Core engine (Go, embeds the React dashboard incl. visual workflow editor) |
 | [`go-sdk/`](https://github.com/Duragraph/duragraph/tree/main/go-sdk) | Go SDK |
 | [`examples/`](https://github.com/Duragraph/duragraph/tree/main/examples) | Example projects (multi-language) |
 | [`docs/`](https://github.com/Duragraph/duragraph/tree/main/docs) | Documentation site source |
-| [`studio/`](https://github.com/Duragraph/duragraph/tree/main/studio) | Visual workflow editor |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Two leaks in the v0.7.3 docs sweep that the user caught:

1. **\`studio/\` rows in component tables**. PR #190 folded the standalone studio app into \`dashboard/\` and the visual workflow editor is now a feature of the dashboard, not its own subdir. Four READMEs still listed it as a separate row (root, \`docs/\`, \`python/\`, \`examples/\`). Replaced with an inline note that the visual editor is embedded in the dashboard.
2. **Private \`duragraph-spec\` mentions on public surfaces**. The spec repo is private by design; six places in the public docs leaked references to it or the now-non-existent \`spec/\` path. Removed/rephrased:
   - \`README.md\` — dropped the \"spec is the source of truth\" sentence and the \`spec/roadmap.yml\` link from the Status section
   - \`dashboard/README.md\` — replaced the \"design spec lives in duragraph-spec/frontend\" section with an inline design-system summary
   - \`docs/src/content/docs/docs/architecture/async-events.mdx\` — dropped three \`duragraph-spec\` links (intro paragraph + two Resources entries)
   - \`internal/.../migrations/platform/README.md\` — stripped the \`duragraph-spec\` convention reference

Public docs no longer reference \`duragraph-spec\` or list studio as a top-level component.

## Test plan

- [ ] CI passes (Prettier, conformance, builds)
- [ ] \`grep -r 'duragraph-spec\\|tree/main/studio' docs/ *.md\` returns nothing