### PR TITLE
fix(auth): dashboard auth gate honors /info instead of just localStorage

### DIFF
--- a/dashboard/src/api/info.ts
+++ b/dashboard/src/api/info.ts
@@ -21,6 +21,7 @@ export interface Capabilities {
   mode: EngineMode
   platformEnabled: boolean
   authEnabled: boolean
+  passwordAuthEnabled: boolean
   oauthProviders: OAuthProvider[]
 }
 
@@ -33,6 +34,7 @@ interface InfoResponseWire {
   mode: EngineMode
   platform_enabled: boolean
   auth_enabled: boolean
+  password_auth_enabled: boolean
   oauth_providers: OAuthProvider[]
 }
 
@@ -53,6 +55,7 @@ export async function fetchInfo(): Promise<Capabilities> {
     mode: raw.mode,
     platformEnabled: raw.platform_enabled,
     authEnabled: raw.auth_enabled,
+    passwordAuthEnabled: raw.password_auth_enabled,
     oauthProviders: raw.oauth_providers ?? [],
   }
 }

--- a/dashboard/src/lib/routeGuards.ts
+++ b/dashboard/src/lib/routeGuards.ts
@@ -27,20 +27,64 @@ import { redirect } from "@tanstack/react-router"
 import { fetchInfo, type Capabilities } from "@/api/info"
 import { CAPABILITIES_QUERY_KEY } from "@/hooks/useCapabilities"
 import { queryClient } from "@/lib/queryClient"
+import { isAuthenticated } from "@/lib/auth"
 
-/**
- * adminOnlyGuard redirects to "/" when the engine is not in multi-tenant mode.
- *
- * Async: uses `ensureQueryData` so it works on cold load (deep link / refresh)
- * before `<CapabilitiesProvider>` mounts. TanStack Router's `beforeLoad`
- * accepts async functions and awaits them.
- */
-export async function adminOnlyGuard() {
-  const caps = await queryClient.ensureQueryData<Capabilities>({
+/** Shared capability fetcher for guards. Same identity as `useCapabilities`. */
+async function ensureCapabilities(): Promise<Capabilities> {
+  return queryClient.ensureQueryData<Capabilities>({
     queryKey: CAPABILITIES_QUERY_KEY,
     queryFn: fetchInfo,
     staleTime: Infinity,
   })
+}
+
+/**
+ * authGuard protects the authenticated app shell (/_app/*).
+ *
+ * Decision matrix driven by GET /info:
+ *   - authEnabled=false  → no gate, let the user straight in
+ *   - authEnabled=true, no token  → bounce to /login
+ *   - authEnabled=true, token present → let through (JWT middleware
+ *     enforces validity on each /api/* call)
+ *
+ * Replaces the previous bare `isAuthenticated()` check, which gated the
+ * dashboard even when the backend wasn't enforcing auth — causing the
+ * "login form submits to a 404" bug in `duragraph dev` defaults.
+ */
+export async function authGuard() {
+  const caps = await ensureCapabilities()
+  if (!caps.authEnabled) {
+    return
+  }
+  if (!isAuthenticated()) {
+    throw redirect({ to: "/login" })
+  }
+}
+
+/**
+ * publicAuthGuard protects the /_auth/* routes (login, register).
+ *
+ *   - authEnabled=false  → redirect to /  (no auth to configure, the
+ *     login screen is meaningless)
+ *   - authEnabled=true, already authenticated → redirect to /
+ *   - otherwise → render (the page itself can branch on
+ *     passwordAuthEnabled vs OAuth providers to pick its UI)
+ */
+export async function publicAuthGuard() {
+  const caps = await ensureCapabilities()
+  if (!caps.authEnabled) {
+    throw redirect({ to: "/" })
+  }
+  if (isAuthenticated()) {
+    throw redirect({ to: "/" })
+  }
+}
+
+/**
+ * adminOnlyGuard redirects to "/" when the engine is not in multi-tenant mode.
+ */
+export async function adminOnlyGuard() {
+  const caps = await ensureCapabilities()
   if (!caps.platformEnabled) {
     throw redirect({ to: "/" })
   }

--- a/dashboard/src/routes/_app.tsx
+++ b/dashboard/src/routes/_app.tsx
@@ -1,23 +1,19 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 import { AppSidebar } from "@/components/app-sidebar"
 import { Topbar } from "@/components/layout/Topbar"
 import { ErrorBoundary } from "@/components/common/ErrorBoundary"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import { isAuthenticated } from "@/lib/auth"
+import { authGuard } from "@/lib/routeGuards"
 
-// Auth gate for the app shell. Any route under /_app/* runs through
-// this beforeLoad — without a token, bounce to /login. Public routes
-// live under /_auth/* (login, register) and are not gated.
+// Auth gate for the app shell. authGuard reads GET /info: if the backend
+// has AUTH_ENABLED=false the user goes straight in; otherwise it
+// requires a token in localStorage and bounces to /login when missing.
 //
 // Shell layout uses shadcn's <SidebarProvider> + <Sidebar> block
 // (sidebar-05) so collapse/keyboard/persistence behaviours come from
 // the canonical implementation rather than hand-rolled state.
 export const Route = createFileRoute("/_app")({
-  beforeLoad: () => {
-    if (!isAuthenticated()) {
-      throw redirect({ to: "/login" })
-    }
-  },
+  beforeLoad: authGuard,
   component: AppLayout,
 })
 

--- a/dashboard/src/routes/_auth.tsx
+++ b/dashboard/src/routes/_auth.tsx
@@ -1,17 +1,13 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
-import { isAuthenticated } from "@/lib/auth"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { publicAuthGuard } from "@/lib/routeGuards"
 
 // Public layout for unauthenticated routes (login, register). The
 // _auth segment is the conventional TanStack Router pattern for routes
-// that should NOT use the app shell. If the user is already
-// authenticated, bounce them straight to the app — no point letting
-// someone with a valid token land on /login and re-enter creds.
+// that should NOT use the app shell. publicAuthGuard sends users away
+// from here when (a) auth is disabled entirely, or (b) they're already
+// signed in — both cases the login screen is useless to them.
 export const Route = createFileRoute("/_auth")({
-  beforeLoad: () => {
-    if (isAuthenticated()) {
-      throw redirect({ to: "/" })
-    }
-  },
+  beforeLoad: publicAuthGuard,
   component: AuthLayout,
 })
 

--- a/dashboard/src/routes/_auth/login.tsx
+++ b/dashboard/src/routes/_auth/login.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { AuthError, loginUser, registerUser, toAuthUser } from "@/api/auth"
 import { setAuth } from "@/lib/auth"
+import { useCapabilities } from "@/hooks/useCapabilities"
 
 export const Route = createFileRoute("/_auth/login")({
   component: () => <LoginPage initialMode="login" />,
@@ -44,8 +45,40 @@ function friendlyMessage(err: unknown): string {
 }
 
 export function LoginPage({ initialMode = "login" }: { initialMode?: Mode }) {
+  const caps = useCapabilities()
   const navigate = useNavigate()
   const [mode, setMode] = useState<Mode>(initialMode)
+
+  // publicAuthGuard already ensured authEnabled=true. If password auth
+  // is off, the form here would just 404 on submit — render a clearer
+  // message instead. OAuth UI lives in a separate component once the
+  // OAuth flow is built; for now we just surface what's configured.
+  if (!caps.passwordAuthEnabled) {
+    return (
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Password sign-in disabled</CardTitle>
+          <CardDescription>
+            This deployment runs with <code>AUTH_PASSWORD_ENABLED=false</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {caps.oauthProviders.length > 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Configured OAuth providers: {caps.oauthProviders.join(", ")}.
+              Ask your admin for the sign-in URL.
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No auth methods are configured. Ask your admin to enable
+              either password or OAuth sign-in, or unset{" "}
+              <code>AUTH_ENABLED</code> for an open deployment.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    )
+  }
   const [form, setForm] = useState<FormState>(blank)
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<string | null>(null)

--- a/internal/infrastructure/http/handlers/system.go
+++ b/internal/infrastructure/http/handlers/system.go
@@ -59,6 +59,11 @@ type InfoResponse struct {
 	PlatformEnabled bool `json:"platform_enabled"`
 	// AuthEnabled mirrors the AUTH_ENABLED env toggle (JWT/auth gating).
 	AuthEnabled bool `json:"auth_enabled"`
+	// PasswordAuthEnabled mirrors the AUTH_PASSWORD_ENABLED env toggle —
+	// whether /api/auth/register and /api/auth/login routes are registered.
+	// The dashboard reads this to decide whether to render the password
+	// login form vs. fall through to OAuth-only or no-auth UX.
+	PasswordAuthEnabled bool `json:"password_auth_enabled"`
 	// OAuthProviders lists configured OAuth providers in alphabetical order.
 	// Always non-nil so the JSON shape is `[]` not `null`.
 	OAuthProviders []string `json:"oauth_providers"`
@@ -78,6 +83,7 @@ func (h *SystemHandler) Ok(c echo.Context) error {
 func (h *SystemHandler) Info(c echo.Context) error {
 	platformEnabled := os.Getenv("MIGRATOR_PLATFORM_ENABLED") == "true"
 	authEnabled := os.Getenv("AUTH_ENABLED") == "true"
+	passwordAuthEnabled := os.Getenv("AUTH_PASSWORD_ENABLED") == "true"
 
 	// alphabetical, stable for tests
 	oauthProviders := []string{}
@@ -114,9 +120,10 @@ func (h *SystemHandler) Info(c echo.Context) error {
 			Checkpointer: "postgres",
 			Store:        "postgres",
 		},
-		Mode:            mode,
-		PlatformEnabled: platformEnabled,
-		AuthEnabled:     authEnabled,
-		OAuthProviders:  oauthProviders,
+		Mode:                mode,
+		PlatformEnabled:     platformEnabled,
+		AuthEnabled:         authEnabled,
+		PasswordAuthEnabled: passwordAuthEnabled,
+		OAuthProviders:      oauthProviders,
 	})
 }

--- a/internal/infrastructure/http/handlers/system_test.go
+++ b/internal/infrastructure/http/handlers/system_test.go
@@ -19,6 +19,7 @@ func TestInfo_Capabilities(t *testing.T) {
 		wantMode           EngineMode
 		wantPlatform       bool
 		wantAuth           bool
+		wantPasswordAuth   bool
 		wantOAuthProviders []string
 	}{
 		{
@@ -27,6 +28,7 @@ func TestInfo_Capabilities(t *testing.T) {
 			wantMode:           ModeServe,
 			wantPlatform:       false,
 			wantAuth:           false,
+			wantPasswordAuth:   false,
 			wantOAuthProviders: []string{},
 		},
 		{
@@ -47,6 +49,15 @@ func TestInfo_Capabilities(t *testing.T) {
 			wantMode:           ModeServe,
 			wantPlatform:       false,
 			wantAuth:           true,
+			wantOAuthProviders: []string{},
+		},
+		{
+			name: "password auth enabled toggle",
+			env: map[string]string{
+				"AUTH_PASSWORD_ENABLED": "true",
+			},
+			wantMode:           ModeServe,
+			wantPasswordAuth:   true,
 			wantOAuthProviders: []string{},
 		},
 		{
@@ -79,12 +90,14 @@ func TestInfo_Capabilities(t *testing.T) {
 			env: map[string]string{
 				"MIGRATOR_PLATFORM_ENABLED": "true",
 				"AUTH_ENABLED":              "true",
+				"AUTH_PASSWORD_ENABLED":     "true",
 				"OAUTH_GOOGLE_CLIENT_ID":    "g",
 				"OAUTH_GITHUB_CLIENT_ID":    "h",
 			},
 			wantMode:           ModeMultitenant,
 			wantPlatform:       true,
 			wantAuth:           true,
+			wantPasswordAuth:   true,
 			wantOAuthProviders: []string{"github", "google"},
 		},
 		{
@@ -106,6 +119,7 @@ func TestInfo_Capabilities(t *testing.T) {
 			for _, k := range []string{
 				"MIGRATOR_PLATFORM_ENABLED",
 				"AUTH_ENABLED",
+				"AUTH_PASSWORD_ENABLED",
 				"OAUTH_GOOGLE_CLIENT_ID",
 				"OAUTH_GITHUB_CLIENT_ID",
 			} {
@@ -142,6 +156,9 @@ func TestInfo_Capabilities(t *testing.T) {
 			}
 			if resp.AuthEnabled != tc.wantAuth {
 				t.Errorf("auth_enabled = %v, want %v", resp.AuthEnabled, tc.wantAuth)
+			}
+			if resp.PasswordAuthEnabled != tc.wantPasswordAuth {
+				t.Errorf("password_auth_enabled = %v, want %v", resp.PasswordAuthEnabled, tc.wantPasswordAuth)
 			}
 			if !slicesEqual(resp.OAuthProviders, tc.wantOAuthProviders) {
 				t.Errorf("oauth_providers = %v, want %v", resp.OAuthProviders, tc.wantOAuthProviders)


### PR DESCRIPTION
## Summary

Fixes the bug the user hit on v0.7.6: in default `duragraph dev` mode, the dashboard would redirect `/` → `/login`, the user submits the form, and `POST /api/auth/register` returns 404 because those routes are only registered when `AUTH_PASSWORD_ENABLED=true`. The backend correctly said "no auth here", the dashboard insisted on a login screen that didn't exist.

Root cause: `_app.tsx`'s auth gate checked `isAuthenticated()` (a localStorage probe) regardless of whether the backend was actually enforcing auth. The `/info` endpoint already returns `auth_enabled`, but the gate ignored it.

## Changes

### Backend
- **`internal/infrastructure/http/handlers/system.go`** — `/info` now also exposes `password_auth_enabled` (mirrors `AUTH_PASSWORD_ENABLED` env). Dashboard reads this to decide whether to render the password form.
- **`internal/infrastructure/http/handlers/system_test.go`** — new `"password auth enabled toggle"` test case + extension of the existing `"all flags together"` case. Env-clearing list also gets `AUTH_PASSWORD_ENABLED` so host env can't leak in.

### Dashboard
- **`dashboard/src/api/info.ts`** — `Capabilities` interface grows `passwordAuthEnabled: boolean`; mapped from the wire shape's `password_auth_enabled`.
- **`dashboard/src/lib/routeGuards.ts`** — two new guards:
  - `authGuard` (protects `/_app/*`): short-circuits when `authEnabled=false`; otherwise the existing token check.
  - `publicAuthGuard` (protects `/_auth/*`): redirects to `/` when `authEnabled=false` (login screen meaningless) or when already authenticated.
- **`dashboard/src/routes/_app.tsx`** — swaps inline `isAuthenticated()` check for `authGuard`.
- **`dashboard/src/routes/_auth.tsx`** — swaps its inline check for `publicAuthGuard` (which subsumes the existing "already-logged-in" redirect).
- **`dashboard/src/routes/_auth/login.tsx`** — when `passwordAuthEnabled=false`, renders a "password sign-in disabled" card with OAuth provider info instead of a form that 404s on submit.

## Behavior matrix

| `auth_enabled` | `password_auth_enabled` | Dashboard does |
|---|---|---|
| `false` | `false` | No gate, no login screen — straight into `/` |
| `false` | `true` | No gate; users CAN visit `/login` via `publicAuthGuard` redirect-away (this is a weird hybrid mode, but consistent) |
| `true` | `true` | Login form renders, normal flow |
| `true` | `false` | "Password sign-in disabled" card; lists OAuth providers if any |
| `true` | `false`, no OAuth | "Auth misconfigured" message |

## Test plan

- [x] Backend: `go test -run TestInfo ./internal/infrastructure/http/handlers/` — 10/10 pass including new case
- [x] Local build + `duragraph dev` without `AUTH_PASSWORD_ENABLED` — `/info` returns `auth_enabled: false, password_auth_enabled: false`, dashboard loads at `/` (no `/login` redirect)
- [x] Local build + `AUTH_PASSWORD_ENABLED=true duragraph dev` — `/info` reports `password_auth_enabled: true`, `POST /api/auth/register` returns 201, login returns admin JWT
- [x] Dashboard typecheck (`tsc -b --noEmit`) clean
- [x] Bundle contains `passwordAuthEnabled` symbol
- [ ] CI: backend tests + dashboard build (likely the same flake on `TestGetMetrics_WindowOverride` we hit on #207)
- [ ] Browser smoke test by reviewer

## Out of scope

OAuth sign-in UI itself — this PR only wires the capability flag through. When OAuth UI lands, it can switch on `caps.oauthProviders` without further backend work.

## Not bundled in this PR

- Adding `setIfUnset("AUTH_PASSWORD_ENABLED", "true")` to `cmd/duragraph/cmd/dev.go` (the one-line workaround) — deliberately omitted. With this fix, `duragraph dev` defaults are already correct: no auth gate, no login screen. Users who *want* password auth in dev set the env var themselves and the existing register flow takes over.