### PR TITLE
chore(dev): cut watch SIGTERMGrace from 10s to 2s for faster Ctrl-C

### DIFF
--- a/internal/dev/watch/supervisor.go
+++ b/internal/dev/watch/supervisor.go
@@ -65,7 +65,14 @@ type WorkerSupervisor struct {
 func newWorkerSupervisor(cfg supervisorConfig) *WorkerSupervisor {
 	prefix := "[" + filepath.Base(cfg.File) + "] "
 	if cfg.SIGTERMGrace == 0 {
-		cfg.SIGTERMGrace = 10 * time.Second
+		// 2s is enough time for a worker that actually handles SIGTERM
+		// to flush logs + exit; workers that ignore it get SIGKILL'd
+		// 8 seconds sooner than the previous 10s default, which made
+		// `duragraph dev` Ctrl-C take 10–13s end-to-end. Dev iteration
+		// loops benefit far more from snappiness than from gentle
+		// shutdown — anyone reaching for the long-grace path should
+		// configure SIGTERMGrace explicitly.
+		cfg.SIGTERMGrace = 2 * time.Second
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = log.Default()

--- a/internal/dev/watch/watch.go
+++ b/internal/dev/watch/watch.go
@@ -67,7 +67,7 @@ type Options struct {
 	DebounceWindow time.Duration
 
 	// SIGTERMGrace is how long a worker has to exit after SIGTERM
-	// before SIGKILL. Default 10s (per spec).
+	// before SIGKILL. Default 2s — see supervisor.go for the reasoning.
 	SIGTERMGrace time.Duration
 
 	// HealthURL is the engine's /health endpoint. The watcher polls
@@ -135,7 +135,7 @@ func New(opts Options) (*Watcher, error) {
 		opts.DebounceWindow = 200 * time.Millisecond
 	}
 	if opts.SIGTERMGrace == 0 {
-		opts.SIGTERMGrace = 10 * time.Second
+		opts.SIGTERMGrace = 2 * time.Second
 	}
 	if opts.HealthURL == "" {
 		opts.HealthURL = fmt.Sprintf("http://localhost:%d/health", opts.EnginePort)


### PR DESCRIPTION
## Summary

\`duragraph dev\` Ctrl-C took 10–13 seconds end-to-end to fully exit. Empirical timing observed today:

| t  | state |
|----|-------|
| 0s | SIGINT sent to engine |
| 0–10s | all 14 processes still alive (engine + embedded postgres + 6 uv→python chains) |
| 10–13s | everything dies in a burst |
| 13s+ | zero survivors |

The 10-second hold was the watch supervisor's \`SIGTERMGrace\`: it sends SIGTERM to each Python worker's process group, waits up to that grace, then SIGKILLs. The shipped Python workers don't catch SIGTERM, so they all hit the SIGKILL deadline.

This PR drops the default grace from 10s to 2s, bringing end-to-end Ctrl-C latency to ~2–3s. Workers that handle SIGTERM cleanly exit instantly; workers that don't get force-killed 8s sooner. No behaviour change for callers that pass \`SIGTERMGrace\` explicitly.

Files: \`internal/dev/watch/supervisor.go\`, \`internal/dev/watch/watch.go\` (defaults only).

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/dev/watch/...\` passes
- [ ] Manual: \`duragraph dev --watch examples/python\`, then Ctrl-C — verify shutdown ≤ 3s and no orphan processes