### PR TITLE
chore: drop LangGraph framing from brew formula + dockerhub descriptions

### DIFF
--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -22,5 +22,5 @@ jobs:
           username: ${{ secrets.INFISICAL_DOCKER_USERNAME }}
           password: ${{ secrets.INFISICAL_DOCKER_PASSWORD }}
           repository: ${{ secrets.INFISICAL_DOCKER_USERNAME }}/duragraph
-          short-description: "Open-source LangGraph Cloud-compatible AI workflow orchestration with event sourcing & CQRS"
+          short-description: "Temporal for AI agents — durable, replayable, event-sourced workflow orchestration. Self-hosted."
           enable-url-completion: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,7 @@ brews:
       token: "{{ .Env.INFISICAL_HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     homepage: "https://github.com/Duragraph/duragraph"
-    description: "LangGraph-compatible AI workflow orchestration platform — durable, self-hostable, single binary."
+    description: "Temporal for AI agents — durable, replayable agent workflows on your infra. Self-hosted, event-sourced, single binary."
     license: "Apache-2.0"
     commit_author:
       name: duragraph-release-bot


### PR DESCRIPTION
## Summary

Two release-metadata strings still pitched DuraGraph as \"LangGraph-compatible\" / \"LangGraph Cloud-compatible\". Both now lead with the \"Temporal for AI agents\" framing to match the v0.7.3 positioning realignment.

### \`.goreleaser.yml\` (brew formula \`desc\`)

```diff
- description: "LangGraph-compatible AI workflow orchestration platform — durable, self-hostable, single binary."
+ description: "Temporal for AI agents — durable, replayable agent workflows on your infra. Self-hosted, event-sourced, single binary."
```

Auto-written into \`Duragraph/homebrew-tap/Formula/duragraph.rb\`'s \`desc\` field on each release. Visible in \`brew info duragraph\`.

### \`.github/workflows/dockerhub-readme.yml\` (Docker Hub short-description)

```diff
- short-description: "Open-source LangGraph Cloud-compatible AI workflow orchestration with event sourcing & CQRS"
+ short-description: "Temporal for AI agents — durable, replayable, event-sourced workflow orchestration. Self-hosted."
```

100-char tagline shown above the README on the Docker Hub repo page.

## Effect timing

- **Brew formula \`desc\`**: changes on the next release tag (v0.7.4 onward). v0.7.3's formula is already written and immutable.
- **Docker Hub short-description**: changes on the next push to \`main\` that touches \`README.md\` or this workflow file. (The workflow's \`paths:\` trigger covers both.)

## Test plan

- [ ] \`grep -rE 'LangGraph[^.]*compatible' .goreleaser.yml .github/workflows/\` returns nothing
- [ ] After merge, the dockerhub-readme workflow runs (since this PR touches its YAML) and pushes the new short-description