### PR TITLE
fix(serve): log clear bootstrap-admin instructions when AUTH_PASSWORD_ENABLED=true

### DIFF
--- a/cmd/duragraph/cmd/serve.go
+++ b/cmd/duragraph/cmd/serve.go
@@ -579,6 +579,29 @@ func runServe(_ *cobra.Command, _ []string) error {
 			}
 			passwordHandler = ph
 			slog.Info("Password auth handler constructed (POST /api/auth/register, /api/auth/login)")
+
+			// Loud, actionable startup hint for operators following the
+			// `duragraph dev` quickstart. The engine ships NO default
+			// credentials (deliberate — no widely-known-default-password
+			// CVE), so users need to know:
+			//   * there is no default to log in with
+			//   * the first user to register becomes the bootstrap admin
+			//   * which URL to open / endpoint to hit
+			// Without this hint, users with AUTH_PASSWORD_ENABLED=true hit
+			// a login page with no obvious next step.
+			//
+			// Display the host as "localhost" when bound to 0.0.0.0 so
+			// the printed URL is clickable rather than a non-routable
+			// network bind address.
+			displayHost := cfg.Server.Host
+			if displayHost == "0.0.0.0" || displayHost == "" {
+				displayHost = "localhost"
+			}
+			slog.Info("password auth enabled — register the first user; they become admin automatically",
+				"register_ui", fmt.Sprintf("http://%s:%d/register", displayHost, cfg.Server.Port),
+				"register_api", "POST /api/auth/register",
+				"note", "no default credentials — choose your own email + password",
+			)
 		}
 
 		// OAuth handler wiring — only when AUTH_OAUTH_ENABLED.


### PR DESCRIPTION
## Summary

The engine ships **no default credentials** (deliberate — no widely-known-default-password footgun). But users running with \`AUTH_PASSWORD_ENABLED=true\` see a login page they can't log into, because there's no admin user yet and nothing on screen explains what to do.

The deploy README quickstarts told users to \"sign in with the bootstrap admin credentials shown in the engine logs\" — but no such credentials were ever logged. Pure documentation drift caught when @user hit the v0.7.4 405 login bug and asked \"where are these credentials?\"

## Fix

Adds a clear, actionable startup log entry that fires when password auth is enabled:

\`\`\`
INFO  password auth enabled — register the first user; they become admin automatically
      register_ui=http://localhost:8081/register
      register_api=\"POST /api/auth/register\"
      note=\"no default credentials — choose your own email + password\"
\`\`\`

Host displays as \`localhost\` when bound to \`0.0.0.0\` so the URL is clickable when copy-pasted from container logs.

## Test plan

- [x] \`go build ./...\` passes
- [ ] Manual: \`AUTH_PASSWORD_ENABLED=true duragraph dev\` — confirm the new log line appears with a clickable URL
- [ ] Manual: visit the URL, register a user, confirm they're auto-promoted to admin

## Pairs with

- PR #202 (SPA fallback fix — gives 404 instead of 405 for unmatched /api/* paths)
- PR #203 (remove TanStack devtools floating buttons)
- Follow-up docs PR (sweep through deploy READMEs to fix the misleading \"credentials in the logs\" wording)

All four should land together in a v0.7.5 hotfix to clean up the onboarding flow for v0.7.4 deploy templates.