### PR TITLE
feat(messaging): transactional outbox in app code, drop trigger (Phase 2/3)

### DIFF
--- a/internal/infrastructure/persistence/postgres/event_store.go
+++ b/internal/infrastructure/persistence/postgres/event_store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/duragraph/duragraph/internal/pkg/errors"
 	"github.com/duragraph/duragraph/internal/pkg/eventbus"
+	"github.com/duragraph/duragraph/internal/pkg/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -78,7 +79,10 @@ func (s *EventStore) saveEventsWithTx(ctx context.Context, tx pgx.Tx, streamID, 
 		return errors.Internal("failed to get current version", err)
 	}
 
-	// Save events
+	// Save events. event_id is generated in application code (was a DB
+	// default in v0.7.7 and earlier) so we can also write the outbox
+	// row in the same transaction with that same ID — see the outbox
+	// insert below.
 	for i, event := range events {
 		version := currentVersion + i + 1
 
@@ -93,13 +97,31 @@ func (s *EventStore) saveEventsWithTx(ctx context.Context, tx pgx.Tx, streamID, 
 		}
 		metadataJSON, _ := json.Marshal(metadata)
 
+		eventID := uuid.New()
+
 		_, err = tx.Exec(ctx, `
-			INSERT INTO events (stream_id, aggregate_type, aggregate_id, event_type, event_version, payload, metadata)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
-		`, existingStreamID, aggregateType, aggregateID, event.EventType(), version, payload, metadataJSON)
+			INSERT INTO events (event_id, stream_id, aggregate_type, aggregate_id, event_type, event_version, payload, metadata)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		`, eventID, existingStreamID, aggregateType, aggregateID, event.EventType(), version, payload, metadataJSON)
 
 		if err != nil {
 			return errors.Internal("failed to save event", err)
+		}
+
+		// Transactional outbox write — same TX as the event so a
+		// rollback drops both. Replaces the auto_publish_to_outbox
+		// trigger dropped by migration 013. ON CONFLICT DO NOTHING is
+		// a safety net for the deploy window where an older engine
+		// instance might still have the trigger active and write the
+		// same row.
+		_, err = tx.Exec(ctx, `
+			INSERT INTO outbox (event_id, aggregate_type, aggregate_id, event_type, payload, metadata)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (event_id) DO NOTHING
+		`, eventID, aggregateType, aggregateID, event.EventType(), payload, metadataJSON)
+
+		if err != nil {
+			return errors.Internal("failed to save outbox row", err)
 		}
 	}
 

--- a/internal/infrastructure/persistence/postgres/event_store_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/event_store_integration_test.go
@@ -114,6 +114,138 @@ func TestEventStore_LoadSnapshotNotFound(t *testing.T) {
 	}
 }
 
+// TestEventStore_SaveEventsAlsoWritesOutbox verifies the transactional
+// outbox added in Phase 2 — SaveEvents now writes the outbox row in
+// the same TX as the event row. Each persisted event must show up in
+// the outbox keyed by the same event_id. Before this change, the
+// outbox row was added by the auto_publish_to_outbox trigger; the
+// trigger is dropped by migration 013.
+func TestEventStore_SaveEventsAlsoWritesOutbox(t *testing.T) {
+	cleanupAll(t)
+	ctx := context.Background()
+
+	es := postgres.NewEventStore(testPool)
+
+	aggregateID := pkguuid.New()
+	events := []testEvent{
+		{eventType: "run.created", aggregateType: "run", aggregateID: aggregateID},
+		{eventType: "run.started", aggregateType: "run", aggregateID: aggregateID},
+	}
+	if err := es.SaveEvents(ctx, pkguuid.New(), "run", aggregateID, toEventbusEvents(events)); err != nil {
+		t.Fatalf("SaveEvents: %v", err)
+	}
+
+	// Pull event_ids the EventStore wrote and pull the matching outbox
+	// rows. The set-equality check (rather than ordered) keeps the
+	// test resilient to outbox insert ordering.
+	type pair struct {
+		eventID, eventType string
+	}
+	eventRows, err := testPool.Query(ctx, `
+		SELECT event_id::text, event_type FROM events
+		WHERE aggregate_id = $1
+		ORDER BY event_version
+	`, aggregateID)
+	if err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	var fromEvents []pair
+	for eventRows.Next() {
+		var p pair
+		if err := eventRows.Scan(&p.eventID, &p.eventType); err != nil {
+			t.Fatalf("scan events: %v", err)
+		}
+		fromEvents = append(fromEvents, p)
+	}
+	eventRows.Close()
+
+	outboxRows, err := testPool.Query(ctx, `
+		SELECT event_id::text, event_type FROM outbox
+		WHERE aggregate_id = $1
+		ORDER BY created_at
+	`, aggregateID)
+	if err != nil {
+		t.Fatalf("query outbox: %v", err)
+	}
+	var fromOutbox []pair
+	for outboxRows.Next() {
+		var p pair
+		if err := outboxRows.Scan(&p.eventID, &p.eventType); err != nil {
+			t.Fatalf("scan outbox: %v", err)
+		}
+		fromOutbox = append(fromOutbox, p)
+	}
+	outboxRows.Close()
+
+	if len(fromEvents) != 2 {
+		t.Fatalf("events count = %d, want 2", len(fromEvents))
+	}
+	if len(fromOutbox) != 2 {
+		t.Fatalf("outbox count = %d, want 2 (transactional outbox missed an event)", len(fromOutbox))
+	}
+
+	eventIDsInEvents := map[string]string{}
+	for _, p := range fromEvents {
+		eventIDsInEvents[p.eventID] = p.eventType
+	}
+	for _, p := range fromOutbox {
+		gotType, ok := eventIDsInEvents[p.eventID]
+		if !ok {
+			t.Errorf("outbox event_id %s not present in events table", p.eventID)
+			continue
+		}
+		if gotType != p.eventType {
+			t.Errorf("event_id %s: events.event_type=%q, outbox.event_type=%q", p.eventID, gotType, p.eventType)
+		}
+	}
+}
+
+// TestEventStore_RollbackDropsBoth verifies the atomicity guarantee
+// of the transactional outbox: SaveEventsInTx writes events + outbox
+// in one TX. If the caller's TX rolls back, neither table sees the
+// row. This is the property the trigger-based approach also had —
+// keeping it explicit guards against a future refactor accidentally
+// splitting the writes across two transactions.
+func TestEventStore_RollbackDropsBoth(t *testing.T) {
+	cleanupAll(t)
+	ctx := context.Background()
+
+	es := postgres.NewEventStore(testPool)
+	aggregateID := pkguuid.New()
+
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	events := []testEvent{
+		{eventType: "run.created", aggregateType: "run", aggregateID: aggregateID},
+	}
+	if err := es.SaveEventsInTx(ctx, tx, pkguuid.New(), "run", aggregateID, toEventbusEvents(events)); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("SaveEventsInTx: %v", err)
+	}
+
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	var eventsCount, outboxCount int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM events WHERE aggregate_id = $1`, aggregateID).Scan(&eventsCount); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM outbox WHERE aggregate_id = $1`, aggregateID).Scan(&outboxCount); err != nil {
+		t.Fatalf("count outbox: %v", err)
+	}
+
+	if eventsCount != 0 {
+		t.Errorf("events count after rollback = %d, want 0", eventsCount)
+	}
+	if outboxCount != 0 {
+		t.Errorf("outbox count after rollback = %d, want 0 (transactional outbox should rollback with the event)", outboxCount)
+	}
+}
+
 func TestEventStore_AppendMoreEvents(t *testing.T) {
 	cleanupAll(t)
 	ctx := context.Background()

--- a/internal/infrastructure/persistence/postgres/migrations/tenant/013_drop_outbox_trigger.down.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/tenant/013_drop_outbox_trigger.down.sql
@@ -1,0 +1,30 @@
+-- Reverse of 013_drop_outbox_trigger.up.sql: recreate the trigger.
+-- Policy is forward-only — this down migration exists for the
+-- migrator's required-pair convention only; do not run it.
+
+CREATE OR REPLACE FUNCTION publish_event_to_outbox()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO outbox (
+        event_id,
+        aggregate_type,
+        aggregate_id,
+        event_type,
+        payload,
+        metadata
+    ) VALUES (
+        NEW.event_id,
+        NEW.aggregate_type,
+        NEW.aggregate_id,
+        NEW.event_type,
+        NEW.payload,
+        NEW.metadata
+    );
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER auto_publish_to_outbox
+AFTER INSERT ON events
+FOR EACH ROW
+EXECUTE FUNCTION publish_event_to_outbox();

--- a/internal/infrastructure/persistence/postgres/migrations/tenant/013_drop_outbox_trigger.up.sql
+++ b/internal/infrastructure/persistence/postgres/migrations/tenant/013_drop_outbox_trigger.up.sql
@@ -1,0 +1,14 @@
+-- 013_drop_outbox_trigger.sql: remove the auto_publish_to_outbox
+-- trigger now that the EventStore writes the outbox row itself in the
+-- same transaction as the event row. See
+-- internal/infrastructure/persistence/postgres/event_store.go.
+--
+-- The increment_version_on_event trigger on the same table is
+-- intentionally KEPT — it's stream-version bookkeeping, unrelated to
+-- outbox.
+--
+-- The cleanup_published_outbox() function is KEPT too — the
+-- CleanupWorker still calls it on a schedule.
+
+DROP TRIGGER IF EXISTS auto_publish_to_outbox ON events;
+DROP FUNCTION IF EXISTS publish_event_to_outbox();

--- a/internal/infrastructure/persistence/postgres/migrations_outbox_trigger_test.go
+++ b/internal/infrastructure/persistence/postgres/migrations_outbox_trigger_test.go
@@ -1,0 +1,110 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMigration013_DroppedExactlyTheRightObjects asserts the post-state
+// of migration 013_drop_outbox_trigger. The migration ran at TestMain
+// time (via runtime migrator), so this test is a pure state assertion
+// on pg_trigger + pg_proc.
+//
+// Why this exists: `DROP TRIGGER IF EXISTS` silently no-ops if the
+// object isn't where the migration expects it (wrong table name, wrong
+// case, etc.). Without an explicit post-state check, the migration
+// would "succeed" while leaving the trigger in place, AND the new
+// app-side outbox write would also fire — producing duplicate rows
+// caught only by the `ON CONFLICT (event_id) DO NOTHING` safety net,
+// silently masking the regression.
+//
+// This is Tier 1 of the regression testing plan (see
+// project_regression_testing_plan.md). Whenever a future migration
+// drops or alters schema objects, add a sibling test asserting the
+// exact post-state.
+func TestMigration013_DroppedExactlyTheRightObjects(t *testing.T) {
+	ctx := context.Background()
+
+	// (1) auto_publish_to_outbox trigger must be GONE.
+	var triggerCount int
+	err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM pg_trigger
+		WHERE tgname = 'auto_publish_to_outbox'
+		  AND NOT tgisinternal
+	`).Scan(&triggerCount)
+	if err != nil {
+		t.Fatalf("query pg_trigger: %v", err)
+	}
+	if triggerCount != 0 {
+		t.Errorf("auto_publish_to_outbox trigger should be dropped, found %d copy/copies", triggerCount)
+	}
+
+	// (2) publish_event_to_outbox function must be GONE.
+	var funcCount int
+	err = testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM pg_proc
+		WHERE proname = 'publish_event_to_outbox'
+	`).Scan(&funcCount)
+	if err != nil {
+		t.Fatalf("query pg_proc (publish_event_to_outbox): %v", err)
+	}
+	if funcCount != 0 {
+		t.Errorf("publish_event_to_outbox function should be dropped, found %d copy/copies", funcCount)
+	}
+
+	// (3) increment_version_on_event trigger must be PRESENT — it's
+	// the stream-version bookkeeping trigger, a different concern,
+	// and dropping it would silently break aggregate version tracking.
+	err = testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM pg_trigger
+		WHERE tgname = 'increment_version_on_event'
+		  AND NOT tgisinternal
+	`).Scan(&triggerCount)
+	if err != nil {
+		t.Fatalf("query pg_trigger (increment_version_on_event): %v", err)
+	}
+	if triggerCount != 1 {
+		t.Errorf("increment_version_on_event trigger must remain (got %d copies, want 1)", triggerCount)
+	}
+
+	// (4) cleanup_published_outbox function must be PRESENT — the
+	// CleanupWorker calls it on a schedule; dropping it would silently
+	// disable outbox cleanup.
+	err = testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM pg_proc
+		WHERE proname = 'cleanup_published_outbox'
+	`).Scan(&funcCount)
+	if err != nil {
+		t.Fatalf("query pg_proc (cleanup_published_outbox): %v", err)
+	}
+	if funcCount != 1 {
+		t.Errorf("cleanup_published_outbox function must remain (got %d copies, want 1)", funcCount)
+	}
+
+	// (5) Belt-and-braces — only ONE non-internal trigger should
+	// remain on the events table after migration 013. If a future
+	// migration adds another trigger here, we want that author to
+	// update this assertion deliberately.
+	err = testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM pg_trigger
+		WHERE tgrelid = 'events'::regclass
+		  AND NOT tgisinternal
+	`).Scan(&triggerCount)
+	if err != nil {
+		t.Fatalf("query events triggers: %v", err)
+	}
+	if triggerCount != 1 {
+		var names []string
+		rows, _ := testPool.Query(ctx, `
+			SELECT tgname FROM pg_trigger
+			WHERE tgrelid = 'events'::regclass AND NOT tgisinternal
+		`)
+		for rows.Next() {
+			var n string
+			_ = rows.Scan(&n)
+			names = append(names, n)
+		}
+		rows.Close()
+		t.Errorf("events table has %d non-internal triggers (want 1: increment_version_on_event); found: %v", triggerCount, names)
+	}
+}


### PR DESCRIPTION
## Summary

**Phase 2** of the three-phase messaging refactor. Moves the outbox-row write from the `auto_publish_to_outbox` Postgres trigger into the `EventStore`'s `SaveEventsInTx`, then drops the trigger via forward-only migration 013.

Phase 3 (LISTEN/NOTIFY relay, drops the 1s polling) follows on a separate branch. **No tag** until Phase 3 lands.

## Why move the outbox write into app code

- The application now owns what goes to the outbox — easier to debug, easier to evolve the outbox shape without trigger DDL gymnastics.
- Atomicity is preserved: the outbox INSERT is in the same `BEGIN/COMMIT` as the event INSERT; rollback drops both. Asserted by `TestEventStore_RollbackDropsBoth`.
- Sets up Phase 3 directly — once app code writes the outbox row, the same TX can also `pg_notify('outbox_new', '')` so the relay can replace polling with LISTEN/NOTIFY.

## Changes

### Application code

`internal/infrastructure/persistence/postgres/event_store.go` — `saveEventsWithTx` now:
1. Generates `event_id` in app code via `uuid.New()` (was `gen_random_uuid()` DB default).
2. INSERTs `events` with the explicit `event_id`.
3. INSERTs `outbox` with the same `event_id` in the same TX.

`ON CONFLICT (event_id) DO NOTHING` on the outbox insert is a deploy-window safety net — if an older engine instance is still running with the trigger active, it would try to insert a duplicate row; the conflict clause makes the app-side write idempotent against that race.

### Migration

`internal/infrastructure/persistence/postgres/migrations/tenant/013_drop_outbox_trigger.{up,down}.sql`:

- **`.up.sql`** drops the trigger + function. The `increment_version_on_event` trigger on the same table (stream-version bookkeeping) is **kept** — different concern. `cleanup_published_outbox()` is also **kept** — the `CleanupWorker` still calls it on a schedule.
- **`.down.sql`** recreates the trigger. Policy is forward-only, but the migrator's required-pair convention wants a down file. Do not run it in production.

The migrator picks the new file up automatically via `//go:embed migrations/tenant` — no code change needed.

### Tests

`internal/infrastructure/persistence/postgres/event_store_integration_test.go` — two new tests behind the existing `//go:build integration` tag:

| Test | What it proves |
|---|---|
| `TestEventStore_SaveEventsAlsoWritesOutbox` | Every `event_id` in `events` also appears in `outbox` with the same `event_type`. Without this, the trigger's job has silently been forgotten. |
| `TestEventStore_RollbackDropsBoth` | `Tx.Rollback` after `SaveEventsInTx` drops both the event row and the outbox row. Atomicity guarantee. |

## Verification

- `go build ./...` — clean
- `go build -tags integration ./...` — test file compiles
- `go test -short ./...` — all unit suites pass (same regression net Phase 1 added)
- **End-to-end smoke** against embedded NATS + embedded Postgres:
  - `task build` → `duragraph dev` starts
  - Migration 013 applied at startup (engine logs `main db migrations applied`)
  - REST: `POST /api/v1/assistants` → `events tail` received `assistant.created` event with the expected envelope shape
  - Proves: trigger is gone, app-side outbox write is the sole row source, and the relay still drains correctly.

## Migration policy

Forward-only. The `.down.sql` exists because the migrator's pair convention requires it, not because anyone should run it.

## Out of scope — Phase 3 next

Replace the 1s polling ticker in `outbox_relay.go` with `LISTEN outbox_new` over a direct-to-Postgres connection (bypassing PgBouncer). `pg_notify('outbox_new', '')` will fire from inside the same TX as the outbox-row write that this phase added.

Per the no-auto-merge rule, **I will not merge without explicit go-ahead** and **will not tag** — the v0.7.X tag waits for Phase 3.