### PR TITLE
feat(debug): add pprof debug listener for contributor profiling

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -211,3 +211,27 @@ tasks:
       - rm -rf dashboard/node_modules/
       - rm -rf python/.venv/
       - go clean -modcache
+
+  # Profiling shortcuts. Assume `duragraph dev` is running locally with
+  # its default pprof listener at 127.0.0.1:6060 (auto-enabled in dev
+  # mode). See docs/project/profiling for the full contributor workflow.
+  profile:heap:
+    desc: Take a heap snapshot from the running engine and open pprof
+    cmds:
+      - go tool pprof http://localhost:6060/debug/pprof/heap
+
+  profile:goroutines:
+    desc: Dump every goroutine's stack from the running engine
+    cmds:
+      - curl -s 'http://localhost:6060/debug/pprof/goroutine?debug=2'
+
+  profile:cpu:
+    desc: Capture a 30s CPU profile from the running engine and open pprof
+    cmds:
+      - go tool pprof 'http://localhost:6060/debug/pprof/profile?seconds=30'
+
+  profile:trace:
+    desc: Capture a 5s runtime execution trace and open in `go tool trace`
+    cmds:
+      - curl -o /tmp/duragraph-trace.out 'http://localhost:6060/debug/pprof/trace?seconds=5'
+      - go tool trace /tmp/duragraph-trace.out

--- a/cmd/duragraph/cmd/dev.go
+++ b/cmd/duragraph/cmd/dev.go
@@ -177,4 +177,8 @@ func applyDevEnvDefaults(opts devOptions) {
 	setIfUnset("PORT", strconv.Itoa(opts.Port))
 	setIfUnset("DB_EMBEDDED_DATA_DIR", filepath.Join(opts.DataDir, "pg"))
 	setIfUnset("NATS_EMBEDDED_DATA_DIR", filepath.Join(opts.DataDir, "nats"))
+	// Auto-enable the pprof debug listener for contributor-friendly
+	// profiling. 127.0.0.1-bound so it's never reachable beyond the
+	// laptop; operators running `duragraph serve` opt in explicitly.
+	setIfUnset("DURAGRAPH_PPROF_ADDR", "127.0.0.1:6060")
 }

--- a/cmd/duragraph/cmd/serve.go
+++ b/cmd/duragraph/cmd/serve.go
@@ -34,6 +34,7 @@ import (
 	"github.com/duragraph/duragraph/internal/infrastructure/streaming"
 	"github.com/duragraph/duragraph/internal/infrastructure/tools"
 	"github.com/duragraph/duragraph/internal/infrastructure/tracing"
+	"github.com/duragraph/duragraph/internal/pkg/debug"
 	"github.com/duragraph/duragraph/internal/pkg/eventbus"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
@@ -93,6 +94,18 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
+
+	// pprof debug listener (optional, contributor-only). Enabled when
+	// DURAGRAPH_PPROF_ADDR is set — auto-set to 127.0.0.1:6060 by
+	// `duragraph dev`, off by default in `duragraph serve`. The debug
+	// package binds to a separate localhost listener and refuses
+	// public binds without an explicit override. See
+	// internal/pkg/debug/pprof.go for the contributor workflow.
+	if pprofAddr := os.Getenv("DURAGRAPH_PPROF_ADDR"); pprofAddr != "" {
+		if err := debug.StartPprof(ctx, pprofAddr); err != nil {
+			slog.Warn("pprof listener not started", "err", err)
+		}
+	}
 
 	// Embedded Postgres (binary-modes.yml § embedded_components.postgres).
 	//

--- a/docs/src/content/docs/docs/project/profiling.mdx
+++ b/docs/src/content/docs/docs/project/profiling.mdx
@@ -1,0 +1,118 @@
+---
+title: Profiling
+description: How to use the built-in pprof debug listener to find memory leaks, goroutine leaks, and CPU hotspots in the DuraGraph engine.
+---
+
+DuraGraph ships a [`net/http/pprof`](https://pkg.go.dev/net/http/pprof) listener for contributor profiling. It exposes Go's standard profile surface — heap, goroutines, CPU, allocations, mutex contention, execution traces — on a separate localhost-bound port so it can't accidentally leak through the main API.
+
+## Enabling
+
+**`duragraph dev`** turns the listener on automatically at `127.0.0.1:6060` (see `cmd/duragraph/cmd/dev.go`'s `applyDevEnvDefaults`).
+
+**`duragraph serve`** leaves it off. Operators opt in with:
+
+```bash
+DURAGRAPH_PPROF_ADDR=127.0.0.1:6060 duragraph serve
+```
+
+Public binds (anything not on `127.0.0.1` / `localhost` / `::1`) are **refused by default** — pprof endpoints leak heap state and accept long-running profile requests that can DoS the engine. The guard can be bypassed with `DURAGRAPH_PPROF_ALLOW_PUBLIC=true` if you have a specific reason (e.g. profiling inside a private network), but it should never be set in a production deploy with public reach.
+
+## Finding a memory leak
+
+```bash
+# 1. Take a snapshot before the suspect path
+curl -o before.pprof http://localhost:6060/debug/pprof/heap
+
+# 2. Exercise the engine — replay the workflow, send a flurry of runs,
+#    whatever you think is leaking. Wait ~30 seconds after it settles
+#    so GC has a chance to reclaim anything not actually retained.
+
+# 3. Take an after snapshot
+curl -o after.pprof http://localhost:6060/debug/pprof/heap
+
+# 4. Diff
+go tool pprof -base=before.pprof after.pprof
+```
+
+Then in the pprof REPL:
+
+```
+(pprof) top10                  # biggest growth between snapshots
+(pprof) list someFunction      # source-level annotation
+(pprof) web                    # flamegraph in your browser
+```
+
+Anything that grew unboundedly between snapshots is your leak. Typical culprits: maps that never delete entries, goroutines that hold references to large structs, response bodies / connections not closed.
+
+## Finding a goroutine leak
+
+Goroutine leaks are more common than heap leaks in event-driven systems like DuraGraph — every long-running goroutine retains every variable it references, often a transitive heap-full of state. The engine spawns goroutines for:
+
+- HTTP request handlers
+- SSE stream subscribers
+- The outbox relay
+- The cron scheduler
+- The watch supervisor (in dev mode)
+- The lease monitor + stale-worker cleanup loops
+- Each subscribed NATS consumer
+
+Count goroutines over time:
+
+```bash
+# Baseline count
+curl -s 'http://localhost:6060/debug/pprof/goroutine?debug=2' | grep -c '^goroutine'
+
+# Exercise the suspect path
+
+# Re-count
+curl -s 'http://localhost:6060/debug/pprof/goroutine?debug=2' | grep -c '^goroutine'
+```
+
+A healthy engine settles at a steady-state goroutine count (~50–200 depending on consumers). If the count climbs without bound, dump the stacks to see what's stuck:
+
+```bash
+curl -s 'http://localhost:6060/debug/pprof/goroutine?debug=2' > goroutines.txt
+# Look for: many goroutines parked at the same line of the same function.
+# That's your stuck call. Usually a channel send/recv that has no receiver/sender.
+```
+
+## CPU profiling
+
+```bash
+# Profile for 30 seconds while the engine is under load
+go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+```
+
+REPL commands work the same as for heap profiles.
+
+## Execution traces (Go runtime trace)
+
+For visualising scheduler behaviour, GC pauses, or blocking syscalls:
+
+```bash
+curl -o trace.out 'http://localhost:6060/debug/pprof/trace?seconds=5'
+go tool trace trace.out
+```
+
+Opens an interactive HTML viewer.
+
+## Available endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /debug/pprof/` | HTML index of available profiles |
+| `GET /debug/pprof/heap` | Current heap snapshot |
+| `GET /debug/pprof/goroutine` | Goroutine count + stack dumps (`?debug=2` for full stacks) |
+| `GET /debug/pprof/profile?seconds=N` | CPU profile (default 30 s) |
+| `GET /debug/pprof/allocs` | Cumulative alloc tracking (all allocations since start) |
+| `GET /debug/pprof/mutex` | Mutex contention profile |
+| `GET /debug/pprof/block` | Goroutine blocking events |
+| `GET /debug/pprof/trace?seconds=N` | Runtime execution trace |
+| `GET /debug/pprof/cmdline` | The engine's argv |
+| `GET /debug/pprof/symbol` | Symbol resolution helper (used by pprof itself) |
+
+## Security recap
+
+- Never bind to `0.0.0.0` or a public interface in production. The default-deny guard catches accidents, but don't override it without a clear reason.
+- Anyone with network access to the pprof listener can read your heap (often contains tokens, credentials, intermediate LLM state) and DoS your engine.
+- The dev-mode default of `127.0.0.1:6060` is safe because loopback isn't routable.

--- a/docs/src/content/docs/docs/project/profiling.mdx
+++ b/docs/src/content/docs/docs/project/profiling.mdx
@@ -98,18 +98,18 @@ Opens an interactive HTML viewer.
 
 ## Available endpoints
 
-| Endpoint | Purpose |
-|---|---|
-| `GET /debug/pprof/` | HTML index of available profiles |
-| `GET /debug/pprof/heap` | Current heap snapshot |
-| `GET /debug/pprof/goroutine` | Goroutine count + stack dumps (`?debug=2` for full stacks) |
-| `GET /debug/pprof/profile?seconds=N` | CPU profile (default 30 s) |
-| `GET /debug/pprof/allocs` | Cumulative alloc tracking (all allocations since start) |
-| `GET /debug/pprof/mutex` | Mutex contention profile |
-| `GET /debug/pprof/block` | Goroutine blocking events |
-| `GET /debug/pprof/trace?seconds=N` | Runtime execution trace |
-| `GET /debug/pprof/cmdline` | The engine's argv |
-| `GET /debug/pprof/symbol` | Symbol resolution helper (used by pprof itself) |
+| Endpoint                             | Purpose                                                    |
+| ------------------------------------ | ---------------------------------------------------------- |
+| `GET /debug/pprof/`                  | HTML index of available profiles                           |
+| `GET /debug/pprof/heap`              | Current heap snapshot                                      |
+| `GET /debug/pprof/goroutine`         | Goroutine count + stack dumps (`?debug=2` for full stacks) |
+| `GET /debug/pprof/profile?seconds=N` | CPU profile (default 30 s)                                 |
+| `GET /debug/pprof/allocs`            | Cumulative alloc tracking (all allocations since start)    |
+| `GET /debug/pprof/mutex`             | Mutex contention profile                                   |
+| `GET /debug/pprof/block`             | Goroutine blocking events                                  |
+| `GET /debug/pprof/trace?seconds=N`   | Runtime execution trace                                    |
+| `GET /debug/pprof/cmdline`           | The engine's argv                                          |
+| `GET /debug/pprof/symbol`            | Symbol resolution helper (used by pprof itself)            |
 
 ## Security recap
 

--- a/internal/pkg/debug/pprof.go
+++ b/internal/pkg/debug/pprof.go
@@ -1,0 +1,141 @@
+// Package debug exposes the stdlib net/http/pprof handlers on a
+// separate localhost-bound listener for contributor profiling. It is
+// deliberately separated from the main API router so:
+//
+//   - pprof handlers cannot leak through accidentally if someone wires
+//     the default ServeMux into a public listener
+//   - the listener can be bound to 127.0.0.1 (or empty / off entirely)
+//     regardless of where the API server binds, so production deploys
+//     don't accidentally expose heap dumps to the internet
+//   - enabling/disabling is a single env var, no flag plumbing through
+//     cobra or config.Load needed
+//
+// Workflow:
+//
+//	`duragraph dev` auto-enables this at 127.0.0.1:6060 (see dev.go's
+//	applyDevEnvDefaults — sets DURAGRAPH_PPROF_ADDR if unset).
+//
+//	`duragraph serve` leaves it off. Operators opt in with:
+//	    DURAGRAPH_PPROF_ADDR=127.0.0.1:6060 duragraph serve
+//	never expose this on 0.0.0.0 — see security note below.
+//
+// Contributor usage once running:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/heap
+//	  (pprof) top10
+//	  (pprof) list <function>
+//	  (pprof) web        # flamegraph in browser
+//
+//	curl http://localhost:6060/debug/pprof/goroutine?debug=2 | grep -c '^goroutine'
+//	  prints the goroutine count — diff across snapshots to find leaks
+//
+// Security note: the pprof endpoints expose heap state (sensitive
+// data may be retained in memory), accept long-running profile
+// requests (DoS via worker exhaustion), and reveal binary symbols
+// (useful for vulnerability scanning). NEVER bind to 0.0.0.0 or a
+// public interface — the unconditional 127.0.0.1 default in dev
+// mode is intentional.
+package debug
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strings"
+	"time"
+)
+
+// StartPprof spins up a separate net/http listener on addr serving
+// the stdlib net/http/pprof handlers. Returns nil if addr is empty
+// (pprof disabled). Returns an error only on misconfiguration —
+// the listener runs in a goroutine, so listener errors after Start
+// returns are slog.Error()'d but not returned.
+//
+// Defensive: rejects non-localhost binds with a slog.Warn + a guard
+// rejection. Operators who genuinely need a remote-reachable pprof
+// can set DURAGRAPH_PPROF_ALLOW_PUBLIC=true to bypass — but the
+// default-deny is intentional.
+func StartPprof(ctx context.Context, addr string) error {
+	if addr == "" {
+		return nil
+	}
+
+	// Guard against accidental public binds.
+	if !isLocalhostBind(addr) && !envAllowsPublic() {
+		slog.Warn("pprof listener refused public bind",
+			"addr", addr,
+			"hint", "set DURAGRAPH_PPROF_ALLOW_PUBLIC=true to override, but heap dumps + DoS risk")
+		return errors.New("pprof: refused public bind (set DURAGRAPH_PPROF_ALLOW_PUBLIC=true to override)")
+	}
+
+	// Register pprof handlers on a fresh mux so they NEVER end up on
+	// the default ServeMux. If we used `import _ "net/http/pprof"`
+	// instead, the handlers would be registered on the default mux
+	// at init time — meaning any future code that wires
+	// http.DefaultServeMux into a public listener (third-party
+	// integration, devtools, anything) would expose pprof too. A
+	// scoped mux is belt-and-suspenders.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second, // belt-and-suspenders against slowloris
+	}
+
+	go func() {
+		slog.Info("pprof listener started", "addr", addr)
+		err := srv.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("pprof listener failed", "err", err)
+		}
+	}()
+
+	// Graceful shutdown when the parent context is cancelled. Mirrors
+	// the engine's main HTTP server lifecycle so pprof doesn't
+	// outlive a graceful Ctrl-C.
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	return nil
+}
+
+// isLocalhostBind returns true if addr resolves to a loopback bind.
+// We accept ":<port>" (binds to all interfaces — technically not
+// loopback) only when the user has explicitly set the public-allow
+// env var, otherwise it's caught by the public-bind guard.
+func isLocalhostBind(addr string) bool {
+	// Strip optional ":port" suffix; pull out the host.
+	host := addr
+	if idx := strings.LastIndex(addr, ":"); idx >= 0 {
+		host = addr[:idx]
+	}
+	switch host {
+	case "127.0.0.1", "localhost", "::1", "[::1]":
+		return true
+	default:
+		return false
+	}
+}
+
+func envAllowsPublic() bool {
+	// Read at call time (not init) so tests can flip it via t.Setenv.
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("DURAGRAPH_PPROF_ALLOW_PUBLIC"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/pkg/debug/pprof_test.go
+++ b/internal/pkg/debug/pprof_test.go
@@ -1,0 +1,99 @@
+package debug
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartPprof_EmptyAddrIsNoOp(t *testing.T) {
+	// Empty addr → pprof disabled. Should return nil without starting
+	// any listener.
+	if err := StartPprof(context.Background(), ""); err != nil {
+		t.Fatalf("empty addr: want nil err, got %v", err)
+	}
+}
+
+func TestStartPprof_LocalhostBindServesHeapHandler(t *testing.T) {
+	// Bind to :0 → kernel picks a free port. We need a deterministic
+	// localhost-prefixed addr so isLocalhostBind accepts it; ":0"
+	// would fail the public-bind guard, so we explicitly bind to
+	// 127.0.0.1:0 instead. The Listen behaviour is the same.
+	addr := "127.0.0.1:46060"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := StartPprof(ctx, addr); err != nil {
+		t.Fatalf("StartPprof: %v", err)
+	}
+
+	// Give the goroutine a moment to actually bind. ListenAndServe
+	// runs in a goroutine; without this the first request can race
+	// the listener and connection-refuse.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := http.Get("http://" + addr + "/debug/pprof/")
+		if err == nil {
+			conn.Body.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// `?debug=1` gives the human-readable text profile; without it,
+	// the response is a pprof-format binary blob (also 200, but
+	// trickier to verify in a test).
+	resp, err := http.Get("http://" + addr + "/debug/pprof/heap?debug=1")
+	if err != nil {
+		t.Fatalf("GET heap: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("heap status: want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestStartPprof_RefusesPublicBindByDefault(t *testing.T) {
+	// 0.0.0.0 binds are rejected unless DURAGRAPH_PPROF_ALLOW_PUBLIC
+	// is set. Default-deny is the whole reason this package exists.
+	err := StartPprof(context.Background(), "0.0.0.0:46061")
+	if err == nil {
+		t.Fatalf("public bind: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "refused public bind") {
+		t.Errorf("error message should mention 'refused public bind', got: %v", err)
+	}
+}
+
+func TestStartPprof_AllowsPublicBindWithOverride(t *testing.T) {
+	t.Setenv("DURAGRAPH_PPROF_ALLOW_PUBLIC", "true")
+	// Use a port we won't actually serve on for the test — just
+	// verifying the guard doesn't reject the call. The listener
+	// itself will fail or succeed depending on port availability,
+	// but StartPprof returns nil regardless because the listener
+	// runs in a goroutine.
+	if err := StartPprof(context.Background(), "0.0.0.0:0"); err != nil {
+		t.Fatalf("override should permit: %v", err)
+	}
+}
+
+func TestIsLocalhostBind(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1:6060": true,
+		"localhost:6060": true,
+		"[::1]:6060":     true,
+		"::1:6060":       true,
+		"0.0.0.0:6060":   false,
+		":6060":          false,
+		"10.0.0.1:6060":  false,
+		"example.com:80": false,
+	}
+	for addr, want := range cases {
+		got := isLocalhostBind(addr)
+		if got != want {
+			t.Errorf("isLocalhostBind(%q) = %v, want %v", addr, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in pprof debug listener for contributors hunting memory leaks, goroutine leaks, or CPU hotspots — a long-running event-driven system like DuraGraph collects plenty of opportunities for both.

### What's enabled

- **\`internal/pkg/debug\`** package — single \`StartPprof(ctx, addr)\` function. Mounts the stdlib \`net/http/pprof\` handlers on a **fresh ServeMux** (not the default mux, so the handlers can never leak through to the main API listener even if someone wires the default mux somewhere).
- **\`duragraph dev\`** auto-enables it at \`127.0.0.1:6060\` via \`applyDevEnvDefaults\` — contributors get pprof for free, no flags to remember.
- **\`duragraph serve\`** leaves it off. Operators opt in via \`DURAGRAPH_PPROF_ADDR=127.0.0.1:6060\`.

### Security guardrails

- **Default-deny public binds.** Anything not on \`127.0.0.1\` / \`localhost\` / \`::1\` is refused with a clear error. pprof endpoints leak heap state (sensitive intermediate values, tokens) and accept long-running profile requests that can DoS the engine — never exposing them on a routable interface, even by accident, is the whole point.
- \`DURAGRAPH_PPROF_ALLOW_PUBLIC=true\` exists as an explicit override for the rare legitimate cases (profiling inside a private subnet).
- \`ReadHeaderTimeout: 5s\` on the listener (slowloris guard).
- Graceful shutdown wired to the parent ctx.

### Contributor workflow docs

- \`docs/src/content/docs/docs/project/profiling.mdx\` — heap snapshot diff workflow, goroutine leak detection, CPU profiles, runtime traces. Real \`go tool pprof\` REPL commands, security recap, table of every available endpoint.
- Taskfile shortcuts: \`task profile:heap\`, \`task profile:goroutines\`, \`task profile:cpu\`, \`task profile:trace\`.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` passes
- [x] \`go test ./internal/pkg/debug/...\` — 5/5 tests pass (empty-addr no-op, localhost bind serves /heap, public bind refused, override accepts public bind, isLocalhostBind table tests)
- [ ] Manual: \`duragraph dev\`, then \`task profile:heap\` opens a working pprof REPL
- [ ] Manual: \`curl http://localhost:6060/debug/pprof/goroutine?debug=2\` dumps stacks