### PR TITLE
chore(landing): refresh for v0.7 single-binary reality

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -58,7 +58,7 @@ import '../styles/landing.css';
           <!-- Actions -->
           <div class="flex items-center gap-2">
             <a
-              href="https://github.com/duragraph/duragraph"
+              href="https://github.com/Duragraph/duragraph"
               target="_blank"
               rel="noopener noreferrer"
               class="p-2 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
@@ -152,10 +152,31 @@ import '../styles/landing.css';
               horizontal scaling, and full observability — on your infrastructure.
             </p>
 
+            <!-- Quick install -->
+            <div
+              class="max-w-2xl mx-auto mb-10 bg-card border border-border p-5 text-left font-mono text-sm shadow-[var(--shadow-card)]"
+            >
+              <div class="text-muted-foreground text-xs mb-3 uppercase tracking-wide">
+                Try it in 60 seconds
+              </div>
+              <div class="space-y-1">
+                <div>
+                  <span class="text-muted-foreground select-none">$ </span>brew install
+                  Duragraph/tap/duragraph
+                </div>
+                <div>
+                  <span class="text-muted-foreground select-none">$ </span>duragraph dev
+                </div>
+                <div class="text-muted-foreground pt-1">
+                  # → http://localhost:8081 — embedded Postgres + NATS, no setup
+                </div>
+              </div>
+            </div>
+
             <!-- CTAs -->
             <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
               <a
-                href="https://github.com/duragraph/duragraph"
+                href="https://github.com/Duragraph/duragraph"
                 class="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 transition-colors"
               >
                 <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"
@@ -305,9 +326,9 @@ import '../styles/landing.css';
             </div>
             <div class="bg-background p-6">
               <div class="text-3xl font-bold text-primary font-mono mb-3">02</div>
-              <h3 class="text-base font-semibold text-foreground mb-2">Generate Code</h3>
+              <h3 class="text-base font-semibold text-foreground mb-2">Author in Code</h3>
               <p class="text-sm text-muted-foreground">
-                Auto-generate type-safe workflow code from your graph
+                Write nodes and edges in Python or Go — the graph <em>is</em> the code
               </p>
             </div>
             <div class="bg-background p-6">
@@ -446,9 +467,9 @@ import '../styles/landing.css';
                     d="M5 13l4 4L19 7"></path></svg
                 >
                 <div>
-                  <h3 class="font-medium text-foreground">RBAC & Multi-tenancy</h3>
+                  <h3 class="font-medium text-foreground">Pluggable Auth</h3>
                   <p class="text-sm text-muted-foreground mt-1">
-                    Enterprise access control included
+                    Password + OAuth out of the box; RBAC and multi-tenancy on the roadmap
                   </p>
                 </div>
               </div>
@@ -659,7 +680,7 @@ import '../styles/landing.css';
 
           <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
             <a
-              href="https://github.com/duragraph/duragraph"
+              href="https://github.com/Duragraph/duragraph"
               target="_blank"
               rel="noopener noreferrer"
               class="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-foreground bg-secondary hover:bg-secondary/80 transition-colors"
@@ -737,7 +758,7 @@ import '../styles/landing.css';
                 >Docs</a
               >
               <a
-                href="https://github.com/duragraph/duragraph"
+                href="https://github.com/Duragraph/duragraph"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary

Three factual fixes + one URL normalization on `docs/src/pages/index.astro` (the marketing landing). Companion to #205 (deploy README wording fix) — same spirit, applied to the landing page surface.

### 1. Step 02 was factually wrong

**Before**: "Generate Code — Auto-generate type-safe workflow code from your graph"

DuraGraph has no codegen step. Users write graphs *in code* (Python `@Graph` / `@node` decorators, Go SDK types). The graph **is** the code, not a precursor to it.

**After**: "Author in Code — Write nodes and edges in Python or Go — the graph *is* the code"

### 2. "RBAC & Multi-tenancy" overpromised

**Before**: "RBAC & Multi-tenancy — Enterprise access control included"

Per the v0.7 → v0.9 roadmap, multi-tenancy is **not** in v0.7. RBAC lives in the private `duragraph-enterprise` repo. Claiming "included" today is the same drift PR #205 just fixed in the docs.

**After**: "Pluggable Auth — Password + OAuth out of the box; RBAC and multi-tenancy on the roadmap"

### 3. Hero now shows the v0.7 "wow"

Added a terminal block between the subtitle and the existing CTAs:

```
Try it in 60 seconds
$ brew install Duragraph/tap/duragraph
$ duragraph dev
# → http://localhost:8081 — embedded Postgres + NATS, no setup
```

The whole point of v0.7 is zero-infra, single-binary DX. The previous hero had only "View on GitHub" + "Read the Docs" — nothing communicated the brew → dev one-two punch. Pure CSS terminal styling using existing tokens (`bg-card`, `border-border`, etc.); no new SVGs.

### 4. GitHub URL case

Four occurrences of `github.com/duragraph/duragraph` → `github.com/Duragraph/duragraph` (correct org casing). GitHub redirects case-insensitively so the old URLs worked, but the visible casing in the source matters for cross-references.

## Test plan

- [x] `pnpm exec prettier --check src/pages/index.astro` — clean
- [x] `pnpm build` — 74 pages built in 10.49s, no errors
- [x] grep verifies no `duragraph/duragraph` lowercase remains
- [ ] Visual review on the Cloudflare Pages preview (CI deploys)

## Out of scope (deliberately not in this PR)

- Product screenshot or animated graph-execution diagram in the hero — bigger visual lift, separate design effort.
- "Stats" card refresh (ES+CQRS / OSS / Any Cloud-On-Prem) — subjective design choice; leaving for a future copy pass.
- Footer copyright year — stays `© 2025` (project founding year is correct).