### PR TITLE
fix(python): align worker register payload with engine, bump 0.3.3

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "duragraph"
-version = "0.3.2"
-description = "Python SDK for DuraGraph - Reliable AI Workflow Orchestration"
+version = "0.3.3"
+description = "Python SDK for DuraGraph — durable, replayable agent workflows"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bump \`python/pyproject.toml\`: \`0.3.2\` → \`0.3.3\`. Also refresh the description string to match the v0.7.3 positioning.

The actual SDK code change that warrants the bump landed in **#191** (the engine-side traces fix), specifically the change to \`python/src/duragraph/worker/worker.py\` that flattened the \`graph_definitions\` payload to the shape the engine expects:

> \`WorkerClient.register\` was sending \`graph_definitions\` as \`{graph_id, definition: g.to_ir()}\`, but the engine's worker-graph registry expects a flat \`{graph_id, name, description, nodes, edges, entry_point}\`. The wrapping silently failed: workers registered, but the engine couldn't introspect their graph topology, so the dashboard's \`/traces\` Graph tab showed an empty graph for every Python-worker assistant.

That fix is on \`main\` but not yet released to PyPI. \`0.3.2\` (currently on PyPI) does not work with engine \`v0.7.3\`'s graph-introspection path.

## Test plan

- [ ] CI passes
- [ ] After merge, manually trigger PyPI publish: \`gh workflow run pypi.yml --ref main\` (per the workflow_dispatch flow in \`.github/workflows/pypi.yml\`)
- [ ] Confirm \`pip install duragraph==0.3.3\` works on PyPI
- [ ] A Python worker on \`0.3.3\` against engine \`v0.7.3\` renders correctly in \`/traces\` Graph tab