### PR TITLE
fix(dashboard): /api/* unmatched paths return 404, not confusing 405

### DIFF
--- a/internal/infrastructure/http/dashboard/handler.go
+++ b/internal/infrastructure/http/dashboard/handler.go
@@ -11,11 +11,20 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// Register mounts the dashboard at the catch-all GET route. API and system
-// routes (/api/*, /health, /metrics, /ok, /info) must already be registered;
-// Echo's router prioritises exact matches over the wildcard.
+// Register mounts the dashboard at a catch-all route that accepts ALL
+// methods. API and system routes (/api/*, /health, /metrics, /ok, /info)
+// must already be registered; Echo's router prioritises exact matches over
+// the wildcard.
+//
+// Why Any and not GET: registering this as e.GET caused unmatched POST /api/*
+// requests (e.g. when password auth is disabled and the dashboard still
+// tries to POST /api/auth/login) to return 405 Method Not Allowed because
+// Echo's router matched the path against the GET wildcard but rejected the
+// method *before* any handler ran. Registering for Any lets the handler run
+// for every method, where it can return a clean 404 for /api/* paths that
+// have no real registered route.
 func Register(e *echo.Echo, distFS fs.FS) {
-	e.GET("/*", spaHandler(distFS))
+	e.Any("/*", spaHandler(distFS))
 }
 
 func spaHandler(distFS fs.FS) echo.HandlerFunc {
@@ -24,6 +33,32 @@ func spaHandler(distFS fs.FS) echo.HandlerFunc {
 
 	return func(c echo.Context) error {
 		req := c.Request()
+
+		// Never absorb /api/* paths into the SPA fallback. When an API
+		// route is conditionally disabled (e.g. POST /api/auth/login
+		// is only registered when AUTH_PASSWORD_ENABLED=true), an
+		// unmatched request against /api/* would otherwise hit this
+		// catch-all and either serve index.html (for GET) or return 405
+		// (for POST/PUT/DELETE), both of which are confusing. Returning
+		// ErrNotFound here lets the engine's error middleware respond
+		// with a clean 404 + JSON body that callers can parse.
+		//
+		// Health / metrics / system endpoints (/health, /ok, /info,
+		// /metrics) and real API routes are registered with exact paths
+		// and reach their handlers before this catch-all fires, so this
+		// guard only filters genuinely-unmatched /api/* requests.
+		if strings.HasPrefix(req.URL.Path, "/api/") {
+			return echo.ErrNotFound
+		}
+
+		// Non-API, non-GET requests against the SPA make no sense (the
+		// dashboard is HTML/JS/CSS served via GET; state changes go to
+		// /api/*). Return 405 instead of trying to read static assets
+		// with the wrong method.
+		if req.Method != http.MethodGet {
+			return echo.ErrMethodNotAllowed
+		}
+
 		path := strings.TrimPrefix(req.URL.Path, "/")
 		// Trim trailing slash before fs.Open — io/fs treats "studio/"
 		// as an invalid name and returns ErrInvalid rather than ErrNotExist,

--- a/internal/infrastructure/http/dashboard/handler_test.go
+++ b/internal/infrastructure/http/dashboard/handler_test.go
@@ -87,3 +87,47 @@ func TestSPAHandler_DoesNotInterceptAPIRoutes(t *testing.T) {
 		t.Fatalf("body = %q, want API response", got)
 	}
 }
+
+// Regression: unmatched /api/* requests must return a clean 404, NOT a 405
+// from the GET-only SPA fallback. Bug observed in v0.7.4: when password auth
+// was disabled (AUTH_PASSWORD_ENABLED not set), POST /api/auth/login fell
+// through to the catch-all GET wildcard and Echo returned 405 Method Not
+// Allowed, confusing users who just wanted to log in.
+func TestSPAHandler_UnmatchedAPIPathReturns404NotMethodNotAllowed(t *testing.T) {
+	e := echo.New()
+	Register(e, newTestFS())
+
+	// POST to an /api/* path that has NO handler registered. Before the fix
+	// this returned 405 (matched the catch-all GET wildcard with wrong method).
+	// After the fix it returns 404 (the API route legitimately does not exist).
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("status = 405; SPA fallback absorbed /api/* POST (regression of the v0.7.4 login bug)")
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for unmatched /api/* path", rec.Code)
+	}
+}
+
+// Same shape but with GET — also must return 404, not the SPA index.
+// Without the /api/* guard, GET on an unmatched /api/* path would 200 with
+// the React SPA body, which is even more confusing (the dashboard mounting
+// at the API URL instead of an honest "not found").
+func TestSPAHandler_UnmatchedAPIPathGETReturns404NotIndexHTML(t *testing.T) {
+	e := echo.New()
+	Register(e, newTestFS())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/does/not/exist", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (api path should not fall through to SPA)", rec.Code)
+	}
+	if got := rec.Body.String(); got == "<html>root</html>" {
+		t.Fatalf("body served index.html for /api/* path; should 404 instead")
+	}
+}


### PR DESCRIPTION
## Summary

The dashboard's SPA fallback (\`e.GET(\"/*\", spaHandler)\`) was absorbing unmatched POST /api/* requests and triggering a \`405 Method Not Allowed\` from Echo's router. Most user-visible case: when a deployment runs without \`AUTH_PASSWORD_ENABLED=true\`, the password-auth handler isn't constructed, so POST /api/auth/login has no real route — the dashboard's login form posts there and the user sees:

\`\`\`
api/auth/login:1 Failed to load resource: the server responded with a status of 405 (Method Not Allowed)
\`\`\`

…with no useful next step. The v0.7.4 deploy templates default \`AUTH_PASSWORD_ENABLED=false\`, so this lands on every new Fly/Render/Railway/DO/Scaleway deploy.

## Fix

Register the catch-all as \`e.Any(\"/*\", spaHandler)\` so the handler runs for every method, then dispatch inside:

| Case | Response | Why |
|---|---|---|
| Unmatched \`/api/*\` (any method) | \`404 Not Found\` | API routes should produce honest 404s, not method-confusion |
| Non-GET on non-API path | \`405 Method Not Allowed\` | SPA assets are GET-only |
| GET on non-API path | SPA \`index.html\` (unchanged) | Client-side routing still works |
| Real API route exists | exact-match wins | Echo's router prioritises exact matches over wildcards |

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/infrastructure/http/dashboard/ -v\` — 6/6 tests pass:
  - Existing: serves index at /, serves assets, falls back for unknown paths, doesn't intercept registered API routes
  - **New**: unmatched /api/* POST returns 404 (not 405) — regression test for this bug
  - **New**: unmatched /api/* GET returns 404 (not the SPA index)
- [ ] Manual: \`duragraph dev\` (without AUTH_PASSWORD_ENABLED), POST /api/auth/login → confirm 404 with JSON body

## Hotfix candidate

Worth tagging \`v0.7.5\` once this lands — every new user trying the deploy templates from v0.7.4 will hit this exact 405 footgun otherwise.