### PR TITLE
docs: correct bootstrap-admin wording across deploy READMEs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,7 +61,7 @@ docker run --rm -p 8080:8080 -v duragraph-data:/data duragraph:local \
   ./duragraph dev --port 8080 --data-dir /data
 ```
 
-Open `http://localhost:8080`, sign in with the bootstrap admin credentials printed on first boot.
+Open `http://localhost:8080` and visit `/register`. No default credentials ship with the binary — the first user you register is auto-promoted to admin.
 
 ## Verifying after deploy
 

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -34,7 +34,7 @@ doctl apps create --spec deploy/digitalocean/.do/app.yaml
 
 ## After deploy
 
-- Visit the public URL App Platform assigns. Sign in with the bootstrap admin credentials in the **Runtime Logs** of the api component.
+- Visit the public URL App Platform assigns and go to `/register`. The first user to register is auto-promoted to admin. No default credentials — choose your own email and password.
 - (Optional) Flip `AUTH_PASSWORD_ENABLED` to `true` in env vars to require email+password login.
 
 ## Scaling considerations

--- a/deploy/fly/README.md
+++ b/deploy/fly/README.md
@@ -31,7 +31,7 @@ flyctl secrets set AUTH_PASSWORD_ENABLED=true
 flyctl deploy
 ```
 
-Then open the URL `flyctl status` prints; sign in with the bootstrap admin credentials shown in the engine logs on first boot (`flyctl logs`).
+Then open the URL `flyctl status` prints and visit `/register`. The first user to register is auto-promoted to admin. No default credentials ship with the binary — choose your own email and password.
 
 ## What `fly.toml` configures
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -35,7 +35,7 @@ railway up
 
 ## After deploy
 
-- Open the public URL Railway assigns; sign in with the bootstrap admin credentials in the logs (**Deploys → Logs**).
+- Open the public URL Railway assigns and visit `/register`. The first user to register is auto-promoted to admin. No default credentials ship with the binary — choose your own email and password. Subsequent users register as pending until an admin approves them.
 - (Optional) Flip `AUTH_PASSWORD_ENABLED` to `true` via env vars to enable login.
 
 ## Scaling considerations

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -24,7 +24,7 @@ render blueprint launch --file deploy/render/render.yaml
 
 ## After deploy
 
-- Visit the service URL Render assigns. Sign in with the bootstrap admin credentials printed in the engine logs on first boot.
+- Visit the service URL Render assigns and go to `/register`. The first user to register is auto-promoted to admin. No default credentials — choose your own email and password.
 - (Optional) Set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` in the service's **Environment** tab if you want assistants backed by real models.
 - (Optional) Flip `AUTH_PASSWORD_ENABLED` to `true` to require email+password login — first registered user becomes the admin.
 

--- a/deploy/scaleway/README.md
+++ b/deploy/scaleway/README.md
@@ -37,7 +37,7 @@ docker push rg.fr-par.scw.cloud/<namespace>/duragraph:latest
 
 ## After deploy
 
-- Hit the public URL Scaleway assigns. Sign in with the bootstrap admin credentials printed in the container logs.
+- Hit the public URL Scaleway assigns and visit `/register`. The first user to register is auto-promoted to admin. No default credentials — choose your own email and password.
 
 ## Scaling considerations
 

--- a/docs/src/content/docs/docs/getting-started.mdx
+++ b/docs/src/content/docs/docs/getting-started.mdx
@@ -32,7 +32,7 @@ That's it. The binary boots an embedded PostgreSQL + NATS, starts the engine, an
 
 - **API** — `http://localhost:8081`
 - **Dashboard** — `http://localhost:8081` (same origin; SPA routing)
-- **Bootstrap admin** — credentials are printed on first start; sign in with those.
+- **Bootstrap admin** — the binary ships with no default credentials. With `AUTH_PASSWORD_ENABLED=true`, visit `/register` (or POST to `/api/auth/register`) and create the first user — they're auto-promoted to admin. Subsequent users register as pending until an admin approves them.
 
 ## 3. Run your first workflow
 


### PR DESCRIPTION
## Summary

The deploy templates and quick-start guide were telling users to *"sign in with the bootstrap admin credentials in the logs"* — but the engine ships with **no default credentials** and logs none. The actual flow is: visit `/register`, the first user to register is auto-promoted to admin (`internal/application/command/register_user_with_password.go` uses `CountAll == 0` → `isFirstUser = true`).

This sweeps the misleading wording out of 7 docs.

## Files

- `deploy/README.md`
- `deploy/digitalocean/README.md`
- `deploy/fly/README.md`
- `deploy/railway/README.md`
- `deploy/render/README.md`
- `deploy/scaleway/README.md`
- `docs/src/content/docs/docs/getting-started.mdx`

Each one swaps the "credentials in the logs" line for the honest "first user to register is auto-promoted to admin; no default credentials" wording.

Companion to #204 (which adds an actually-helpful log line when `AUTH_PASSWORD_ENABLED=true`).

## Test plan

- [x] grep for the stale wording across the repo — clean
- [x] prettier check on the mdx file — passes
- [ ] Astro docs site builds (CI will check)