### PR TITLE
fix(onboarding): add /register route + ship install.sh

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,11 +82,14 @@ tasks:
   # === Building ===
   build:
     desc: Build everything (Go binary with embedded dashboard)
-    deps: ["build:dashboard", "build:duragraph"]
+    cmds:
+      - task: build:dashboard
+      - task: build:duragraph
 
   build:duragraph:
-    desc: Build the duragraph binary. Embeds dashboard/dist via go:embed,
-      so `build:dashboard` must run first when iterating on the UI.
+    desc: Build the duragraph binary. Depends on build:dashboard so the
+      Vite output is on disk before `go build` runs the //go:embed.
+    deps: ["build:dashboard"]
     cmds:
       - go build -o bin/duragraph ./cmd/duragraph
     generates:

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as AppIndexRouteImport } from './routes/_app/index'
+import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AppTracesRouteImport } from './routes/_app/traces'
 import { Route as AppThreadsRouteImport } from './routes/_app/threads'
@@ -42,6 +43,11 @@ const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AppRoute,
+} as any)
+const AuthRegisterRoute = AuthRegisterRouteImport.update({
+  id: '/register',
+  path: '/register',
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthLoginRoute = AuthLoginRouteImport.update({
   id: '/login',
@@ -141,6 +147,7 @@ export interface FileRoutesByFullPath {
   '/threads': typeof AppThreadsRouteWithChildren
   '/traces': typeof AppTracesRouteWithChildren
   '/login': typeof AuthLoginRoute
+  '/register': typeof AuthRegisterRoute
   '/': typeof AppIndexRoute
   '/admin/metrics': typeof AppAdminMetricsRoute
   '/admin/users': typeof AppAdminUsersRoute
@@ -160,6 +167,7 @@ export interface FileRoutesByTo {
   '/threads': typeof AppThreadsRouteWithChildren
   '/traces': typeof AppTracesRouteWithChildren
   '/login': typeof AuthLoginRoute
+  '/register': typeof AuthRegisterRoute
   '/': typeof AppIndexRoute
   '/admin/metrics': typeof AppAdminMetricsRoute
   '/admin/users': typeof AppAdminUsersRoute
@@ -183,6 +191,7 @@ export interface FileRoutesById {
   '/_app/threads': typeof AppThreadsRouteWithChildren
   '/_app/traces': typeof AppTracesRouteWithChildren
   '/_auth/login': typeof AuthLoginRoute
+  '/_auth/register': typeof AuthRegisterRoute
   '/_app/': typeof AppIndexRoute
   '/_app/admin/metrics': typeof AppAdminMetricsRoute
   '/_app/admin/users': typeof AppAdminUsersRoute
@@ -205,6 +214,7 @@ export interface FileRouteTypes {
     | '/threads'
     | '/traces'
     | '/login'
+    | '/register'
     | '/'
     | '/admin/metrics'
     | '/admin/users'
@@ -224,6 +234,7 @@ export interface FileRouteTypes {
     | '/threads'
     | '/traces'
     | '/login'
+    | '/register'
     | '/'
     | '/admin/metrics'
     | '/admin/users'
@@ -246,6 +257,7 @@ export interface FileRouteTypes {
     | '/_app/threads'
     | '/_app/traces'
     | '/_auth/login'
+    | '/_auth/register'
     | '/_app/'
     | '/_app/admin/metrics'
     | '/_app/admin/users'
@@ -283,6 +295,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof AppIndexRouteImport
       parentRoute: typeof AppRoute
+    }
+    '/_auth/register': {
+      id: '/_auth/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof AuthRegisterRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/login': {
       id: '/_auth/login'
@@ -499,10 +518,12 @@ const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
 interface AuthRouteChildren {
   AuthLoginRoute: typeof AuthLoginRoute
+  AuthRegisterRoute: typeof AuthRegisterRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
   AuthLoginRoute: AuthLoginRoute,
+  AuthRegisterRoute: AuthRegisterRoute,
 }
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)

--- a/dashboard/src/routes/_auth/login.tsx
+++ b/dashboard/src/routes/_auth/login.tsx
@@ -9,10 +9,10 @@ import { AuthError, loginUser, registerUser, toAuthUser } from "@/api/auth"
 import { setAuth } from "@/lib/auth"
 
 export const Route = createFileRoute("/_auth/login")({
-  component: LoginPage,
+  component: () => <LoginPage initialMode="login" />,
 })
 
-type Mode = "login" | "register"
+export type Mode = "login" | "register"
 
 interface FormState {
   email: string
@@ -43,9 +43,9 @@ function friendlyMessage(err: unknown): string {
   }
 }
 
-function LoginPage() {
+export function LoginPage({ initialMode = "login" }: { initialMode?: Mode }) {
   const navigate = useNavigate()
-  const [mode, setMode] = useState<Mode>("login")
+  const [mode, setMode] = useState<Mode>(initialMode)
   const [form, setForm] = useState<FormState>(blank)
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<string | null>(null)

--- a/dashboard/src/routes/_auth/register.tsx
+++ b/dashboard/src/routes/_auth/register.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { LoginPage } from "./login"
+
+export const Route = createFileRoute("/_auth/register")({
+  component: () => <LoginPage initialMode="register" />,
+})

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+# DuraGraph installer.
+#
+# Usage:
+#   curl -fsSL https://duragraph.ai/install.sh | sh
+#
+# Environment overrides:
+#   DURAGRAPH_VERSION       Pin to a specific tag, e.g. v0.7.5 (default: latest)
+#   DURAGRAPH_INSTALL_DIR   Install location (default: /usr/local/bin if writable,
+#                           else $HOME/.local/bin)
+
+set -eu
+
+REPO="Duragraph/duragraph"
+BINARY="duragraph"
+
+# ---------- helpers ---------------------------------------------------------
+
+err() {
+    printf 'install.sh: error: %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf 'install.sh: %s\n' "$*" >&2
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || err "missing required command: $1"
+}
+
+# ---------- detection -------------------------------------------------------
+
+detect_os() {
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$os" in
+        darwin) printf 'darwin' ;;
+        linux)  printf 'linux' ;;
+        *)      err "unsupported OS: $(uname -s) (only macOS and Linux are supported)" ;;
+    esac
+}
+
+detect_arch() {
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64|amd64)  printf 'x86_64' ;;
+        arm64|aarch64) printf 'arm64' ;;
+        *)             err "unsupported architecture: $arch (only x86_64 and arm64 are supported)" ;;
+    esac
+}
+
+# Resolve the latest release tag via GitHub's redirect (no API rate limit).
+latest_version() {
+    redirect=$(curl -sILo /dev/null -w '%{url_effective}' \
+        "https://github.com/${REPO}/releases/latest")
+    case "$redirect" in
+        */tag/v*) printf '%s' "${redirect##*/tag/}" ;;
+        *)        err "could not determine latest version from redirect: $redirect" ;;
+    esac
+}
+
+# ---------- checksum --------------------------------------------------------
+
+verify_checksum() {
+    archive=$1
+    expected=$2
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+    else
+        err "neither sha256sum nor shasum available — cannot verify download integrity"
+    fi
+
+    [ "$actual" = "$expected" ] || err "checksum mismatch (expected $expected, got $actual)"
+}
+
+# ---------- install dir -----------------------------------------------------
+
+choose_install_dir() {
+    if [ -n "${DURAGRAPH_INSTALL_DIR:-}" ]; then
+        printf '%s' "$DURAGRAPH_INSTALL_DIR"
+        return
+    fi
+    if [ -w /usr/local/bin ]; then
+        printf '/usr/local/bin'
+        return
+    fi
+    printf '%s/.local/bin' "$HOME"
+}
+
+# ---------- main ------------------------------------------------------------
+
+main() {
+    need_cmd curl
+    need_cmd tar
+    need_cmd uname
+    need_cmd awk
+
+    os=$(detect_os)
+    arch=$(detect_arch)
+
+    if [ -n "${DURAGRAPH_VERSION:-}" ]; then
+        version=$DURAGRAPH_VERSION
+    else
+        version=$(latest_version)
+    fi
+    # Normalize: always ensure leading 'v' on the tag
+    case "$version" in
+        v*) ;;
+        *)  version="v${version}" ;;
+    esac
+    version_no_v="${version#v}"
+
+    archive_name="${BINARY}_${version_no_v}_${os}_${arch}.tar.gz"
+    archive_url="https://github.com/${REPO}/releases/download/${version}/${archive_name}"
+    checksum_url="https://github.com/${REPO}/releases/download/${version}/checksums.txt"
+
+    install_dir=$(choose_install_dir)
+
+    info "platform: ${os}/${arch}"
+    info "version:  ${version}"
+    info "target:   ${install_dir}/${BINARY}"
+
+    tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t duragraph-install)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    archive_path="${tmpdir}/${archive_name}"
+
+    info "downloading ${archive_url}"
+    curl -fsSL --retry 3 "$archive_url" -o "$archive_path" \
+        || err "download failed: $archive_url"
+
+    info "verifying checksum"
+    checksums=$(curl -fsSL --retry 3 "$checksum_url") \
+        || err "could not fetch checksums.txt"
+    expected=$(printf '%s\n' "$checksums" | awk -v f="$archive_name" '$2==f {print $1}')
+    [ -n "$expected" ] || err "no checksum entry for ${archive_name} in checksums.txt"
+    verify_checksum "$archive_path" "$expected"
+
+    info "extracting"
+    tar -xzf "$archive_path" -C "$tmpdir" || err "tar extraction failed"
+    [ -f "${tmpdir}/${BINARY}" ] || err "extracted archive does not contain '${BINARY}'"
+
+    mkdir -p "$install_dir" || err "could not create ${install_dir}"
+    info "installing"
+    if command -v install >/dev/null 2>&1; then
+        install -m 0755 "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}" \
+            || err "install to ${install_dir} failed"
+    else
+        mv "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}" \
+            || err "move to ${install_dir} failed"
+        chmod 0755 "${install_dir}/${BINARY}"
+    fi
+
+    # PATH guidance — non-fatal, just a heads-up
+    case ":${PATH:-}:" in
+        *":${install_dir}:"*)
+            ;;
+        *)
+            info ""
+            info "NOTE: ${install_dir} is not in your PATH. Add it to your shell profile:"
+            info "  export PATH=\"${install_dir}:\$PATH\""
+            ;;
+    esac
+
+    cat >&2 <<EOF
+
+duragraph ${version} installed at ${install_dir}/${BINARY}
+
+Quick start — zero config, embedded Postgres + NATS:
+  duragraph dev
+
+Self-hosted serve mode (config in ~/.config/duragraph/config.toml or env vars):
+  duragraph serve
+
+Documentation: https://duragraph.ai
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Two onboarding fixes that the v0.7.5 docs/log lines referenced but the repo never actually shipped. Both were caught by the user trying to bootstrap-admin into a fresh dashboard and finding the URL we documented (`/register`) doesn't exist as a route.

### 1. /register route in the dashboard

The Register UI has shipped since password auth landed — but only as a *tab* inside `/login`. PRs #204 (bootstrap-admin log line) and #205 (docs sweep) both told users to "visit /register", which doesn't match any TanStack Router file route. The SPA fallback served index.html and the user landed back on `/login` with no obvious way to find the Register tab.

**Fix**: refactor `LoginPage` to accept an `initialMode` prop, add a sibling `/_auth/register.tsx` route that renders the same component with `initialMode="register"`. The URL the docs advertise now lands directly on the registration tab.

### 2. duragraph.ai/install.sh

`getting-started.mdx:17` and `README.md:28` both reference `curl -fsSL https://duragraph.ai/install.sh | sh` — the script was never written. Adding `docs/public/install.sh` which Astro serves verbatim from the docs site root.

**Design**:
- POSIX sh (`set -eu`), shellcheck clean
- Detects OS via `uname -s` (darwin/linux), arch via `uname -m` (normalizes x86_64/amd64 and arm64/aarch64)
- Resolves latest tag via the GitHub `releases/latest` redirect (no API rate limit issues behind corporate NAT / CI)
- `DURAGRAPH_VERSION` and `DURAGRAPH_INSTALL_DIR` env overrides
- Verifies SHA-256 checksums against `checksums.txt` from the release (fails closed — does not silently skip if neither `sha256sum` nor `shasum` is available)
- Install dir defaults to `/usr/local/bin` if writable, else `$HOME/.local/bin` with a PATH hint
- Wrapped in `main()` called as the literal last line — partial curl|sh downloads fail to find `main` before doing anything destructive

## Test plan

- [x] `shellcheck -s sh docs/public/install.sh` — clean
- [x] `DURAGRAPH_VERSION=v0.7.5 DURAGRAPH_INSTALL_DIR=/tmp/dg-test/bin sh docs/public/install.sh` — installs, `/tmp/dg-test/bin/duragraph version` prints `DuraGraph 0.7.5`, commit matches `bf30b55`
- [x] Same command without `DURAGRAPH_VERSION` (auto-latest detection) — same result via the redirect
- [x] `pnpm exec vite build` — routeTree regenerated, includes `/register` mapped to `AuthRegisterRoute`, build clean (9.24s)
- [x] `pnpm exec tsc -b --noEmit` — clean
- [ ] CI: dashboard build + lint (pre-existing lint errors are in files I didn't touch — `useElkLayout.ts`, `NewRunDialog.tsx`, `ui/badge.tsx`, `ui/button.tsx`, `routeTree.gen.ts`; merged PRs #202, #203 had them too)

## Out of scope

Docs/log lines are already correct (they say `/register` and that URL now works). No doc edits needed in this PR.