### PR TITLE
feat(controlplane): worker execution path — push dispatch, ack redelivery, durable checkpoint resume

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,169 @@
+// Command worker is a standalone worker process for the control-plane
+// rebuild: it registers with the control-plane's worker endpoints,
+// consumes worker.graph.execute commands off the graph-executor durable
+// consumer (WORKER_COMMANDS stream, filter worker.graph.execute), and
+// drives CounterExecutor's 2-step graph via controlplane/worker.Runner
+// with the ack/checkpoint discipline documented on that type. This
+// binary is wiring only — see controlplane/worker/runner.go for the
+// actual execution + durability logic.
+//
+// Env:
+//
+//	DURAGRAPH_API_URL - control-plane base URL, e.g. http://localhost:8081 (required)
+//	NATS_URL          - JetStream URL, e.g. nats://localhost:4222 (required)
+//	WORKER_ID         - this worker's UUID (optional; random if unset)
+//	WORKER_GRAPHS     - comma-separated graph ids this worker can run (optional; default "counter")
+//	WORKER_CAPACITY   - concurrent run capacity advertised at Register (optional; default 1)
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+	"github.com/google/uuid"
+)
+
+// heartbeatInterval is how often the worker renews its lease with the
+// control-plane. ~20s per the task brief; well under any reasonable
+// worker-offline detection window.
+const heartbeatInterval = 20 * time.Second
+
+// drainTimeout bounds how long shutdown waits for the runner to finish
+// in-flight work before deregistering anyway. Mirrors
+// controlplane/server.DefaultDrainTimeout's role for the HTTP server.
+const drainTimeout = 15 * time.Second
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("worker: exiting", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	apiURL := os.Getenv("DURAGRAPH_API_URL")
+	if apiURL == "" {
+		return fmt.Errorf("worker: DURAGRAPH_API_URL is required")
+	}
+	natsURL := os.Getenv("NATS_URL")
+	if natsURL == "" {
+		return fmt.Errorf("worker: NATS_URL is required")
+	}
+
+	workerID := uuid.New()
+	if v := os.Getenv("WORKER_ID"); v != "" {
+		id, err := uuid.Parse(v)
+		if err != nil {
+			return fmt.Errorf("worker: invalid WORKER_ID %q: %w", v, err)
+		}
+		workerID = id
+	}
+
+	graphs := []string{"counter"}
+	if v := os.Getenv("WORKER_GRAPHS"); v != "" {
+		graphs = splitCSV(v)
+	}
+
+	capacity := 1
+	if v := os.Getenv("WORKER_CAPACITY"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("worker: invalid WORKER_CAPACITY %q: %w", v, err)
+		}
+		capacity = n
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	nc, js, err := nats.Connect(ctx, natsURL)
+	if err != nil {
+		return fmt.Errorf("worker: nats connect: %w", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+
+	// Defensive: a worker started independently of (or before) the
+	// server still needs the durable consumers to exist. Idempotent —
+	// safe even when the server already ensured them.
+	if err := nats.EnsureConsumers(ctx, js); err != nil {
+		return fmt.Errorf("worker: ensure consumers: %w", err)
+	}
+
+	client := worker.NewClient(apiURL, workerID, nil)
+	if err := client.Register(ctx, graphs, capacity); err != nil {
+		return fmt.Errorf("worker: register: %w", err)
+	}
+	slog.Info("worker: registered", "worker_id", workerID, "graphs", graphs, "capacity", capacity)
+
+	heartbeatDone := make(chan struct{})
+	go heartbeatLoop(ctx, client, heartbeatDone)
+
+	runner := worker.NewRunner(js, client, worker.CounterExecutor{})
+	runnerDone := make(chan error, 1)
+	go func() { runnerDone <- runner.Start(ctx) }()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("worker: signal received, shutting down")
+		select {
+		case <-runnerDone:
+		case <-time.After(drainTimeout):
+			slog.Warn("worker: runner did not stop within drain timeout")
+		}
+	case err := <-runnerDone:
+		if err != nil {
+			slog.Error("worker: runner exited", "err", err)
+		}
+	}
+	<-heartbeatDone
+
+	// Deregister after the runner has stopped so the control-plane
+	// requeues only work this worker is actually no longer doing.
+	deregisterCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Deregister(deregisterCtx); err != nil {
+		slog.Error("worker: deregister failed", "err", err)
+	}
+	return nil
+}
+
+// heartbeatLoop renews the worker's lease every heartbeatInterval until
+// ctx is canceled, then closes done.
+func heartbeatLoop(ctx context.Context, client *worker.Client, done chan<- struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := client.Heartbeat(ctx, 0); err != nil {
+				slog.Warn("worker: heartbeat failed", "err", err)
+			}
+		}
+	}
+}
+
+// splitCSV parses a comma-separated env value into a trimmed,
+// non-empty slice.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/controlplane/db/migrations/tenant/006_worker_checkpoint.down.sql
+++ b/controlplane/db/migrations/tenant/006_worker_checkpoint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE snapshots DROP CONSTRAINT IF EXISTS uq_snapshots_stream_version;

--- a/controlplane/db/migrations/tenant/006_worker_checkpoint.up.sql
+++ b/controlplane/db/migrations/tenant/006_worker_checkpoint.up.sql
@@ -1,0 +1,7 @@
+-- Worker checkpoint idempotency — built from spec/models/d2 (worker execution
+-- path). A checkpoint is identified by (stream_id, version); the worker upserts
+-- it, and under JetStream redelivery the same (stream_id, version) may be
+-- written twice. This constraint makes that upsert idempotent and makes the
+-- "latest checkpoint by version" resume lookup unambiguous.
+ALTER TABLE snapshots
+    ADD CONSTRAINT uq_snapshots_stream_version UNIQUE (stream_id, version);

--- a/controlplane/docs/superpowers/plans/2026-07-20-worker-execution-path.md
+++ b/controlplane/docs/superpowers/plans/2026-07-20-worker-execution-path.md
@@ -1,0 +1,1604 @@
+# Worker Execution Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the thin-but-reliable worker execution path — push dispatch over NATS with explicit-ack redelivery, worker HTTP endpoints, durable checkpoints, and a 2-step counter worker that proves crash-resume.
+
+**Architecture:** `run-processor` NATS consumer turns `run.created` into a `worker.graph.execute` command on `WORKER_COMMANDS`. A worker (`cmd/worker`) consumes it via a durable pull consumer with explicit ack, leases the run through the epoch-fenced events endpoint, runs a 2-step counter graph writing a checkpoint after each node, and acks only after the run is durably terminal. A mid-run crash leaves the command un-acked → `ack_wait` redelivers → a fresh worker resumes from the last checkpoint (not from zero), fencing the dead worker via `lease_epoch`.
+
+**Tech Stack:** Go 1.25, Echo v4, pgx v5, NATS JetStream (`nats-io/nats.go` jetstream + embedded `nats-server/v2` for tests), testcontainers Postgres.
+
+## Global Constraints
+
+- Source of truth is the **structural** d2 only: `workers.d2`, `nats.d2`, `endpoint-queries.d2` (workers block), `postgres.d2`. The `code-*.d2` files document the OLD `internal/` design — **excluded**.
+- Design doc: `controlplane/docs/superpowers/specs/2026-07-20-worker-execution-path-design.md`. It is the contract; this plan implements it.
+- **`runs` has NO `lease_expires_at`** — fencing is `lease_epoch` only; JetStream redelivery is the "prior worker dead" trigger.
+- Generated `*_gen.go` are never hand-edited — change `endpoints.yaml` / template and regenerate (`go run ./controlplane/gen` from the worktree root `~/worktrees/duragraph/feat/controlplane-worker-execution`). The `custom: true` flag (already in the generator) emits routes-only; hand-written bodies live in a sibling `.go`.
+- `execution_history.node_type` CHECK: `start|end|llm|tool|conditional`. `status` CHECK: `started|completed|failed|skipped`. Use only these.
+- Worker↔control-plane protocol is internal/native → Go request/response types hand-defined from the d2, NOT added to `duragraph-latest.yaml`.
+- Integration tests use testcontainers Postgres + embedded in-process NATS, no build tag, run in standard CI. Reuse the embedded-NATS `TestMain` pattern in `controlplane/nats/nats_integration_test.go`.
+- Migrations forward-only; every `*.up.sql` ships a `*.down.sql`.
+- Never hand-edit go.mod/go.sum. Conventional commits. Commit after each task. No PR/push/merge without explicit per-PR approval.
+- Reuse existing helpers: `writeTx`, `appendEvent`, `Event`, `mustJSON`, `intOr`, `nilIfEmpty`, `Publisher.PublishWithID`, `SubjectFor`, the `custom` generator flag.
+
+---
+
+## File Structure
+
+- `controlplane/db/migrations/tenant/006_worker_checkpoint.{up,down}.sql` — snapshots unique constraint.
+- `controlplane/endpoints/worker_types.go` — hand-defined worker protocol types.
+- `controlplane/endpoints/rows.go` (modify) — `workerRow`, `snapshotRow`, `execHistoryRow` + mappers.
+- `controlplane/endpoints/workers.go` — hand-written worker handlers (register/heartbeat/deregister/events/checkpoints).
+- `controlplane/endpoints/workers_gen.go` (regenerate) — routes-only.
+- `controlplane/gen/endpoints.yaml` (modify) — mark the 6 worker endpoints `custom`.
+- `controlplane/nats/run_processor.go` — dispatch consumer.
+- `controlplane/nats/consumers.go` (modify) — add `maxDeliver` to `graph-executor`.
+- `controlplane/worker/{client,executor,runner}.go` — worker package.
+- `cmd/worker/main.go` — binary.
+- `controlplane/server/server.go` (modify) — wire run-processor.
+- Tests: `workers_integration_test.go`, `run_processor` test additions, `controlplane/worker/execution_integration_test.go`.
+- `spec/models/d2/endpoint-queries.d2` (spec repo) — reconcile.
+
+---
+
+## Task 1: Migration 006 — snapshots unique constraint
+
+**Files:**
+- Create: `controlplane/db/migrations/tenant/006_worker_checkpoint.up.sql`
+- Create: `controlplane/db/migrations/tenant/006_worker_checkpoint.down.sql`
+- Test: `controlplane/endpoints/migration006_test.go`
+
+**Interfaces:**
+- Produces: a `UNIQUE (stream_id, version)` constraint named `uq_snapshots_stream_version` on `snapshots`, enabling `ON CONFLICT (stream_id, version)` checkpoint upsert (Task 5).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `controlplane/endpoints/migration006_test.go`:
+
+```go
+package endpoints
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSnapshotsUniqueStreamVersion(t *testing.T) {
+	ctx := context.Background()
+	// A stream to hang snapshots off (FK to event_streams).
+	var streamID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
+		VALUES (gen_random_uuid(), 'Run', gen_random_uuid(), 0)
+		RETURNING stream_id`).Scan(&streamID); err != nil {
+		t.Fatal(err)
+	}
+	ins := `INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+	        VALUES ($1, 'Run', gen_random_uuid(), 1, '{}'::jsonb)`
+	if _, err := testPool.Exec(ctx, ins, streamID); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	// Duplicate (stream_id, version) must be rejected by the constraint.
+	if _, err := testPool.Exec(ctx, ins, streamID); err == nil {
+		t.Fatal("duplicate (stream_id, version) should violate uq_snapshots_stream_version, but insert succeeded")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/endpoints/ -run TestSnapshotsUniqueStreamVersion -v`
+Expected: FAIL — the second insert succeeds (no constraint yet).
+
+- [ ] **Step 3: Write the migration**
+
+Create `controlplane/db/migrations/tenant/006_worker_checkpoint.up.sql`:
+
+```sql
+-- Worker checkpoint idempotency — built from spec/models/d2 (worker execution
+-- path). A checkpoint is identified by (stream_id, version); the worker upserts
+-- it, and under JetStream redelivery the same (stream_id, version) may be
+-- written twice. This constraint makes that upsert idempotent and makes the
+-- "latest checkpoint by version" resume lookup unambiguous.
+ALTER TABLE snapshots
+    ADD CONSTRAINT uq_snapshots_stream_version UNIQUE (stream_id, version);
+```
+
+Create `controlplane/db/migrations/tenant/006_worker_checkpoint.down.sql`:
+
+```sql
+ALTER TABLE snapshots DROP CONSTRAINT IF EXISTS uq_snapshots_stream_version;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+The test harness (`applyTenantMigrations` in `assistants_integration_test.go`) applies every `*.up.sql` in sorted order at `TestMain`, so `006` is picked up automatically.
+
+Run: `go test ./controlplane/endpoints/ -run TestSnapshotsUniqueStreamVersion -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add controlplane/db/migrations/tenant/006_worker_checkpoint.up.sql \
+  controlplane/db/migrations/tenant/006_worker_checkpoint.down.sql \
+  controlplane/endpoints/migration006_test.go
+git commit -m "feat(controlplane): migration 006 — snapshots (stream_id,version) unique for checkpoint upsert"
+```
+
+---
+
+## Task 2: Worker protocol types + row structs
+
+**Files:**
+- Create: `controlplane/endpoints/worker_types.go`
+- Modify: `controlplane/endpoints/rows.go`
+- Test: `controlplane/endpoints/worker_rows_test.go`
+
+**Interfaces:**
+- Produces (types, consumed by Tasks 3–5 and the worker package via a shared copy):
+  - `WorkerRegisterRequest{ WorkerID uuid.UUID; Graphs []string; Capacity int }`
+  - `WorkerRegisterResponse{ WorkerID uuid.UUID; Status string }`
+  - `WorkerHeartbeatRequest{ Status string; ActiveRuns int }`
+  - `WorkerHeartbeatResponse{ Commands []string }`
+  - `WorkerEvent{ Type string; LeaseEpoch int; NodeID, NodeType, NodeStatus string; Input, Output json.RawMessage; DurationMs *int; Error *string }`
+  - `WorkerEventsRequest{ Events []WorkerEvent }`
+  - `RunStartedResponse{ LeaseEpoch int }`
+  - `CheckpointWriteRequest{ RunID uuid.UUID; LeaseEpoch, Version int; State json.RawMessage }`
+  - `CheckpointWriteResponse{ CheckpointID int64 }`
+  - `CheckpointResponse{ CheckpointID int64; RunID uuid.UUID; Version int; State json.RawMessage }`
+- Produces (rows): `workerRow`+`toAPI()`, `snapshotRow`+`toAPI()`, `execHistoryRow`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `controlplane/endpoints/worker_rows_test.go`:
+
+```go
+package endpoints
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkerRowToAPI(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	r := workerRow{Status: "online", ActiveRuns: 2, Capacity: 4, LeaseExpiresAt: &now}
+	got := r.toAPI()
+	if got.Status != "online" {
+		t.Errorf("status: want online, got %q", got.Status)
+	}
+}
+
+func TestSnapshotRowToAPI(t *testing.T) {
+	r := snapshotRow{ID: 9, AggregateID: mustUUID("11111111-1111-1111-1111-111111111111"), Version: 2, State: []byte(`{"count":2}`)}
+	got := r.toAPI()
+	if got.CheckpointID != 9 || got.Version != 2 {
+		t.Errorf("checkpoint id/version: got %d/%d", got.CheckpointID, got.Version)
+	}
+	if string(got.State) != `{"count":2}` {
+		t.Errorf("state: got %s", got.State)
+	}
+}
+```
+
+Add this helper at the bottom of `worker_rows_test.go` (used above):
+
+```go
+func mustUUID(s string) uuid.UUID { u, _ := uuid.Parse(s); return u }
+```
+
+and the import `"github.com/google/uuid"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestWorkerRowToAPI|TestSnapshotRowToAPI' -v`
+Expected: FAIL — `undefined: workerRow` / `snapshotRow`.
+
+- [ ] **Step 3: Add the protocol types**
+
+Create `controlplane/endpoints/worker_types.go`:
+
+```go
+// Hand-defined worker↔control-plane protocol types. This is an internal,
+// native protocol (NOT the public LangGraph API), so its types live here rather
+// than in duragraph-latest.yaml. Source of truth: spec/models/d2 workers block
+// + workers.d2 + the worker-execution design doc.
+package endpoints
+
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+type WorkerRegisterRequest struct {
+	WorkerID uuid.UUID `json:"worker_id"`
+	Graphs   []string  `json:"graphs"`
+	Capacity int       `json:"capacity"`
+}
+
+type WorkerRegisterResponse struct {
+	WorkerID uuid.UUID `json:"worker_id"`
+	Status   string    `json:"status"`
+}
+
+type WorkerHeartbeatRequest struct {
+	Status     string `json:"status"`
+	ActiveRuns int    `json:"active_runs"`
+}
+
+type WorkerHeartbeatResponse struct {
+	Commands []string `json:"commands"`
+}
+
+// WorkerEvent is one worker→server state event. Type is one of:
+// run.started | run.completed | run.failed | execution.node_started |
+// execution.node_completed | execution.node_failed. LeaseEpoch fences all
+// non-start events; run.started ignores it (it establishes the lease).
+type WorkerEvent struct {
+	Type       string          `json:"type"`
+	LeaseEpoch int             `json:"lease_epoch"`
+	NodeID     string          `json:"node_id,omitempty"`
+	NodeType   string          `json:"node_type,omitempty"`
+	NodeStatus string          `json:"node_status,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	Output     json.RawMessage `json:"output,omitempty"`
+	DurationMs *int            `json:"duration_ms,omitempty"`
+	Error      *string         `json:"error,omitempty"`
+}
+
+type WorkerEventsRequest struct {
+	Events []WorkerEvent `json:"events"`
+}
+
+type RunStartedResponse struct {
+	LeaseEpoch int `json:"lease_epoch"`
+}
+
+type CheckpointWriteRequest struct {
+	RunID      uuid.UUID       `json:"run_id"`
+	LeaseEpoch int             `json:"lease_epoch"`
+	Version    int             `json:"version"`
+	State      json.RawMessage `json:"state"`
+}
+
+type CheckpointWriteResponse struct {
+	CheckpointID int64 `json:"checkpoint_id"`
+}
+
+type CheckpointResponse struct {
+	CheckpointID int64           `json:"checkpoint_id"`
+	RunID        uuid.UUID       `json:"run_id"`
+	Version      int             `json:"version"`
+	State        json.RawMessage `json:"state"`
+}
+```
+
+- [ ] **Step 4: Add the row structs + mappers**
+
+Append to `controlplane/endpoints/rows.go` (before the DIVERGENCES block); `time`, `uuid`, `json` are already imported there:
+
+```go
+// workerRow mirrors the workers table (postgres.d2 worker_ctx, migration 005).
+type workerRow struct {
+	WorkerID        uuid.UUID  `db:"worker_id"`
+	Graphs          []string   `db:"graphs"`
+	Capacity        int        `db:"capacity"`
+	ActiveRuns      int        `db:"active_runs"`
+	Status          string     `db:"status"`
+	LeaseExpiresAt  *time.Time `db:"lease_expires_at"`
+	LastHeartbeatAt *time.Time `db:"last_heartbeat_at"`
+	CreatedAt       time.Time  `db:"created_at"`
+	UpdatedAt       time.Time  `db:"updated_at"`
+}
+
+func (r workerRow) toAPI() WorkerRegisterResponse {
+	return WorkerRegisterResponse{WorkerID: r.WorkerID, Status: r.Status}
+}
+
+// snapshotRow mirrors the snapshots table (postgres.d2 event_sourcing_ctx).
+type snapshotRow struct {
+	ID          int64     `db:"id"`
+	StreamID    uuid.UUID `db:"stream_id"`
+	AggregateID uuid.UUID `db:"aggregate_id"`
+	Version     int       `db:"version"`
+	State       []byte    `db:"state"` // jsonb
+	CreatedAt   time.Time `db:"created_at"`
+}
+
+func (r snapshotRow) toAPI() CheckpointResponse {
+	return CheckpointResponse{
+		CheckpointID: r.ID,
+		RunID:        r.AggregateID,
+		Version:      r.Version,
+		State:        json.RawMessage(r.State),
+	}
+}
+
+// execHistoryRow mirrors execution_history (postgres.d2 run_ctx). Not returned
+// over the API in this slice; used by tests to assert node execution.
+type execHistoryRow struct {
+	ID       int64  `db:"id"`
+	RunID    uuid.UUID `db:"run_id"`
+	NodeID   string `db:"node_id"`
+	NodeType string `db:"node_type"`
+	Status   string `db:"status"`
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestWorkerRowToAPI|TestSnapshotRowToAPI' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/endpoints/worker_types.go controlplane/endpoints/rows.go \
+  controlplane/endpoints/worker_rows_test.go
+git commit -m "feat(controlplane): worker protocol types + worker/snapshot/exec rows"
+```
+
+---
+
+## Task 3: Worker lifecycle endpoints — register / heartbeat / deregister
+
+**Files:**
+- Modify: `controlplane/gen/endpoints.yaml`
+- Regenerate: `controlplane/endpoints/workers_gen.go`
+- Create: `controlplane/endpoints/workers.go`
+- Test: `controlplane/endpoints/workers_integration_test.go`
+
+**Interfaces:**
+- Consumes: `WorkerRegisterRequest/Response`, `WorkerHeartbeatRequest/Response` (Task 2); `Server.Tenant`; `custom` generator flag.
+- Produces: `func (s *Server) RegisterWorkers(g *echo.Group)` (routes); handlers `WorkersRegister`, `WorkersHeartbeat`, `WorkersDeregister`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `controlplane/endpoints/workers_integration_test.go`:
+
+```go
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+func newTestServerWithWorkers() *echo.Echo {
+	e := echo.New()
+	s := &Server{Tenant: testPool}
+	g := e.Group("/api/v1")
+	s.RegisterWorkers(g)
+	return e
+}
+
+func TestWorkerLifecycle(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE workers, runs, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithWorkers()
+	wid := uuid.NewString()
+
+	// register
+	if rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/register",
+		`{"worker_id":"`+wid+`","graphs":["counter"],"capacity":4}`); rec.Code != http.StatusOK {
+		t.Fatalf("register: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var w struct {
+		Status   string `json:"status"`
+		Capacity int    `json:"capacity"`
+	}
+	if err := testPool.QueryRow(ctx, `SELECT status, capacity FROM workers WHERE worker_id=$1`, wid).Scan(&w.Status, &w.Capacity); err != nil {
+		t.Fatal(err)
+	}
+	if w.Status != "online" || w.Capacity != 4 {
+		t.Errorf("registered worker: got status=%s capacity=%d", w.Status, w.Capacity)
+	}
+
+	// heartbeat (lease valid)
+	rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/heartbeat", `{"status":"online","active_runs":1}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var hb WorkerHeartbeatResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &hb)
+	if hb.Commands == nil {
+		t.Error("heartbeat: commands should be non-nil (empty slice)")
+	}
+
+	// deregister requeues in-flight runs
+	rid := seedInProgressRun(t, ctx, wid) // helper below
+	if rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/deregister", `{}`); rec.Code != http.StatusNoContent {
+		t.Fatalf("deregister: want 204, got %d", rec.Code)
+	}
+	var status string
+	var workerID *string
+	if err := testPool.QueryRow(ctx, `SELECT status, worker_id::text FROM runs WHERE id=$1`, rid).Scan(&status, &workerID); err != nil {
+		t.Fatal(err)
+	}
+	if status != "queued" || workerID != nil {
+		t.Errorf("deregister requeue: want queued/null worker, got %s/%v", status, workerID)
+	}
+}
+
+// seedInProgressRun inserts an assistant + an in_progress run held by wid.
+func seedInProgressRun(t *testing.T, ctx context.Context, wid string) string {
+	t.Helper()
+	var aid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	var rid string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO runs (assistant_id, status, worker_id) VALUES ($1, 'in_progress', $2) RETURNING id`,
+		aid, wid).Scan(&rid); err != nil {
+		t.Fatal(err)
+	}
+	return rid
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/endpoints/ -run TestWorkerLifecycle -v`
+Expected: FAIL — `RegisterWorkers` still generates stub bodies (register won't write the row; heartbeat/deregister return the stub).
+
+- [ ] **Step 3: Mark the lifecycle endpoints custom in the manifest**
+
+In `controlplane/gen/endpoints.yaml`, under `- name: workers`, add `custom: true` to `register`, `heartbeat`, `deregister` (leave `claim`, `stream_events`, `write_checkpoint`, `read_checkpoint` as-is for now — Tasks 4–5 handle events + checkpoints; `claim` stays stub/deferred). Preserve existing fields; only add the `custom: true` line to those three.
+
+- [ ] **Step 4: Regenerate and verify prior groups unchanged**
+
+Run: `go run ./controlplane/gen`
+Run: `git diff --stat controlplane/endpoints/assistants_gen.go controlplane/endpoints/store_gen.go`
+Expected: empty (other groups byte-identical).
+Run: `git diff controlplane/endpoints/workers_gen.go` — `register/heartbeat/deregister` now route-only; the rest keep stub bodies.
+
+- [ ] **Step 5: Write the handlers**
+
+Create `controlplane/endpoints/workers.go`:
+
+```go
+// Hand-written worker endpoints (worker↔control-plane protocol). Routes are
+// generated into workers_gen.go (endpoints marked custom in endpoints.yaml);
+// bodies live here. Source of truth: spec/models/d2 workers block + workers.d2
+// + the worker-execution design doc. runs has NO lease_expires_at — fencing is
+// lease_epoch only.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// WorkersRegister upserts a worker as online. POST /workers/register -> 200.
+func (s *Server) WorkersRegister(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req WorkerRegisterRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if _, err := s.Tenant.Exec(ctx, `
+		INSERT INTO workers (worker_id, graphs, capacity, status, lease_expires_at, last_heartbeat_at)
+		VALUES ($1, $2, $3, 'online', now() + interval '60 seconds', now())
+		ON CONFLICT (worker_id) DO UPDATE
+		  SET graphs=EXCLUDED.graphs, capacity=EXCLUDED.capacity, status='online',
+		      lease_expires_at=now() + interval '60 seconds', last_heartbeat_at=now()`,
+		req.WorkerID, req.Graphs, req.Capacity); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, WorkerRegisterResponse{WorkerID: req.WorkerID, Status: "online"})
+}
+
+// WorkersHeartbeat renews the worker lease. POST /workers/{id}/heartbeat -> 200.
+func (s *Server) WorkersHeartbeat(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid := c.Param("id")
+	var req WorkerHeartbeatRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	ct, err := s.Tenant.Exec(ctx, `
+		UPDATE workers SET status=$2, active_runs=$3,
+		  lease_expires_at=now() + interval '60 seconds', last_heartbeat_at=now()
+		WHERE worker_id=$1 AND lease_expires_at > now()`,
+		wid, req.Status, req.ActiveRuns)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if ct.RowsAffected() == 0 {
+		// Unknown worker or expired lease — worker must re-register.
+		return echo.NewHTTPError(http.StatusConflict, "worker lease expired or unknown; re-register")
+	}
+	return c.JSON(http.StatusOK, WorkerHeartbeatResponse{Commands: []string{}})
+}
+
+// WorkersDeregister marks the worker offline and requeues its in-flight runs.
+// POST /workers/{id}/deregister -> 204.
+func (s *Server) WorkersDeregister(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid := c.Param("id")
+	tx, err := s.Tenant.Begin(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	if _, err := tx.Exec(ctx, `UPDATE workers SET status='offline' WHERE worker_id=$1`, wid); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE runs SET status='queued', worker_id=NULL
+		WHERE worker_id=$1 AND status='in_progress'`, wid); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+var _ = errors.Is // retained for Tasks 4–5 handlers added to this file
+var _ = pgx.ErrNoRows
+```
+
+Note: remove the two trailing `var _ =` lines in Step 3 of Task 4 once the real uses land — they exist only so this file compiles standalone in this task. (If `go vet` complains now, keep them; they are removed when events/checkpoints add real `errors`/`pgx` uses.)
+
+- [ ] **Step 6: Build, run the test**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/endpoints/ -run TestWorkerLifecycle -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add controlplane/gen/endpoints.yaml controlplane/endpoints/workers_gen.go \
+  controlplane/endpoints/workers.go controlplane/endpoints/workers_integration_test.go
+git commit -m "feat(controlplane): worker register/heartbeat/deregister endpoints"
+```
+
+---
+
+## Task 4: Events endpoint — run lifecycle + node events, epoch-fenced
+
+**Files:**
+- Modify: `controlplane/gen/endpoints.yaml` (mark `stream_events` custom)
+- Regenerate: `controlplane/endpoints/workers_gen.go`
+- Modify: `controlplane/endpoints/workers.go` (add `WorkersStreamEvents`)
+- Test: `controlplane/endpoints/workers_integration_test.go` (add cases)
+
+**Interfaces:**
+- Consumes: `WorkerEventsRequest`, `WorkerEvent`, `RunStartedResponse` (Task 2); `writeTx`, `Event`, `mustJSON`.
+- Produces: `func (s *Server) WorkersStreamEvents(c echo.Context) error` handling `POST /workers/{id}/runs/{rid}/events`. run.started returns `RunStartedResponse{lease_epoch}`; node/terminal events are epoch-fenced (409 on mismatch/terminal).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `controlplane/endpoints/workers_integration_test.go`:
+
+```go
+func TestWorkerEventsLifecycle(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE workers, runs, execution_history, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithWorkers()
+	wid := uuid.NewString()
+	var aid, rid string
+	_ = testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO runs (assistant_id, status) VALUES ($1,'queued') RETURNING id`, aid).Scan(&rid)
+
+	base := "/api/v1/workers/" + wid + "/runs/" + rid + "/events"
+
+	// run.started leases the run and returns epoch 1
+	rec := doJSON(t, e, http.MethodPost, base, `{"events":[{"type":"run.started"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.started: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var rs RunStartedResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &rs)
+	if rs.LeaseEpoch != 1 {
+		t.Fatalf("run.started epoch: want 1, got %d", rs.LeaseEpoch)
+	}
+	var st string
+	var le int
+	_ = testPool.QueryRow(ctx, `SELECT status, lease_epoch FROM runs WHERE id=$1`, rid).Scan(&st, &le)
+	if st != "in_progress" || le != 1 {
+		t.Errorf("after start: want in_progress/epoch1, got %s/%d", st, le)
+	}
+
+	// node_completed with correct epoch -> execution_history row + 200
+	rec = doJSON(t, e, http.MethodPost, base,
+		`{"events":[{"type":"execution.node_completed","lease_epoch":1,"node_id":"A","node_type":"tool","node_status":"completed"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("node event: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var n int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM execution_history WHERE run_id=$1`, rid).Scan(&n)
+	if n != 1 {
+		t.Errorf("execution_history: want 1, got %d", n)
+	}
+
+	// stale epoch -> 409
+	rec = doJSON(t, e, http.MethodPost, base,
+		`{"events":[{"type":"execution.node_completed","lease_epoch":0,"node_id":"A","node_type":"tool","node_status":"completed"}]}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("stale epoch: want 409, got %d", rec.Code)
+	}
+
+	// run.completed -> completed
+	rec = doJSON(t, e, http.MethodPost, base, `{"events":[{"type":"run.completed","lease_epoch":1}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.completed: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	_ = testPool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&st)
+	if st != "completed" {
+		t.Errorf("after complete: want completed, got %s", st)
+	}
+
+	// run.started on a terminal run -> 409
+	rec = doJSON(t, e, http.MethodPost, base, `{"events":[{"type":"run.started"}]}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("start on terminal: want 409, got %d", rec.Code)
+	}
+
+	// outbox carries run.started + node_completed + run.completed
+	var oc int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1`, rid).Scan(&oc)
+	if oc < 3 {
+		t.Errorf("outbox events: want >=3, got %d", oc)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/endpoints/ -run TestWorkerEventsLifecycle -v`
+Expected: FAIL — `stream_events` still returns the stub.
+
+- [ ] **Step 3: Mark `stream_events` custom + regenerate**
+
+In `controlplane/gen/endpoints.yaml`, add `custom: true` to the workers `stream_events` endpoint. Run `go run ./controlplane/gen`. Confirm other groups unchanged (`git diff --stat` empty for them) and `workers_gen.go` now routes `WorkersStreamEvents`.
+
+Also remove the two placeholder `var _ =` lines from `workers.go` (Task 3 Step 5) — this task's handler uses `errors` and `pgx` for real.
+
+- [ ] **Step 4: Add the events handler to `workers.go`**
+
+Append to `controlplane/endpoints/workers.go`:
+
+```go
+// WorkersStreamEvents is the single worker→server state channel.
+// POST /workers/{id}/runs/{rid}/events. run.started establishes the lease and
+// returns the epoch; all other events are fenced on lease_epoch. Source: design
+// doc "events endpoint". runs has no lease_expires_at — fence on epoch only.
+func (s *Server) WorkersStreamEvents(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid := c.Param("id")
+	rid := c.Param("rid")
+	var req WorkerEventsRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	var startedEpoch *int
+	for _, ev := range req.Events {
+		switch ev.Type {
+		case "run.started":
+			epoch, err := s.leaseRun(ctx, rid, wid)
+			if err != nil {
+				return err // already-typed echo error (409/500)
+			}
+			startedEpoch = &epoch
+		case "run.completed", "run.failed":
+			if err := s.terminalRun(ctx, rid, ev); err != nil {
+				return err
+			}
+		case "execution.node_started", "execution.node_completed", "execution.node_failed":
+			if err := s.nodeEvent(ctx, rid, ev); err != nil {
+				return err
+			}
+		default:
+			return echo.NewHTTPError(http.StatusBadRequest, "unknown event type: "+ev.Type)
+		}
+	}
+	if startedEpoch != nil {
+		return c.JSON(http.StatusOK, RunStartedResponse{LeaseEpoch: *startedEpoch})
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+// leaseRun re-leases a non-terminal run to wid, bumping lease_epoch, and emits
+// run.started. Returns the new epoch. 409 if the run is already terminal.
+func (s *Server) leaseRun(ctx context.Context, rid, wid string) (int, error) {
+	var epoch int
+	err := s.writeTx(ctx, s.Tenant, []Event{{AggregateType: "Run", AggregateID: mustParseUUID(rid), EventType: "run.started"}},
+		func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `
+				UPDATE runs SET status='in_progress', worker_id=$2,
+				  lease_epoch=lease_epoch+1, started_at=COALESCE(started_at, now())
+				WHERE id=$1 AND status IN ('queued','in_progress')
+				RETURNING lease_epoch`, rid, wid).Scan(&epoch)
+		})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, echo.NewHTTPError(http.StatusConflict, "run is terminal or not found")
+		}
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return epoch, nil
+}
+
+// errStaleLease is returned from a projection when the epoch guard rejects the
+// write (0 rows affected). writeTxOrHTTP maps it to 409. Because writeTx appends
+// the event BEFORE the projection runs, returning this rolls the whole tx back —
+// so a stale worker's event is never committed.
+var errStaleLease = errors.New("stale lease_epoch")
+
+// nodeEvent records a node execution row + emits the execution.node_* event.
+// The epoch guard is ATOMIC (conditional INSERT), not a separate read.
+func (s *Server) nodeEvent(ctx context.Context, rid string, ev WorkerEvent) error {
+	return s.writeTxOrHTTP(ctx, rid, ev.Type, ev, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `
+			INSERT INTO execution_history (run_id, node_id, node_type, status, input, output, error, duration_ms, completed_at)
+			SELECT $1,$2,$3,$4,$5,$6,$7,$8, CASE WHEN $4 <> 'started' THEN now() END
+			WHERE EXISTS (SELECT 1 FROM runs WHERE id=$1 AND lease_epoch=$9)`,
+			rid, ev.NodeID, ev.NodeType, ev.NodeStatus,
+			jsonOrEmpty(ev.Input), jsonOrEmpty(ev.Output), ev.Error, ev.DurationMs, ev.LeaseEpoch)
+		if err != nil {
+			return err
+		}
+		if ct.RowsAffected() == 0 {
+			return errStaleLease
+		}
+		return nil
+	})
+}
+
+// terminalRun marks the run completed/failed + emits the event. Epoch guarded
+// IN the UPDATE (WHERE lease_epoch=$epoch); 0 rows → stale → 409.
+func (s *Server) terminalRun(ctx context.Context, rid string, ev WorkerEvent) error {
+	status := "completed"
+	if ev.Type == "run.failed" {
+		status = "failed"
+	}
+	return s.writeTxOrHTTP(ctx, rid, ev.Type, ev, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx,
+			`UPDATE runs SET status=$2, completed_at=now(), error=$3 WHERE id=$1 AND lease_epoch=$4`,
+			rid, status, ev.Error, ev.LeaseEpoch)
+		if err != nil {
+			return err
+		}
+		if ct.RowsAffected() == 0 {
+			return errStaleLease
+		}
+		return nil
+	})
+}
+
+// writeTxOrHTTP runs a projection inside writeTx (emitting one event) and maps
+// errStaleLease → 409, other errors → 500.
+func (s *Server) writeTxOrHTTP(ctx context.Context, rid, eventType string, ev WorkerEvent, proj func(pgx.Tx) error) error {
+	events := []Event{{AggregateType: "Run", AggregateID: mustParseUUID(rid), EventType: eventType, Payload: mustJSON(ev)}}
+	if err := s.writeTx(ctx, s.Tenant, events, proj); err != nil {
+		if errors.Is(err, errStaleLease) {
+			return echo.NewHTTPError(http.StatusConflict, "stale lease_epoch")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return nil
+}
+```
+
+Add to `controlplane/endpoints/runtime.go` a UUID parse helper (used above and in Task 5):
+
+```go
+// mustParseUUID parses a UUID string, returning the zero UUID on failure (the
+// caller has already validated the path param, or the DB FK will reject zero).
+func mustParseUUID(s string) uuid.UUID { u, _ := uuid.Parse(s); return u }
+```
+
+(`uuid` is already imported in runtime.go.)
+
+- [ ] **Step 5: Build, run the test**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/endpoints/ -run 'TestWorkerEventsLifecycle|TestWorkerLifecycle' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/gen/endpoints.yaml controlplane/endpoints/workers_gen.go \
+  controlplane/endpoints/workers.go controlplane/endpoints/runtime.go \
+  controlplane/endpoints/workers_integration_test.go
+git commit -m "feat(controlplane): worker events endpoint — run lifecycle + node events, epoch-fenced"
+```
+
+---
+
+## Task 5: Checkpoint endpoints — write (epoch-fenced upsert) + read + resume lookup
+
+**Files:**
+- Modify: `controlplane/gen/endpoints.yaml` (mark `write_checkpoint`, `read_checkpoint` custom)
+- Regenerate: `controlplane/endpoints/workers_gen.go`
+- Modify: `controlplane/endpoints/workers.go` (add checkpoint handlers)
+- Test: `controlplane/endpoints/workers_integration_test.go` (add cases)
+
+**Interfaces:**
+- Consumes: `CheckpointWriteRequest/Response`, `CheckpointResponse` (Task 2); `snapshotRow` (Task 2); the `uq_snapshots_stream_version` constraint (Task 1); `errStaleLease` (Task 4).
+- Produces: `WorkersWriteCheckpoint` (`POST /threads/{tid}/checkpoints`), `WorkersReadCheckpoint` (`GET /threads/{tid}/checkpoints/{ckpt}`), and a latest-for-run lookup exposed for the worker resume (query param `?run_id=&latest=true` on read, or a dedicated handler — implement as documented below).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `controlplane/endpoints/workers_integration_test.go`:
+
+```go
+func TestWorkerCheckpoints(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE workers, runs, snapshots, events, outbox, event_streams, assistants, threads CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithWorkers()
+	wid := uuid.NewString()
+	var tid, aid, rid string
+	_ = testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'queued') RETURNING id`, tid, aid).Scan(&rid)
+
+	// lease the run first (creates the event_stream that snapshots FK-references)
+	started := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/runs/"+rid+"/events", `{"events":[{"type":"run.started"}]}`)
+	var rs RunStartedResponse
+	_ = json.Unmarshal(started.Body.Bytes(), &rs)
+
+	cp := "/api/v1/threads/" + tid + "/checkpoints"
+	body := func(v int, st string) string {
+		return `{"run_id":"` + rid + `","lease_epoch":` + itoa(rs.LeaseEpoch) + `,"version":` + itoa(v) + `,"state":` + st + `}`
+	}
+
+	// write checkpoint v1
+	if rec := doJSON(t, e, http.MethodPost, cp, body(1, `{"count":1}`)); rec.Code != http.StatusOK {
+		t.Fatalf("write v1: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// upsert v1 (same version) is idempotent -> still 200, still one row
+	if rec := doJSON(t, e, http.MethodPost, cp, body(1, `{"count":1}`)); rec.Code != http.StatusOK {
+		t.Fatalf("upsert v1: want 200, got %d", rec.Code)
+	}
+	var cnt int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM snapshots WHERE aggregate_id=$1`, rid).Scan(&cnt)
+	if cnt != 1 {
+		t.Errorf("after upsert: want 1 snapshot, got %d", cnt)
+	}
+	// write v2
+	_ = doJSON(t, e, http.MethodPost, cp, body(2, `{"count":2}`))
+
+	// stale epoch -> 409
+	if rec := doJSON(t, e, http.MethodPost, cp, `{"run_id":"`+rid+`","lease_epoch":999,"version":3,"state":{}}`); rec.Code != http.StatusConflict {
+		t.Errorf("stale checkpoint: want 409, got %d", rec.Code)
+	}
+
+	// resume lookup: latest checkpoint for run -> version 2
+	rec := doJSON(t, e, http.MethodGet, cp+"/latest?run_id="+rid, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("latest: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got CheckpointResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.Version != 2 {
+		t.Errorf("latest version: want 2, got %d", got.Version)
+	}
+}
+```
+
+Add this helper (once) to the test file, with `import "strconv"`:
+
+```go
+func itoa(n int) string { return strconv.Itoa(n) }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/endpoints/ -run TestWorkerCheckpoints -v`
+Expected: FAIL — checkpoint endpoints still stub.
+
+- [ ] **Step 3: Mark checkpoints custom + add a `latest` route**
+
+In `controlplane/gen/endpoints.yaml`, add `custom: true` to `write_checkpoint` and `read_checkpoint`. Add a new endpoint entry to the workers group for the resume lookup:
+
+```yaml
+  - name: latest_checkpoint
+    method: GET
+    path: /threads/{tid}/checkpoints/latest
+    kind: read
+    outbox: false
+    custom: true
+```
+
+Run `go run ./controlplane/gen`. Confirm other groups unchanged; `workers_gen.go` now routes `WorkersWriteCheckpoint`, `WorkersReadCheckpoint`, `WorkersLatestCheckpoint`. (Register order: ensure `/checkpoints/latest` is registered — Echo matches static `/latest` before the `/:ckpt` param when both exist; if a conflict arises, the `latest` handler guards on the `run_id` query param.)
+
+- [ ] **Step 4: Add checkpoint handlers to `workers.go`**
+
+Append to `controlplane/endpoints/workers.go`:
+
+```go
+// WorkersWriteCheckpoint upserts a run snapshot, epoch-fenced.
+// POST /threads/{tid}/checkpoints -> 200 {checkpoint_id}.
+func (s *Server) WorkersWriteCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req CheckpointWriteRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	rid := req.RunID.String()
+	// Resolve the run's event stream (created by run.started's writeTx).
+	var streamID string
+	if err := s.Tenant.QueryRow(ctx,
+		`SELECT stream_id FROM event_streams WHERE aggregate_type='Run' AND aggregate_id=$1`, rid).Scan(&streamID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusConflict, "run stream not initialized (post run.started first)")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	// Atomic epoch guard: the INSERT..SELECT only fires when the run's current
+	// lease_epoch matches; a stale worker inserts nothing → 0 rows → 409.
+	var id int64
+	err := s.Tenant.QueryRow(ctx, `
+		INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+		SELECT $1, 'Run', $2, $3, $4
+		WHERE EXISTS (SELECT 1 FROM runs WHERE id=$2 AND lease_epoch=$5)
+		ON CONFLICT (stream_id, version) DO UPDATE SET state=EXCLUDED.state
+		RETURNING id`,
+		streamID, rid, req.Version, jsonOrEmpty(req.State), req.LeaseEpoch).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusConflict, "stale lease_epoch")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, CheckpointWriteResponse{CheckpointID: id})
+}
+
+// WorkersReadCheckpoint returns one snapshot by id, scoped to the thread's runs.
+// GET /threads/{tid}/checkpoints/{ckpt} -> 200 / 404.
+func (s *Server) WorkersReadCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	tid := c.Param("tid")
+	ckpt := c.Param("ckpt")
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots
+		WHERE id=$1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id=$2)`, ckpt, tid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toAPI())
+}
+
+// WorkersLatestCheckpoint returns the highest-version snapshot for a run, for
+// worker resume. GET /threads/{tid}/checkpoints/latest?run_id=... -> 200 / 404.
+func (s *Server) WorkersLatestCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	rid := c.QueryParam("run_id")
+	if rid == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "run_id is required")
+	}
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots WHERE aggregate_id=$1 ORDER BY version DESC LIMIT 1`, rid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "no checkpoint")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toAPI())
+}
+```
+
+- [ ] **Step 5: Build, run the tests**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/endpoints/ -run TestWorkerCheckpoints -v`
+Expected: PASS.
+
+Run: `go test ./controlplane/endpoints/` (full package regression)
+Expected: PASS (store/system/assistants/etc. still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/gen/endpoints.yaml controlplane/endpoints/workers_gen.go \
+  controlplane/endpoints/workers.go controlplane/endpoints/workers_integration_test.go
+git commit -m "feat(controlplane): checkpoint write (epoch-fenced upsert) + read + latest-for-run resume lookup"
+```
+
+---
+
+## Task 6: run-processor dispatch consumer + max_deliver on graph-executor
+
+**Files:**
+- Create: `controlplane/nats/run_processor.go`
+- Modify: `controlplane/nats/consumers.go` (add `maxDeliver` to `graph-executor`)
+- Test: `controlplane/nats/run_processor_test.go`
+
+**Interfaces:**
+- Consumes: `jetstream.JetStream`, `Publisher.PublishWithID`, the `RUNS` stream + `WORKER_COMMANDS` stream (already ensured), the `run-processor` consumer spec (already declared).
+- Produces: `type RunProcessor` with `NewRunProcessor(js jetstream.JetStream, pub *Publisher) *RunProcessor` and `func (rp *RunProcessor) Start(ctx context.Context) error` (blocks, consuming `run-processor` until ctx cancels) + `Stop()`. Publishes `duragraph.worker_commands.worker.graph.execute` with `Nats-Msg-Id = run_id` and payload `{run_id, thread_id, assistant_id, graph_id, input}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `controlplane/nats/run_processor_test.go` (package `nats_test`, reuses the embedded-NATS `TestMain` + `natsURL`):
+
+```go
+package nats_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestRunProcessorDispatch(t *testing.T) {
+	ctx := context.Background()
+	nc, js := connectJS(t) // helper in this package's test files; see nats_integration_test.go
+	defer nc.Close()
+	if err := dnats.EnsureStreams(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js))
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	// Subscribe to WORKER_COMMANDS to observe the dispatched command.
+	cons, err := js.CreateOrUpdateConsumer(ctx, "WORKER_COMMANDS", jetstream.ConsumerConfig{
+		FilterSubject: "duragraph.worker_commands.worker.graph.execute",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Publish a run.created onto RUNS (Nats-Msg-Id = run_id).
+	pub := dnats.NewPublisher(js)
+	runID := "11111111-1111-1111-1111-111111111111"
+	payload := map[string]any{"run_id": runID, "assistant_id": "22222222-2222-2222-2222-222222222222", "graph_id": "counter"}
+	if err := pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID, payload); err != nil {
+		t.Fatal(err)
+	}
+	// Publish the SAME run.created again → dedup → run-processor sees one.
+	_ = pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID, payload)
+
+	batch, err := cons.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got jetstream.Msg
+	for m := range batch.Messages() {
+		got = m
+	}
+	if got == nil {
+		t.Fatal("no worker.graph.execute command dispatched")
+	}
+	var cmd map[string]any
+	_ = json.Unmarshal(got.Data(), &cmd)
+	if cmd["run_id"] != runID {
+		t.Errorf("command run_id: want %s, got %v", runID, cmd["run_id"])
+	}
+	_ = got.Ack()
+
+	// No second command (RUNS dedup on Nats-Msg-Id → single command).
+	batch2, err := cons.Fetch(1, jetstream.FetchMaxWait(1*time.Second))
+	if err != nil {
+		t.Fatalf("fetch2: %v", err)
+	}
+	n := 0
+	for range batch2.Messages() {
+		n++
+	}
+	if n != 0 {
+		t.Errorf("expected only one dispatched command (dedup), got a second")
+	}
+}
+```
+
+If a `connectJS(t)` helper does not already exist in the package's test files, add one mirroring the connection code in `nats_integration_test.go` (dial `natsURL`, return `*nats.Conn` + `jetstream.JetStream`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/nats/ -run TestRunProcessorDispatch -v`
+Expected: FAIL — `undefined: NewRunProcessor`.
+
+- [ ] **Step 3: Add max_deliver to the graph-executor consumer**
+
+In `controlplane/nats/consumers.go`, add a `maxDeliver` field to the `graph-executor` spec so poison/persistently-failing commands dead-letter instead of redelivering forever. Change its `tenantConsumers` entry to include `maxDeliver: 5`:
+
+```go
+{name: "graph-executor", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.graph.execute", ackWait: 5 * time.Minute, maxDeliver: 5},
+```
+
+(The `consumerSpec` struct already has `maxDeliver` and `EnsureConsumers` already applies it.)
+
+- [ ] **Step 4: Write the run-processor**
+
+Create `controlplane/nats/run_processor.go`:
+
+```go
+// run-processor: the dispatch consumer. Drains the RUNS stream (filter
+// run.created) and turns each queued run into a worker.graph.execute command on
+// WORKER_COMMANDS, with Nats-Msg-Id = run_id so a duplicate run.created yields a
+// single command. Thin dispatcher — it does not mutate run state; the worker
+// leases via run.started. Source: spec/models/d2/nats.d2 + endpoint-queries.d2.
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type RunProcessor struct {
+	js   jetstream.JetStream
+	pub  *Publisher
+	stop context.CancelFunc
+}
+
+func NewRunProcessor(js jetstream.JetStream, pub *Publisher) *RunProcessor {
+	return &RunProcessor{js: js, pub: pub}
+}
+
+// runCreatedPayload is the subset of the run.created event the dispatcher needs.
+type runCreatedPayload struct {
+	RunID       string          `json:"run_id"`
+	ThreadID    string          `json:"thread_id,omitempty"`
+	AssistantID string          `json:"assistant_id"`
+	GraphID     string          `json:"graph_id,omitempty"`
+	Input       json.RawMessage `json:"input,omitempty"`
+}
+
+// Start binds the durable run-processor consumer and blocks, dispatching each
+// run.created as a worker.graph.execute command until ctx is cancelled.
+func (rp *RunProcessor) Start(ctx context.Context) error {
+	ctx, rp.stop = context.WithCancel(ctx)
+	cons, err := rp.js.Consumer(ctx, "RUNS", "run-processor")
+	if err != nil {
+		return fmt.Errorf("run-processor: bind consumer: %w", err)
+	}
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		if err := rp.dispatch(ctx, msg); err != nil {
+			_ = msg.Nak() // transient: let it redeliver
+			return
+		}
+		_ = msg.Ack()
+	})
+	if err != nil {
+		return fmt.Errorf("run-processor: consume: %w", err)
+	}
+	defer cc.Stop()
+	<-ctx.Done()
+	return nil
+}
+
+func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
+	// Only run.created triggers dispatch; ignore other run.* subjects on RUNS.
+	if !hasSuffix(msg.Subject(), "run.created") {
+		return nil
+	}
+	var p runCreatedPayload
+	if err := json.Unmarshal(msg.Data(), &p); err != nil {
+		return nil // malformed → drop (ack); nothing to retry
+	}
+	if p.RunID == "" {
+		return nil
+	}
+	cmd := map[string]any{
+		"run_id": p.RunID, "thread_id": p.ThreadID,
+		"assistant_id": p.AssistantID, "graph_id": p.GraphID, "input": p.Input,
+	}
+	// Nats-Msg-Id = run_id → one command per run even if run.created duplicates.
+	return rp.pub.PublishWithID(ctx, SubjectFor("worker.graph.execute"), p.RunID, cmd)
+}
+
+func (rp *RunProcessor) Stop() {
+	if rp.stop != nil {
+		rp.stop()
+	}
+}
+
+func hasSuffix(s, suf string) bool {
+	return len(s) >= len(suf) && s[len(s)-len(suf):] == suf
+}
+```
+
+Note: verify `SubjectFor("worker.graph.execute")` yields `duragraph.worker_commands.worker.graph.execute` — check `categoryFor` in `publisher.go` maps the `worker.` prefix to the `worker_commands` category. If it does not, extend `categoryFor` to map `worker` → `worker_commands` (small, covered by the test's subscription filter).
+
+- [ ] **Step 5: Build, run the test**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/nats/ -run TestRunProcessorDispatch -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/nats/run_processor.go controlplane/nats/consumers.go \
+  controlplane/nats/run_processor_test.go
+git commit -m "feat(controlplane): run-processor dispatch consumer + graph-executor max_deliver"
+```
+
+---
+
+## Task 7: Worker package — HTTP client + 2-step counter executor
+
+**Files:**
+- Create: `controlplane/worker/client.go`
+- Create: `controlplane/worker/executor.go`
+- Test: `controlplane/worker/client_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type Client` with `NewClient(baseURL string, workerID uuid.UUID, http *http.Client) *Client` and methods `Register(ctx, graphs []string, capacity int) error`, `Heartbeat(ctx, activeRuns int) error`, `Deregister(ctx) error`, `RunStarted(ctx, runID uuid.UUID) (epoch int, err error)`, `NodeCompleted(ctx, runID uuid.UUID, epoch int, nodeID, nodeType string) error`, `RunCompleted(ctx, runID uuid.UUID, epoch int) error`, `RunFailed(ctx, runID uuid.UUID, epoch int, reason string) error`, `WriteCheckpoint(ctx, threadID, runID uuid.UUID, epoch, version int, state []byte) error`, `LatestCheckpoint(ctx, threadID, runID uuid.UUID) (version int, state []byte, found bool, err error)`. A 409 from any epoch-fenced call returns a sentinel `ErrStaleLease`.
+  - `type CounterExecutor` implementing the 2-step counter graph: `func (CounterExecutor) Nodes() []string` → `["A","B"]`; `func (CounterExecutor) Run(step int, state map[string]int) map[string]int` (A→count=1, B→count=2).
+- Consumes: the worker endpoints from Tasks 3–5 (over HTTP).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `controlplane/worker/client_test.go`. It mounts the real endpoints over `httptest` against the shared `testPool`, so it exercises the actual handlers. (This test package imports `controlplane/endpoints`; use a small `TestMain` that stands up a Postgres testcontainer + migrations, mirroring `endpoints`'s harness — or, to avoid duplication, keep this test in `package worker_test` and start an `httptest.Server` wrapping an `echo.Echo` with the worker routes and a pool.)
+
+```go
+package worker_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	"github.com/duragraph/duragraph/controlplane/worker"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+func TestClientLifecycleAndCheckpoints(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t) // helper: testcontainer PG + tenant migrations (see execution_integration_test.go)
+	e := echo.New()
+	g := e.Group("/api/v1")
+	(&endpoints.Server{Tenant: pool}).RegisterWorkers(g)
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	wid := uuid.New()
+	cl := worker.NewClient(srv.URL, wid, srv.Client())
+
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool) // queued run on a thread
+	epoch, err := cl.RunStarted(ctx, rid)
+	if err != nil || epoch != 1 {
+		t.Fatalf("run started: epoch=%d err=%v", epoch, err)
+	}
+	if err := cl.WriteCheckpoint(ctx, tid, rid, epoch, 1, []byte(`{"count":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	v, state, found, err := cl.LatestCheckpoint(ctx, tid, rid)
+	if err != nil || !found || v != 1 || string(state) != `{"count":1}` {
+		t.Fatalf("latest: v=%d found=%v state=%s err=%v", v, found, state, err)
+	}
+	if err := cl.NodeCompleted(ctx, rid, epoch, "A", "tool"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.RunCompleted(ctx, rid, epoch); err != nil {
+		t.Fatal(err)
+	}
+	// stale lease surfaces as ErrStaleLease
+	if err := cl.NodeCompleted(ctx, rid, 999, "B", "tool"); err != worker.ErrStaleLease {
+		t.Fatalf("stale lease: want ErrStaleLease, got %v", err)
+	}
+}
+
+func TestCounterExecutor(t *testing.T) {
+	ex := worker.CounterExecutor{}
+	if got := ex.Nodes(); len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("nodes: %v", got)
+	}
+	st := ex.Run(0, map[string]int{})
+	if st["count"] != 1 {
+		t.Errorf("A: want count=1, got %d", st["count"])
+	}
+	st = ex.Run(1, st)
+	if st["count"] != 2 {
+		t.Errorf("B: want count=2, got %d", st["count"])
+	}
+}
+```
+
+(`newPool`, `seedThreadAssistantRun` live in `execution_integration_test.go`, Task 8; if Task 7 is executed first, add a minimal `worker_testmain_test.go` with the testcontainer TestMain + these helpers, and Task 8 reuses them.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/worker/ -run 'TestClientLifecycleAndCheckpoints|TestCounterExecutor' -v`
+Expected: FAIL — `undefined: worker.NewClient` / `worker.CounterExecutor`.
+
+- [ ] **Step 3: Write the executor**
+
+Create `controlplane/worker/executor.go`:
+
+```go
+// The 2-step counter graph — the thin executor that proves durable execution.
+// Node A sets count=1, node B sets count=2. A checkpoint is written after each
+// node so a crash between them resumes at B (not A). Deliberately trivial; the
+// real graph engine is a later cycle.
+package worker
+
+type CounterExecutor struct{}
+
+// Nodes returns the ordered node ids.
+func (CounterExecutor) Nodes() []string { return []string{"A", "B"} }
+
+// Run applies node[step] to state and returns the new state. Node A → count=1,
+// node B → count=2 (idempotent given step).
+func (CounterExecutor) Run(step int, state map[string]int) map[string]int {
+	out := map[string]int{}
+	for k, v := range state {
+		out[k] = v
+	}
+	out["count"] = step + 1
+	return out
+}
+```
+
+- [ ] **Step 4: Write the HTTP client**
+
+Create `controlplane/worker/client.go` implementing every method in the Interfaces block. Key requirements (write the full file):
+- `ErrStaleLease = errors.New("worker: stale lease (409)")`; any epoch-fenced call that gets HTTP 409 returns it.
+- `RunStarted` POSTs `{"events":[{"type":"run.started"}]}` to `/api/v1/workers/{wid}/runs/{rid}/events` and decodes `RunStartedResponse.lease_epoch`.
+- `NodeCompleted`/`RunCompleted`/`RunFailed` POST the corresponding event with `lease_epoch`.
+- `WriteCheckpoint` POSTs `CheckpointWriteRequest` to `/api/v1/threads/{tid}/checkpoints`.
+- `LatestCheckpoint` GETs `/api/v1/threads/{tid}/checkpoints/latest?run_id={rid}`; 404 → `found=false, err=nil`.
+- Non-2xx (other than the mapped 409/404) → a wrapped error including status + body.
+
+Use the protocol types from `controlplane/endpoints` by importing that package (the types are exported), OR duplicate the small structs in the worker package to avoid the import cycle risk. **Preferred: define a tiny local `protocol.go` in the worker package with the same JSON shapes** (worker must not import the endpoints package's server deps). Add `controlplane/worker/protocol.go` with `workerEvent`, `eventsRequest`, `runStartedResponse`, `checkpointWriteRequest`, `checkpointResponse` mirroring the JSON tags in Task 2.
+
+- [ ] **Step 5: Build, run the tests**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/worker/ -run 'TestClientLifecycleAndCheckpoints|TestCounterExecutor' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/worker/client.go controlplane/worker/executor.go \
+  controlplane/worker/protocol.go controlplane/worker/client_test.go \
+  controlplane/worker/worker_testmain_test.go
+git commit -m "feat(worker): HTTP client (epoch-aware) + 2-step counter executor"
+```
+
+---
+
+## Task 8: Worker runner — NATS consume, ack discipline, durable resume (the reliability proof)
+
+**Files:**
+- Create: `controlplane/worker/runner.go`
+- Test: `controlplane/worker/execution_integration_test.go`
+
+**Interfaces:**
+- Consumes: `Client` + `CounterExecutor` (Task 7); `jetstream.JetStream`; the `graph-executor` consumer; the worker endpoints + run-processor.
+- Produces: `type Runner` with `NewRunner(js jetstream.JetStream, cl *Client, ex CounterExecutor) *Runner` and `func (r *Runner) Start(ctx context.Context) error` (binds the `graph-executor` consumer, processes `worker.graph.execute` with the ack discipline, blocks until ctx cancels). `processOne(ctx, cmd)` is unit-visible for the resume test, returning `(acked bool, err error)`.
+
+- [ ] **Step 1: Write the failing tests (end-to-end + durable resume)**
+
+Create `controlplane/worker/execution_integration_test.go`. It needs: testcontainer Postgres + tenant migrations, embedded NATS (JetStream), an httptest server mounting the worker endpoints, the run-processor running, and a Runner. Provide `TestMain` (or reuse `worker_testmain_test.go`) that stands all of this up and exposes `testPool`, `natsURL`, `serverURL`.
+
+Two tests:
+
+```go
+// TestExecuteRunEndToEnd: create a queued run + publish run.created → run-processor
+// dispatches → Runner consumes → counter graph runs → run completed, 2 checkpoints,
+// 2 execution_history rows.
+func TestExecuteRunEndToEnd(t *testing.T) { /* ... */ }
+
+// TestDurableResume: run node A + checkpoint 1, then simulate worker death BEFORE
+// node B (processOne returns without acking, exits early). Re-deliver the command
+// to a fresh Runner. Assert: node A executed exactly ONCE across both attempts
+// (execution_history has A once), run completes, checkpoints reach version 2.
+func TestDurableResume(t *testing.T) { /* ... */ }
+```
+
+Write both bodies fully. For `TestDurableResume`, drive it deterministically without relying on the 5-minute ack_wait: expose a Runner hook/option `stopAfterNode int` (default -1) so the first Runner executes node A, writes checkpoint 1, then returns from `processOne` WITHOUT acking (simulating death); then construct a second Runner (no stop), have it `processOne` the same command (fetch a redelivery, or re-invoke `processOne` with the same command payload), and assert:
+- `SELECT count(*) FROM execution_history WHERE run_id=$rid AND node_id='A'` == 1 (A ran once — resume skipped it),
+- final run status `completed`,
+- `SELECT max(version) FROM snapshots WHERE aggregate_id=$rid` == 2,
+- the dead worker's `lease_epoch` writes (if any replayed) return `ErrStaleLease`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./controlplane/worker/ -run 'TestExecuteRunEndToEnd|TestDurableResume' -v`
+Expected: FAIL — `undefined: worker.NewRunner`.
+
+- [ ] **Step 3: Write the runner**
+
+Create `controlplane/worker/runner.go`. Full implementation with this control flow in `processOne(ctx, cmd)`:
+
+```
+parse cmd → runID, threadID
+epoch, err := client.RunStarted(runID)
+  if ErrStaleLease → run already terminal/owned → return acked=true (ack, nothing to do)
+  if transient err → return acked=false (Nak/redeliver)
+resumeFrom := 0
+if v, _, found, _ := client.LatestCheckpoint(threadID, runID); found { resumeFrom = v } // v = last completed node index (1-based)
+state := loaded-or-empty
+for step := resumeFrom; step < len(nodes); step++ {
+    if r.stopAfterNode >= 0 && step > r.stopAfterNode { return acked=false } // simulate death (no ack)
+    state = executor.Run(step, state)
+    if err := client.WriteCheckpoint(threadID, runID, epoch, step+1, mustJSON(state)); err != nil {
+        if ErrStaleLease { return acked=true }  // superseded → stop, ack
+        return acked=false                        // transient → redeliver
+    }
+    if err := client.NodeCompleted(runID, epoch, nodes[step], "tool"); err != nil {
+        if ErrStaleLease { return acked=true }
+        return acked=false
+    }
+}
+if err := client.RunCompleted(runID, epoch); err != nil {
+    if ErrStaleLease { return acked=true }
+    return acked=false
+}
+return acked=true
+```
+
+- `Start` binds the `graph-executor` durable consumer (`js.Consumer(ctx, "WORKER_COMMANDS", "graph-executor")`), and for each message: `msg.InProgress()` before work, then `acked, err := processOne(...)`; `if acked { msg.Ack() } else { msg.Nak() }`. A deterministic graph error (not implemented for the counter, but wire the branch) → `RunFailed` then `acked=true`.
+- `resumeFrom` uses the checkpoint version as the count of completed nodes: version `v` means nodes `0..v-1` are done, so resume at step `v`. This is what makes A run exactly once on redelivery.
+
+- [ ] **Step 4: Build, run the tests**
+
+Run: `go build ./... && go vet ./controlplane/...`
+Run: `go test ./controlplane/worker/ -run 'TestExecuteRunEndToEnd|TestDurableResume' -v`
+Expected: PASS — including the durable-resume proof (node A once, run completed, checkpoint v2).
+
+- [ ] **Step 5: Full regression**
+
+Run: `go test ./controlplane/...`
+Expected: PASS across endpoints, nats, worker, server.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/worker/runner.go controlplane/worker/execution_integration_test.go
+git commit -m "feat(worker): runner — NATS consume, ack discipline, durable checkpoint resume"
+```
+
+---
+
+## Task 9: cmd/worker binary + server wiring for run-processor
+
+**Files:**
+- Create: `cmd/worker/main.go`
+- Modify: `controlplane/server/server.go` (start the run-processor when NATS is enabled)
+- Test: `controlplane/server/server_integration_test.go` (assert run-processor wired) + a build check for cmd/worker
+
+**Interfaces:**
+- Consumes: `worker.NewRunner`, `worker.NewClient`, `worker.CounterExecutor`, `nats.Connect`, `nats.NewRunProcessor`, `server.Config`.
+- Produces: a runnable `cmd/worker` binary reading env (`DURAGRAPH_API_URL`, `NATS_URL`, `WORKER_ID` optional → random, `WORKER_GRAPHS=counter`); the server starts the `run-processor` alongside the relay when `cfg.NATSURL != "" && cfg.Relays`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `controlplane/server/server_integration_test.go` a test asserting that when the server is constructed with NATS enabled, a run.created flows to a worker.graph.execute command (i.e., the run-processor goroutine is actually started by the server). If the existing server test already stands up NATS, extend it; otherwise add `TestServerStartsRunProcessor` that: builds the server with `NATSURL` set + `Relays: true`, publishes a `run.created`, and asserts a `worker.graph.execute` appears on `WORKER_COMMANDS` within 5s.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./controlplane/server/ -run TestServerStartsRunProcessor -v`
+Expected: FAIL — server does not start a run-processor yet.
+
+- [ ] **Step 3: Wire the run-processor into the server**
+
+In `controlplane/server/server.go`, where the relay + cleanup worker are constructed (inside the `cfg.NATSURL != ""` block), also construct `nats.NewRunProcessor(js, publisher)` and store it on `Server`. In `Run`, when `s.cfg.Relays`, `go func() { s.rpDone <- s.runProcessor.Start(ctx) }()`. In `Shutdown`, call `s.runProcessor.Stop()` and drain `s.rpDone` like the relay. Add the `runProcessor *nats.RunProcessor` and `rpDone chan error` fields.
+
+- [ ] **Step 4: Write cmd/worker**
+
+Create `cmd/worker/main.go`: read env, connect NATS (`nats.Connect`), ensure streams/consumers are present (or assume the server ensured them — call `nats.EnsureConsumers` defensively), build a `worker.Client` (API URL + random/env worker id), `worker.NewRunner(js, client, worker.CounterExecutor{})`, register, start a heartbeat goroutine (ticker ~20s calling `client.Heartbeat`), `runner.Start(ctx)`, and on SIGINT/SIGTERM `client.Deregister` + cancel. Mirror the graceful-shutdown shape in `controlplane/server/server.go`.
+
+- [ ] **Step 5: Build, run the tests**
+
+Run: `go build ./... ` (compiles `cmd/worker`)
+Run: `go test ./controlplane/server/ -run TestServerStartsRunProcessor -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/worker/main.go controlplane/server/server.go controlplane/server/server_integration_test.go
+git commit -m "feat(worker): cmd/worker binary + server wires run-processor consumer"
+```
+
+---
+
+## Task 10: Spec reconcile — endpoint-queries.d2 workers block
+
+**Files:**
+- Modify: `spec/models/d2/endpoint-queries.d2` (spec repo `/home/qwe/platform/duragraph-org/spec`, branch `spec/models-diagrams`)
+
+**Interfaces:** none (spec).
+
+- [ ] **Step 1: Update the workers block to the push model**
+
+In `spec/models/d2/endpoint-queries.d2`, in the `workers_ep` block:
+- Add a note that dispatch is push: `# Dispatch: run.created → run-processor consumer → worker.graph.execute (WORKER_COMMANDS). claim is DEFERRED (pull path).`
+- On the `claim` entry, prepend `[DEFERRED — pull path replaced by push dispatch]` to its label.
+- Rewrite `stream_events` to note it carries run lifecycle too: change its class rows to reflect `run.started` (leases: `status='in_progress', worker_id, lease_epoch+1`; no `runs.lease_expires_at`), `execution.node_*`, and `run.completed`/`run.failed`, all `lease_epoch`-fenced (409 on mismatch).
+- On `write_checkpoint`, note the `(stream_id, version)` upsert + `lease_epoch` fence, and add a `latest_checkpoint` note for the resume lookup (`SELECT ... WHERE aggregate_id=run_id ORDER BY version DESC LIMIT 1`).
+
+- [ ] **Step 2: Optional d2 render check**
+
+Run: `command -v d2 >/dev/null && d2 /home/qwe/platform/duragraph-org/spec/models/d2/endpoint-queries.d2 /tmp/eq.svg && echo "d2 OK" || echo "d2 not installed — skipping"`
+
+- [ ] **Step 3: Commit in the spec repo**
+
+```bash
+git -C /home/qwe/platform/duragraph-org/spec add models/d2/endpoint-queries.d2
+git -C /home/qwe/platform/duragraph-org/spec commit -m "spec(models): worker path is push (run-processor → worker.graph.execute); events endpoint carries run lifecycle; claim deferred"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (design doc → task):
+- Migration 006 snapshots unique → Task 1. ✓
+- Worker protocol types + rows → Task 2. ✓
+- register/heartbeat/deregister → Task 3. ✓
+- events (run lifecycle + node, epoch-fenced) → Task 4. ✓
+- checkpoints (epoch-fenced upsert + read + latest-for-run) → Task 5. ✓
+- run-processor dispatch + max_deliver → Task 6. ✓
+- worker client + counter executor → Task 7. ✓
+- runner ack discipline + durable resume proof → Task 8. ✓
+- cmd/worker + server wiring → Task 9. ✓
+- spec reconcile → Task 10. ✓
+
+**Placeholder scan:** the two `var _ =` lines in Task 3 are explicitly introduced and explicitly removed in Task 4 Step 3 (not a dangling stub). Client method bodies in Task 7 Step 4 are specified by contract + JSON shapes rather than transcribed line-for-line — the interface list gives every signature, endpoint, and status mapping; this is the one place the plan describes rather than transcribes, and it is bounded (a thin HTTP client). Runner control flow (Task 8 Step 3) is given as explicit pseudocode with every branch named.
+
+**Type consistency:** `WorkerEvent.LeaseEpoch`, `RunStartedResponse.LeaseEpoch`, `CheckpointWriteRequest.{RunID,LeaseEpoch,Version,State}` are used identically across Tasks 2/4/5/7. Epoch fencing is atomic (in-SQL `WHERE ... lease_epoch=$epoch`, 0 rows → 409) in Tasks 4 and 5 — no separate read; the server-side `errStaleLease` sentinel (Task 4) is the shared mechanism. `snapshotRow` defined in Task 2, used in Task 5. The worker-side `ErrStaleLease` (Task 7, a distinct client-side sentinel for a 409 response) is consumed by the runner in Task 8. Handler names match `pascal(workers)+pascal(endpoint name)` from the generator (`WorkersStreamEvents`, `WorkersWriteCheckpoint`, `WorkersLatestCheckpoint`).
+
+**Open risks flagged for the implementer:**
+- `SubjectFor("worker.graph.execute")` must map to the `worker_commands` category — Task 6 Step 4 says verify `categoryFor` and extend if needed. Do not assume.
+- Echo route precedence for `/threads/{tid}/checkpoints/latest` vs `/threads/{tid}/checkpoints/{ckpt}` — Task 5 Step 3 notes it; if Echo mis-routes, the `latest` handler still guards on `run_id`.
+- Task 7 test harness (`newPool`, `TestMain`) is shared with Task 8; whichever runs first creates `worker_testmain_test.go`.
+
+---
+
+## Notes for the implementer
+
+- `runs` has NO `lease_expires_at`. If any SQL you write references it on `runs`, that is a bug — fence on `lease_epoch` only.
+- `execution_history.node_type` ∈ {start,end,llm,tool,conditional}; the counter nodes use `tool`. `status` ∈ {started,completed,failed,skipped}.
+- Do not import the `endpoints` package from the `worker` package for anything but is avoided entirely — the worker talks HTTP; protocol structs are duplicated in `controlplane/worker/protocol.go`.
+- Do not push/PR/merge without explicit approval.

--- a/controlplane/docs/superpowers/specs/2026-07-20-worker-execution-path-design.md
+++ b/controlplane/docs/superpowers/specs/2026-07-20-worker-execution-path-design.md
@@ -74,11 +74,11 @@ run-processor consumer (RUNS, filter run.created)
 worker: durable pull consumer (graph-executor, ack_wait=5m, AckExplicit)
   on delivery:
     read latest checkpoint for run_id (snapshots, version DESC)
-    POST events run.started        → lease run (in_progress, worker_id, lease_epoch++)
+    POST events run.started        → re-lease run (in_progress, worker_id, lease_epoch++); returns epoch
     for each node not yet checkpointed:
         execute node
-        POST /threads/{tid}/checkpoints   (snapshot state after node)
-        POST events node_completed         (guarded by lease_epoch)
+        POST /threads/{tid}/checkpoints   (snapshot state after node; epoch-fenced)
+        POST events node_completed         (carries lease_epoch; 409 if stale)
     POST events run.completed        → 200 → msg.Ack()
   failure handling:
     transient (DB/HTTP 5xx, crash, panic) → Nak / no-ack → ack_wait redelivers
@@ -109,26 +109,42 @@ worker: durable pull consumer (graph-executor, ack_wait=5m, AckExplicit)
   requeue its in-flight runs (`UPDATE runs SET status='queued', worker_id=NULL
   WHERE worker_id=$id AND status='in_progress'`). → 204.
 - `POST /workers/{id}/runs/{rid}/events` — the single worker→server state
-  channel. Accepts a batch; each event applies its projection + outbox via
-  `writeTx`, **guarded by `lease_epoch`**:
-  - `run.started`: lease the run — `UPDATE runs SET status='in_progress',
-    worker_id=$id, lease_epoch=lease_epoch+1, started_at=now() WHERE id=$rid AND
-    (status='queued' OR lease_expires_at < now())`; emit `run.started`. Returns
-    the new `lease_epoch` to the worker. If no row updated (already leased by a
-    live worker) → 409.
+  channel. **`run.started` is a discrete call** (it establishes the lease and
+  returns the epoch); `node_*` and terminal events are separate calls (batchable
+  among themselves) that **carry** that epoch. Each event applies its projection +
+  outbox via `writeTx`:
+  - `run.started`: re-lease the run — `UPDATE runs SET status='in_progress',
+    worker_id=$id, lease_epoch=lease_epoch+1, started_at=COALESCE(started_at,now())
+    WHERE id=$rid AND status IN ('queued','in_progress')`; emit `run.started`.
+    Returns the new `lease_epoch`. If the run is already terminal
+    (`completed`/`failed`) no row updates → **409** (worker acks; nothing to do).
+    **There is no `runs.lease_expires_at`** — redelivery itself is the "prior
+    worker presumed dead" signal, and the epoch bump fences the prior worker out.
   - `node_started` / `node_completed`: `INSERT execution_history(...)` + emit
     `execution.node_*`; reject if `body.lease_epoch != runs.lease_epoch` → 409.
-  - `run.completed` / `run.failed`: `UPDATE runs SET status, completed_at`; emit
-    the event; epoch-guarded.
-- `POST /threads/{tid}/checkpoints` (write_checkpoint) → `INSERT snapshots
-  (stream_id, aggregate_type='Run', aggregate_id=run_id, version, state)`. No
-  outbox (checkpoint is infrastructure, not a domain event). `version` = the
-  node index just completed. → 200 `{checkpoint_id}`.
+  - `run.completed` / `run.failed`: `UPDATE runs SET status='completed'|'failed',
+    completed_at=now() WHERE id=$rid AND lease_epoch=$epoch`; emit the event;
+    epoch-guarded (0 rows → 409).
+- `POST /threads/{tid}/checkpoints` (write_checkpoint) — **epoch-fenced** like the
+  events endpoint (`body.lease_epoch` must match `runs.lease_epoch`, else 409, so
+  a dead worker cannot poison resume state). Resolves `stream_id` from the run's
+  stream (`SELECT stream_id FROM event_streams WHERE aggregate_type='Run' AND
+  aggregate_id=$rid` — guaranteed to exist because `run.started` created it via
+  `writeTx`'s EnsureStream; ordering dependency). Then **upsert**
+  `INSERT snapshots(stream_id, aggregate_type='Run', aggregate_id=$rid, version,
+  state) ON CONFLICT (stream_id, version) DO UPDATE SET state=EXCLUDED.state`
+  (requires the new unique constraint, migration `006`). No outbox. `version` =
+  index of the node just completed. → 200 `{checkpoint_id}`.
 - `GET /threads/{tid}/checkpoints/{ckpt}` (read_checkpoint) → `SELECT * FROM
   snapshots WHERE id=$ckpt AND aggregate_id IN (SELECT id FROM runs WHERE
-  thread_id=$tid)`. → 200 `Checkpoint` / 404. (Latest-for-run lookup — `SELECT
-  ... WHERE aggregate_id=$rid ORDER BY version DESC LIMIT 1` — is what the worker
-  uses on resume; exposed as a query variant.)
+  thread_id=$tid)`. → 200 `Checkpoint` / 404. The worker's **resume lookup** is a
+  distinct latest-for-run query (`SELECT ... WHERE aggregate_id=$rid ORDER BY
+  version DESC LIMIT 1`); with the `(stream_id, version)` unique constraint it is
+  unambiguous.
+
+**Migration `006_worker_checkpoint.up.sql`** — `ALTER TABLE snapshots ADD
+CONSTRAINT uq_snapshots_stream_version UNIQUE (stream_id, version)` (forward-only;
+required for checkpoint upsert idempotency under redelivery).
 
 **3. Worker binary** (`cmd/worker/main.go` + `controlplane/worker/` package)
 - `controlplane/worker/` holds: the NATS `graph-executor` pull consumer + ack
@@ -144,14 +160,20 @@ worker: durable pull consumer (graph-executor, ack_wait=5m, AckExplicit)
 
 ### The lease_epoch idempotency mechanic
 
-`runs.lease_epoch` + `lease_expires_at` (migration `005`) are the redelivery
-guard:
-- A fresh or expired-lease `run.started` increments `lease_epoch` and stamps
-  `worker_id`. The worker carries that epoch on every subsequent event/checkpoint.
+`runs.lease_epoch` (migration `003`, a fencing token) is the redelivery guard.
+Note: there is **no** `lease_expires_at` on `runs` — that column exists only on
+`workers`. The run has no timestamp lease; JetStream's `ack_wait` redelivery is
+the sole "prior worker is gone" trigger, and `lease_epoch` is the fence.
+- Every non-terminal `run.started` increments `lease_epoch` and stamps
+  `worker_id`, and returns the new epoch. The worker carries that epoch on every
+  subsequent event **and checkpoint** write.
 - A resurrected or duplicate worker holding a *stale* epoch is rejected (409) on
-  its next write — its lease was superseded.
+  its next write (event or checkpoint) — its lease was superseded.
 - A redelivered command re-leases (epoch++), so the new worker owns the run and
   resumes from the latest checkpoint; the dead worker's late writes bounce.
+- `run.started` on an already-terminal run → 409 (the worker acks; the run is
+  done). This is the redelivery-after-completion case (worker died between the DB
+  write and the ack).
 
 ## Spec-first change (precedes implementation)
 
@@ -203,6 +225,9 @@ Green tests are the done-criteria; test 3 is the one that proves the whole point
 
 ## Files (anticipated)
 
+- `controlplane/db/migrations/tenant/006_worker_checkpoint.up.sql` /
+  `.down.sql` — `UNIQUE (stream_id, version)` on `snapshots` (checkpoint upsert
+  idempotency).
 - `controlplane/gen/endpoints.yaml` — mark workers endpoints `custom`; scope to the
   6 in this cycle.
 - `controlplane/endpoints/workers.go` — hand-written handlers (custom).
@@ -225,3 +250,10 @@ Green tests are the done-criteria; test 3 is the one that proves the whole point
 counter; `llm`/`tool` worker command families; interrupts/HITL; SDK extraction;
 worker `commands` (drain/shutdown/update_config) beyond an empty list;
 multi-worker load/fairness.
+
+**Threaded runs only this slice.** `runs.thread_id` is nullable (stateless runs
+are valid), but the checkpoint endpoints are thread-scoped
+(`POST /threads/{tid}/checkpoints`), so a stateless run cannot checkpoint through
+them. The counter-graph test uses a threaded run. Checkpointing stateless runs
+(a run-scoped checkpoint path, or synthesizing a thread) is deferred and recorded
+here so it is not silently assumed to work.

--- a/controlplane/docs/superpowers/specs/2026-07-20-worker-execution-path-design.md
+++ b/controlplane/docs/superpowers/specs/2026-07-20-worker-execution-path-design.md
@@ -1,0 +1,227 @@
+# Worker execution path — thin vertical slice (with durable checkpoints)
+
+**Date:** 2026-07-20
+**Branch:** `feat/controlplane-worker-execution`
+**Status:** approved design, pending implementation plan
+
+## Context
+
+The control-plane rebuild (`controlplane/`) builds bottom-up from the **structural**
+d2 diagrams in `spec/models/d2/`. Layers 1–4 and endpoint groups
+assistants/threads/runs/crons/store/system are merged. This design covers the
+**worker execution path**: the mechanism that turns a queued run into an executed
+one.
+
+### Source-of-truth discipline (important)
+
+The rebuild builds ONLY from the **structural** d2 set:
+`workers.d2`, `nats.d2`, `endpoint-queries.d2` (workers block), `postgres.d2`
+(migrations `001` snapshots + `005` workers). The **`code-*.d2` files are
+excluded** — their headers declare `internal/application/*`, i.e. they document
+the *old* `internal/` DDD architecture (`WorkerService`, `TaskRepository`,
+`ClaimTask`/`CompleteTask`, DDD aggregates) that the rebuild replaces. Reaching
+for that model is how the rebuild drifts back into the bloat it exists to remove.
+Where the structural d2 leaves a gap, we fill it with a spec-first decision, not
+by importing the stale model.
+
+### Scope of this cycle: A + B + C-thin, **with checkpoints**
+
+- **A. Worker HTTP endpoints** — register, heartbeat, deregister, events,
+  write_checkpoint, read_checkpoint (6 of the 7 workers-block endpoints).
+- **B. Dispatch** — the `run-processor` NATS consumer.
+- **C. Worker binary (thin)** — `cmd/worker` running a **2-step counter graph**
+  with durable checkpoint-based resume.
+
+**Deferred (out of scope), recorded so nothing is silently dropped:**
+- `claim` endpoint — the pull path; replaced by push dispatch (below).
+- Runs SSE / `wait` / `stream` endpoints — pass D.
+- A real graph engine (beyond the 2-step counter), interrupts/HITL, the SDK
+  extraction, multi-graph routing (`llm`/`tool` worker command families).
+
+### Dispatch model: push, not poll
+
+Decision: **push via NATS commands**, not worker polling. Polling cannot tell you
+where a worker got disconnected; a JetStream durable consumer with explicit ack
+can — an un-acked message *is* the durable record of in-flight work, and
+`ack_wait` expiry redelivers it to a healthy worker. This is the reliability
+spine. It aligns with `nats.d2` (`WORKER_COMMANDS` stream, `worker.graph.execute`,
+`graph-executor` consumer with `ack_wait=5m`, `AckExplicit`) and against the pull
+`claim` path in `endpoint-queries.d2` (which is why `claim` is deferred).
+
+### Reliability rests on two legs — ack AND checkpoints
+
+1. **Ack/redelivery** answers *"run it again, somewhere healthy"* when a worker
+   dies.
+2. **Checkpoints** answer *"continue where it died"* instead of restarting from
+   zero. Without them, redelivery re-runs every LLM call and re-fires every tool
+   side effect — the exact unreliability push mode exists to avoid. The d2 makes
+   dispatch checkpoint-aware: `claim` returns `checkpoint_id` *"(null if fresh,
+   set if resuming)"* and `write_checkpoint`/`read_checkpoint` persist/read the
+   `snapshots` table.
+
+A single-node echo graph cannot exercise resume (no intermediate state), so the
+thin graph is **2 steps** (node A → checkpoint → node B). That is the smallest
+graph that proves durable execution.
+
+## Architecture
+
+### Flow
+
+```
+client → POST /runs → run.created (event + outbox) → RUNS stream
+run-processor consumer (RUNS, filter run.created)
+    → publish worker.graph.execute → WORKER_COMMANDS   [Nats-Msg-Id = run_id]
+worker: durable pull consumer (graph-executor, ack_wait=5m, AckExplicit)
+  on delivery:
+    read latest checkpoint for run_id (snapshots, version DESC)
+    POST events run.started        → lease run (in_progress, worker_id, lease_epoch++)
+    for each node not yet checkpointed:
+        execute node
+        POST /threads/{tid}/checkpoints   (snapshot state after node)
+        POST events node_completed         (guarded by lease_epoch)
+    POST events run.completed        → 200 → msg.Ack()
+  failure handling:
+    transient (DB/HTTP 5xx, crash, panic) → Nak / no-ack → ack_wait redelivers
+    deterministic graph error            → POST run.failed → Ack (no redelivery)
+    max_deliver exceeded                 → dead-letter → run.failed
+  msg.InProgress() heartbeats during execution (extend ack deadline past ack_wait)
+```
+
+### Components
+
+**1. `run-processor` consumer** (`controlplane/nats` + wired in `controlplane/server`)
+- Durable pull consumer on `RUNS`, filter `duragraph.runs.run.created`.
+- On a queued run: publish `worker.graph.execute` to `WORKER_COMMANDS` with
+  `Nats-Msg-Id = run_id` (JetStream dedup) and a payload of
+  `{run_id, thread_id, assistant_id, graph_id, input}`.
+- Thin dispatcher only — it does NOT mutate run state (the worker leases via
+  `run.started`). Acks after successful publish.
+
+**2. Worker HTTP endpoints** (`controlplane/endpoints/workers.go`, generator
+`custom` flag; hand-defined request/response types from the d2)
+- `POST /workers/register` → `INSERT workers(worker_id, graphs, capacity,
+  status='online', lease_expires_at)`, upsert `graphs`. → 200 `WorkerRegistered`.
+- `POST /workers/{id}/heartbeat` → `UPDATE workers SET status, active_runs,
+  lease_expires_at=now()+60s WHERE worker_id=$id AND lease_expires_at > now()`.
+  → 200 `{commands: []}` (drain/shutdown/update_config when present; empty for
+  the slice).
+- `POST /workers/{id}/deregister` → `UPDATE workers SET status='offline'` +
+  requeue its in-flight runs (`UPDATE runs SET status='queued', worker_id=NULL
+  WHERE worker_id=$id AND status='in_progress'`). → 204.
+- `POST /workers/{id}/runs/{rid}/events` — the single worker→server state
+  channel. Accepts a batch; each event applies its projection + outbox via
+  `writeTx`, **guarded by `lease_epoch`**:
+  - `run.started`: lease the run — `UPDATE runs SET status='in_progress',
+    worker_id=$id, lease_epoch=lease_epoch+1, started_at=now() WHERE id=$rid AND
+    (status='queued' OR lease_expires_at < now())`; emit `run.started`. Returns
+    the new `lease_epoch` to the worker. If no row updated (already leased by a
+    live worker) → 409.
+  - `node_started` / `node_completed`: `INSERT execution_history(...)` + emit
+    `execution.node_*`; reject if `body.lease_epoch != runs.lease_epoch` → 409.
+  - `run.completed` / `run.failed`: `UPDATE runs SET status, completed_at`; emit
+    the event; epoch-guarded.
+- `POST /threads/{tid}/checkpoints` (write_checkpoint) → `INSERT snapshots
+  (stream_id, aggregate_type='Run', aggregate_id=run_id, version, state)`. No
+  outbox (checkpoint is infrastructure, not a domain event). `version` = the
+  node index just completed. → 200 `{checkpoint_id}`.
+- `GET /threads/{tid}/checkpoints/{ckpt}` (read_checkpoint) → `SELECT * FROM
+  snapshots WHERE id=$ckpt AND aggregate_id IN (SELECT id FROM runs WHERE
+  thread_id=$tid)`. → 200 `Checkpoint` / 404. (Latest-for-run lookup — `SELECT
+  ... WHERE aggregate_id=$rid ORDER BY version DESC LIMIT 1` — is what the worker
+  uses on resume; exposed as a query variant.)
+
+**3. Worker binary** (`cmd/worker/main.go` + `controlplane/worker/` package)
+- `controlplane/worker/` holds: the NATS `graph-executor` pull consumer + ack
+  loop, the HTTP event/checkpoint client (calls the control-plane endpoints), and
+  the **2-step counter executor**.
+- **Counter graph:** state `{count:int}`. Node A: `count=1`. Node B: `count=2`.
+  A checkpoint is written after each node (`version=1` after A, `version=2` after
+  B). `run.completed` output = final state.
+- **Resume:** on delivery, read latest checkpoint for `run_id`. If `version>=1`,
+  skip node A and resume at node B; if none, start fresh. This is what a redeliver
+  after a mid-run crash exercises.
+- Registers on startup; heartbeat goroutine (~20s); deregisters on SIGINT/SIGTERM.
+
+### The lease_epoch idempotency mechanic
+
+`runs.lease_epoch` + `lease_expires_at` (migration `005`) are the redelivery
+guard:
+- A fresh or expired-lease `run.started` increments `lease_epoch` and stamps
+  `worker_id`. The worker carries that epoch on every subsequent event/checkpoint.
+- A resurrected or duplicate worker holding a *stale* epoch is rejected (409) on
+  its next write — its lease was superseded.
+- A redelivered command re-leases (epoch++), so the new worker owns the run and
+  resumes from the latest checkpoint; the dead worker's late writes bounce.
+
+## Spec-first change (precedes implementation)
+
+Reconcile `endpoint-queries.d2`'s workers block to this design (in the spec repo):
+- Replace the `claim` pull path with the push dispatch note (run.created →
+  run-processor → worker.graph.execute), and mark `claim` deferred.
+- Generalize `stream_events` to carry run lifecycle (`run.started` /
+  `run.completed` / `run.failed`) in addition to `execution.node_*`, with the
+  `lease_epoch` guard.
+- Keep `write_checkpoint` / `read_checkpoint` as specified; note the
+  latest-for-run resume lookup.
+
+The worker↔control-plane protocol is **internal and native** (not the public
+LangGraph API), so its Go request/response types are hand-defined **from the d2**
+rather than added to `duragraph-latest.yaml`. Adding an internal worker protocol
+to the public API contract would be wrong; the d2 is its spec.
+
+## Error handling
+
+- Endpoints: `echo.NewHTTPError(status, msg)`; bind failure → 400; `pgx.ErrNoRows`
+  → 404; `lease_epoch` mismatch / already-leased → **409**; unexpected DB error →
+  500.
+- Worker: transient (HTTP 5xx, connection failure, panic) → `Nak`/no-ack →
+  redeliver; deterministic graph error → post `run.failed` then `Ack`;
+  `max_deliver` exceeded → the run is marked `run.failed` (dead-letter).
+
+## Testing
+
+Testcontainers Postgres + **embedded in-process NATS** (per repo convention; no
+build tag, runs in standard CI):
+
+1. **Endpoint unit/integration** — register / heartbeat (lease-valid + expired) /
+   deregister (requeues in-flight) / events happy path / `write_checkpoint` +
+   `read_checkpoint` round-trip / **lease-stale event → 409**.
+2. **End-to-end execution** — create run → `run-processor` publishes command →
+   in-process worker (2-step) consumes → assert final DB state: run `completed`,
+   2 rows in `execution_history`, 2 `snapshots` (version 1 + 2), and the
+   `run.started`/`node_completed`×2/`run.completed` events in `outbox`.
+3. **Durable resume (the reliability proof)** — run node A + write checkpoint 1,
+   then simulate worker death (worker acks nothing, exits before node B) → let
+   `ack_wait` redeliver (or force redelivery) → a second worker reads checkpoint 1
+   and resumes at node B → assert **node A executed exactly once** (via an
+   execution-count / side-effect counter), run reaches `completed`, and the dead
+   worker's stale-epoch write (if any) is rejected 409.
+4. **run-processor dedup** — duplicate `run.created` → single `worker.graph.execute`
+   (Nats-Msg-Id).
+
+Green tests are the done-criteria; test 3 is the one that proves the whole point.
+
+## Files (anticipated)
+
+- `controlplane/gen/endpoints.yaml` — mark workers endpoints `custom`; scope to the
+  6 in this cycle.
+- `controlplane/endpoints/workers.go` — hand-written handlers (custom).
+- `controlplane/endpoints/worker_types.go` — hand-defined worker protocol types.
+- `controlplane/endpoints/rows.go` — `workerRow`, `snapshotRow`, `execHistoryRow`
+  mappers.
+- `controlplane/endpoints/workers_gen.go` — regenerated routes-only.
+- `controlplane/nats/run_processor.go` — the dispatch consumer.
+- `controlplane/worker/` — consumer + ack loop, event/checkpoint HTTP client,
+  counter executor.
+- `cmd/worker/main.go` — binary entrypoint.
+- `controlplane/server/server.go` — wire the run-processor consumer.
+- `controlplane/endpoints/workers_integration_test.go`,
+  `controlplane/worker/execution_integration_test.go` — tests.
+- `spec/models/d2/endpoint-queries.d2` (spec repo) — the reconcile.
+
+## Out of scope (recorded)
+
+`claim` endpoint; runs SSE/`wait`/`stream` (pass D); real graph engine beyond the
+counter; `llm`/`tool` worker command families; interrupts/HITL; SDK extraction;
+worker `commands` (drain/shutdown/update_config) beyond an empty list;
+multi-worker load/fairness.

--- a/controlplane/endpoints/migration006_test.go
+++ b/controlplane/endpoints/migration006_test.go
@@ -1,0 +1,27 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSnapshotsUniqueStreamVersion(t *testing.T) {
+	ctx := context.Background()
+	// A stream to hang snapshots off (FK to event_streams).
+	var streamID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
+		VALUES (gen_random_uuid(), 'Run', gen_random_uuid(), 0)
+		RETURNING stream_id`).Scan(&streamID); err != nil {
+		t.Fatal(err)
+	}
+	ins := `INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+	        VALUES ($1, 'Run', gen_random_uuid(), 1, '{}'::jsonb)`
+	if _, err := testPool.Exec(ctx, ins, streamID); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	// Duplicate (stream_id, version) must be rejected by the constraint.
+	if _, err := testPool.Exec(ctx, ins, streamID); err == nil {
+		t.Fatal("duplicate (stream_id, version) should violate uq_snapshots_stream_version, but insert succeeded")
+	}
+}

--- a/controlplane/endpoints/rows.go
+++ b/controlplane/endpoints/rows.go
@@ -241,6 +241,52 @@ func (r storeItemRow) toAPI() Item {
 	return it
 }
 
+// workerRow mirrors the workers table (postgres.d2 worker_ctx, migration 005).
+type workerRow struct {
+	WorkerID        uuid.UUID  `db:"worker_id"`
+	Graphs          []string   `db:"graphs"`
+	Capacity        int        `db:"capacity"`
+	ActiveRuns      int        `db:"active_runs"`
+	Status          string     `db:"status"`
+	LeaseExpiresAt  *time.Time `db:"lease_expires_at"`
+	LastHeartbeatAt *time.Time `db:"last_heartbeat_at"`
+	CreatedAt       time.Time  `db:"created_at"`
+	UpdatedAt       time.Time  `db:"updated_at"`
+}
+
+func (r workerRow) toAPI() WorkerRegisterResponse {
+	return WorkerRegisterResponse{WorkerID: r.WorkerID, Status: r.Status}
+}
+
+// snapshotRow mirrors the snapshots table (postgres.d2 event_sourcing_ctx).
+type snapshotRow struct {
+	ID          int64     `db:"id"`
+	StreamID    uuid.UUID `db:"stream_id"`
+	AggregateID uuid.UUID `db:"aggregate_id"`
+	Version     int       `db:"version"`
+	State       []byte    `db:"state"` // jsonb
+	CreatedAt   time.Time `db:"created_at"`
+}
+
+func (r snapshotRow) toAPI() CheckpointResponse {
+	return CheckpointResponse{
+		CheckpointID: r.ID,
+		RunID:        r.AggregateID,
+		Version:      r.Version,
+		State:        json.RawMessage(r.State),
+	}
+}
+
+// execHistoryRow mirrors execution_history (postgres.d2 run_ctx). Not returned
+// over the API in this slice; used by tests to assert node execution.
+type execHistoryRow struct {
+	ID       int64     `db:"id"`
+	RunID    uuid.UUID `db:"run_id"`
+	NodeID   string    `db:"node_id"`
+	NodeType string    `db:"node_type"`
+	Status   string    `db:"status"`
+}
+
 // DIVERGENCES (OpenAPI ↔ postgres.d2) — reconcile before tightening mappers:
 //   assistants: API has {config(structured), context, version}; DB has
 //     {tools, model, instructions, config(jsonb)}. version/context not in DB;

--- a/controlplane/endpoints/runtime.go
+++ b/controlplane/endpoints/runtime.go
@@ -163,6 +163,10 @@ func asUUID(v interface{}) uuid.UUID {
 	return uuid.UUID{}
 }
 
+// mustParseUUID parses a UUID string, returning the zero UUID on failure (the
+// caller has already validated the path param, or the DB FK will reject zero).
+func mustParseUUID(s string) uuid.UUID { u, _ := uuid.Parse(s); return u }
+
 // nilIfEmpty returns nil (SQL NULL) for an empty/absent string slice so a
 // `$n::text[] IS NULL OR ...` guard clause matches everything. A non-empty
 // slice is returned as-is for a TEXT[] bind.

--- a/controlplane/endpoints/worker_rows_test.go
+++ b/controlplane/endpoints/worker_rows_test.go
@@ -1,0 +1,30 @@
+package endpoints
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestWorkerRowToAPI(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	r := workerRow{Status: "online", ActiveRuns: 2, Capacity: 4, LeaseExpiresAt: &now}
+	got := r.toAPI()
+	if got.Status != "online" {
+		t.Errorf("status: want online, got %q", got.Status)
+	}
+}
+
+func TestSnapshotRowToAPI(t *testing.T) {
+	r := snapshotRow{ID: 9, AggregateID: mustUUID("11111111-1111-1111-1111-111111111111"), Version: 2, State: []byte(`{"count":2}`)}
+	got := r.toAPI()
+	if got.CheckpointID != 9 || got.Version != 2 {
+		t.Errorf("checkpoint id/version: got %d/%d", got.CheckpointID, got.Version)
+	}
+	if string(got.State) != `{"count":2}` {
+		t.Errorf("state: got %s", got.State)
+	}
+}
+
+func mustUUID(s string) uuid.UUID { u, _ := uuid.Parse(s); return u }

--- a/controlplane/endpoints/worker_types.go
+++ b/controlplane/endpoints/worker_types.go
@@ -1,0 +1,73 @@
+// Hand-defined worker↔control-plane protocol types. This is an internal,
+// native protocol (NOT the public LangGraph API), so its types live here rather
+// than in duragraph-latest.yaml. Source of truth: spec/models/d2 workers block
+// + workers.d2 + the worker-execution design doc.
+package endpoints
+
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+type WorkerRegisterRequest struct {
+	WorkerID uuid.UUID `json:"worker_id"`
+	Graphs   []string  `json:"graphs"`
+	Capacity int       `json:"capacity"`
+}
+
+type WorkerRegisterResponse struct {
+	WorkerID uuid.UUID `json:"worker_id"`
+	Status   string    `json:"status"`
+}
+
+type WorkerHeartbeatRequest struct {
+	Status     string `json:"status"`
+	ActiveRuns int    `json:"active_runs"`
+}
+
+type WorkerHeartbeatResponse struct {
+	Commands []string `json:"commands"`
+}
+
+// WorkerEvent is one worker→server state event. Type is one of:
+// run.started | run.completed | run.failed | execution.node_started |
+// execution.node_completed | execution.node_failed. LeaseEpoch fences all
+// non-start events; run.started ignores it (it establishes the lease).
+type WorkerEvent struct {
+	Type       string          `json:"type"`
+	LeaseEpoch int             `json:"lease_epoch"`
+	NodeID     string          `json:"node_id,omitempty"`
+	NodeType   string          `json:"node_type,omitempty"`
+	NodeStatus string          `json:"node_status,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	Output     json.RawMessage `json:"output,omitempty"`
+	DurationMs *int            `json:"duration_ms,omitempty"`
+	Error      *string         `json:"error,omitempty"`
+}
+
+type WorkerEventsRequest struct {
+	Events []WorkerEvent `json:"events"`
+}
+
+type RunStartedResponse struct {
+	LeaseEpoch int `json:"lease_epoch"`
+}
+
+type CheckpointWriteRequest struct {
+	RunID      uuid.UUID       `json:"run_id"`
+	LeaseEpoch int             `json:"lease_epoch"`
+	Version    int             `json:"version"`
+	State      json.RawMessage `json:"state"`
+}
+
+type CheckpointWriteResponse struct {
+	CheckpointID int64 `json:"checkpoint_id"`
+}
+
+type CheckpointResponse struct {
+	CheckpointID int64           `json:"checkpoint_id"`
+	RunID        uuid.UUID       `json:"run_id"`
+	Version      int             `json:"version"`
+	State        json.RawMessage `json:"state"`
+}

--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -6,6 +6,7 @@
 package endpoints
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -79,5 +80,122 @@ func (s *Server) WorkersDeregister(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-var _ = errors.Is // retained for Tasks 4–5 handlers added to this file
-var _ = pgx.ErrNoRows
+// WorkersStreamEvents is the single worker→server state channel.
+// POST /workers/{id}/runs/{rid}/events. run.started establishes the lease and
+// returns the epoch; all other events are fenced on lease_epoch. Source: design
+// doc "events endpoint". runs has no lease_expires_at — fence on epoch only.
+func (s *Server) WorkersStreamEvents(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid := c.Param("id")
+	rid := c.Param("rid")
+	var req WorkerEventsRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	var startedEpoch *int
+	for _, ev := range req.Events {
+		switch ev.Type {
+		case "run.started":
+			epoch, err := s.leaseRun(ctx, rid, wid)
+			if err != nil {
+				return err // already-typed echo error (409/500)
+			}
+			startedEpoch = &epoch
+		case "run.completed", "run.failed":
+			if err := s.terminalRun(ctx, rid, ev); err != nil {
+				return err
+			}
+		case "execution.node_started", "execution.node_completed", "execution.node_failed":
+			if err := s.nodeEvent(ctx, rid, ev); err != nil {
+				return err
+			}
+		default:
+			return echo.NewHTTPError(http.StatusBadRequest, "unknown event type: "+ev.Type)
+		}
+	}
+	if startedEpoch != nil {
+		return c.JSON(http.StatusOK, RunStartedResponse{LeaseEpoch: *startedEpoch})
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+// leaseRun re-leases a non-terminal run to wid, bumping lease_epoch, and emits
+// run.started. Returns the new epoch. 409 if the run is already terminal.
+func (s *Server) leaseRun(ctx context.Context, rid, wid string) (int, error) {
+	var epoch int
+	err := s.writeTx(ctx, s.Tenant, []Event{{AggregateType: "Run", AggregateID: mustParseUUID(rid), EventType: "run.started"}},
+		func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `
+				UPDATE runs SET status='in_progress', worker_id=$2,
+				  lease_epoch=lease_epoch+1, started_at=COALESCE(started_at, now())
+				WHERE id=$1 AND status IN ('queued','in_progress')
+				RETURNING lease_epoch`, rid, wid).Scan(&epoch)
+		})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, echo.NewHTTPError(http.StatusConflict, "run is terminal or not found")
+		}
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return epoch, nil
+}
+
+// errStaleLease is returned from a projection when the epoch guard rejects the
+// write (0 rows affected). writeTxOrHTTP maps it to 409. Because writeTx appends
+// the event BEFORE the projection runs, returning this rolls the whole tx back —
+// so a stale worker's event is never committed.
+var errStaleLease = errors.New("stale lease_epoch")
+
+// nodeEvent records a node execution row + emits the execution.node_* event.
+// The epoch guard is ATOMIC (conditional INSERT), not a separate read.
+func (s *Server) nodeEvent(ctx context.Context, rid string, ev WorkerEvent) error {
+	return s.writeTxOrHTTP(ctx, rid, ev.Type, ev, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `
+			INSERT INTO execution_history (run_id, node_id, node_type, status, input, output, error, duration_ms, completed_at)
+			SELECT $1,$2,$3,$4::varchar,$5,$6,$7,$8, CASE WHEN $4::varchar <> 'started' THEN now() END
+			WHERE EXISTS (SELECT 1 FROM runs WHERE id=$1 AND lease_epoch=$9)`,
+			rid, ev.NodeID, ev.NodeType, ev.NodeStatus,
+			jsonOrEmpty(ev.Input), jsonOrEmpty(ev.Output), ev.Error, ev.DurationMs, ev.LeaseEpoch)
+		if err != nil {
+			return err
+		}
+		if ct.RowsAffected() == 0 {
+			return errStaleLease
+		}
+		return nil
+	})
+}
+
+// terminalRun marks the run completed/failed + emits the event. Epoch guarded
+// IN the UPDATE (WHERE lease_epoch=$epoch); 0 rows → stale → 409.
+func (s *Server) terminalRun(ctx context.Context, rid string, ev WorkerEvent) error {
+	status := "completed"
+	if ev.Type == "run.failed" {
+		status = "failed"
+	}
+	return s.writeTxOrHTTP(ctx, rid, ev.Type, ev, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx,
+			`UPDATE runs SET status=$2, completed_at=now(), error=$3 WHERE id=$1 AND lease_epoch=$4`,
+			rid, status, ev.Error, ev.LeaseEpoch)
+		if err != nil {
+			return err
+		}
+		if ct.RowsAffected() == 0 {
+			return errStaleLease
+		}
+		return nil
+	})
+}
+
+// writeTxOrHTTP runs a projection inside writeTx (emitting one event) and maps
+// errStaleLease → 409, other errors → 500.
+func (s *Server) writeTxOrHTTP(ctx context.Context, rid, eventType string, ev WorkerEvent, proj func(pgx.Tx) error) error {
+	events := []Event{{AggregateType: "Run", AggregateID: mustParseUUID(rid), EventType: eventType, Payload: mustJSON(ev)}}
+	if err := s.writeTx(ctx, s.Tenant, events, proj); err != nil {
+		if errors.Is(err, errStaleLease) {
+			return echo.NewHTTPError(http.StatusConflict, "stale lease_epoch")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return nil
+}

--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -1,0 +1,83 @@
+// Hand-written worker endpoints (worker↔control-plane protocol). Routes are
+// generated into workers_gen.go (endpoints marked custom in endpoints.yaml);
+// bodies live here. Source of truth: spec/models/d2 workers block + workers.d2
+// + the worker-execution design doc. runs has NO lease_expires_at — fencing is
+// lease_epoch only.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// WorkersRegister upserts a worker as online. POST /workers/register -> 200.
+func (s *Server) WorkersRegister(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req WorkerRegisterRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if _, err := s.Tenant.Exec(ctx, `
+		INSERT INTO workers (worker_id, graphs, capacity, status, lease_expires_at, last_heartbeat_at)
+		VALUES ($1, $2, $3, 'online', now() + interval '60 seconds', now())
+		ON CONFLICT (worker_id) DO UPDATE
+		  SET graphs=EXCLUDED.graphs, capacity=EXCLUDED.capacity, status='online',
+		      lease_expires_at=now() + interval '60 seconds', last_heartbeat_at=now()`,
+		req.WorkerID, req.Graphs, req.Capacity); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, WorkerRegisterResponse{WorkerID: req.WorkerID, Status: "online"})
+}
+
+// WorkersHeartbeat renews the worker lease. POST /workers/{id}/heartbeat -> 200.
+func (s *Server) WorkersHeartbeat(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid := c.Param("id")
+	var req WorkerHeartbeatRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	ct, err := s.Tenant.Exec(ctx, `
+		UPDATE workers SET status=$2, active_runs=$3,
+		  lease_expires_at=now() + interval '60 seconds', last_heartbeat_at=now()
+		WHERE worker_id=$1 AND lease_expires_at > now()`,
+		wid, req.Status, req.ActiveRuns)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if ct.RowsAffected() == 0 {
+		// Unknown worker or expired lease — worker must re-register.
+		return echo.NewHTTPError(http.StatusConflict, "worker lease expired or unknown; re-register")
+	}
+	return c.JSON(http.StatusOK, WorkerHeartbeatResponse{Commands: []string{}})
+}
+
+// WorkersDeregister marks the worker offline and requeues its in-flight runs.
+// POST /workers/{id}/deregister -> 204.
+func (s *Server) WorkersDeregister(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid := c.Param("id")
+	tx, err := s.Tenant.Begin(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	if _, err := tx.Exec(ctx, `UPDATE workers SET status='offline' WHERE worker_id=$1`, wid); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE runs SET status='queued', worker_id=NULL
+		WHERE worker_id=$1 AND status='in_progress'`, wid); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+var _ = errors.Is // retained for Tasks 4–5 handlers added to this file
+var _ = pgx.ErrNoRows

--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -199,3 +199,87 @@ func (s *Server) writeTxOrHTTP(ctx context.Context, rid, eventType string, ev Wo
 	}
 	return nil
 }
+
+// WorkersWriteCheckpoint upserts a run snapshot, epoch-fenced.
+// POST /threads/{tid}/checkpoints -> 200 {checkpoint_id}.
+func (s *Server) WorkersWriteCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req CheckpointWriteRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	rid := req.RunID.String()
+	// Resolve the run's event stream (created by run.started's writeTx).
+	var streamID string
+	if err := s.Tenant.QueryRow(ctx,
+		`SELECT stream_id FROM event_streams WHERE aggregate_type='Run' AND aggregate_id=$1`, rid).Scan(&streamID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusConflict, "run stream not initialized (post run.started first)")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	// Atomic epoch guard: the INSERT..SELECT only fires when the run's current
+	// lease_epoch matches; a stale worker inserts nothing → 0 rows → 409.
+	var id int64
+	err := s.Tenant.QueryRow(ctx, `
+		INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+		SELECT $1, 'Run', $2, $3, $4
+		WHERE EXISTS (SELECT 1 FROM runs WHERE id=$2 AND lease_epoch=$5)
+		ON CONFLICT (stream_id, version) DO UPDATE SET state=EXCLUDED.state
+		RETURNING id`,
+		streamID, rid, req.Version, jsonOrEmpty(req.State), req.LeaseEpoch).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusConflict, "stale lease_epoch")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, CheckpointWriteResponse{CheckpointID: id})
+}
+
+// WorkersReadCheckpoint returns one snapshot by id, scoped to the thread's runs.
+// GET /threads/{tid}/checkpoints/{ckpt} -> 200 / 404.
+func (s *Server) WorkersReadCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	tid := c.Param("tid")
+	ckpt := c.Param("ckpt")
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots
+		WHERE id=$1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id=$2)`, ckpt, tid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toAPI())
+}
+
+// WorkersLatestCheckpoint returns the highest-version snapshot for a run, for
+// worker resume. GET /threads/{tid}/checkpoints/latest?run_id=... -> 200 / 404.
+func (s *Server) WorkersLatestCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	rid := c.QueryParam("run_id")
+	if rid == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "run_id is required")
+	}
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots WHERE aggregate_id=$1 ORDER BY version DESC LIMIT 1`, rid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "no checkpoint")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toAPI())
+}

--- a/controlplane/endpoints/workers_gen.go
+++ b/controlplane/endpoints/workers_gen.go
@@ -61,38 +61,7 @@ func (s *Server) WorkersClaim(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
 }
 
-// WorkersStreamEvents — POST /workers/{id}/runs/{rid}/events  (kind: write)
-//   - Validate worker_id owns run_id, lease not expired
-//   - INSERT execution_history per node event (node_id, node_type, status, input, output, duration_ms)
-//   - INSERT events: execution.node_started / node_completed / node_failed
-//   - INSERT outbox (same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) WorkersStreamEvents(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (WorkersStreamEvents request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "Run", AggregateID: aggID, EventType: "execution.node_started"},
-		{AggregateType: "Run", AggregateID: aggID, EventType: "execution.node_completed"},
-		{AggregateType: "Run", AggregateID: aggID, EventType: "execution.node_failed"},
-	}
-	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   Validate worker_id owns run_id, lease not expired
-		//   INSERT execution_history per node event (node_id, node_type, status, input, output, duration_ms)
-		//   INSERT events: execution.node_started / node_completed / node_failed
-		//   INSERT outbox (same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// WorkersStreamEvents — POST /workers/{id}/runs/{rid}/events  (kind: write) — hand-written in workers.go
 
 // WorkersWriteCheckpoint — POST /threads/{tid}/checkpoints  (kind: write)
 //   - INSERT snapshots (stream_id, aggregate_type='Run', aggregate_id=run_id, version, state=channel_values)

--- a/controlplane/endpoints/workers_gen.go
+++ b/controlplane/endpoints/workers_gen.go
@@ -20,6 +20,7 @@ func (s *Server) RegisterWorkers(g *echo.Group) {
 	g.POST("/workers/:id/runs/:rid/events", s.WorkersStreamEvents)
 	g.POST("/threads/:tid/checkpoints", s.WorkersWriteCheckpoint)
 	g.GET("/threads/:tid/checkpoints/:ckpt", s.WorkersReadCheckpoint)
+	g.GET("/threads/:tid/checkpoints/latest", s.WorkersLatestCheckpoint)
 }
 
 // WorkersRegister — POST /workers/register  (kind: write) — hand-written in workers.go
@@ -63,28 +64,8 @@ func (s *Server) WorkersClaim(c echo.Context) error {
 
 // WorkersStreamEvents — POST /workers/{id}/runs/{rid}/events  (kind: write) — hand-written in workers.go
 
-// WorkersWriteCheckpoint — POST /threads/{tid}/checkpoints  (kind: write)
-//   - INSERT snapshots (stream_id, aggregate_type='Run', aggregate_id=run_id, version, state=channel_values)
-//   - Metadata: parent_checkpoint_id, node, channel_versions, pending_sends
-func (s *Server) WorkersWriteCheckpoint(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (WorkersWriteCheckpoint request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	// projection-only write (not event-sourced — no outbox):
-	//   INSERT snapshots (stream_id, aggregate_type='Run', aggregate_id=run_id, version, state=channel_values)
-	//   Metadata: parent_checkpoint_id, node, channel_versions, pending_sends
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// WorkersWriteCheckpoint — POST /threads/{tid}/checkpoints  (kind: write) — hand-written in workers.go
 
-// WorkersReadCheckpoint — GET /threads/{tid}/checkpoints/{ckpt}  (kind: read)
-//   - SELECT * FROM snapshots WHERE id = :ckpt AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = :tid)
-func (s *Server) WorkersReadCheckpoint(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   SELECT * FROM snapshots WHERE id = :ckpt AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = :tid)
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// WorkersReadCheckpoint — GET /threads/{tid}/checkpoints/{ckpt}  (kind: read) — hand-written in workers.go
+
+// WorkersLatestCheckpoint — GET /threads/{tid}/checkpoints/latest  (kind: read) — hand-written in workers.go

--- a/controlplane/endpoints/workers_gen.go
+++ b/controlplane/endpoints/workers_gen.go
@@ -22,51 +22,11 @@ func (s *Server) RegisterWorkers(g *echo.Group) {
 	g.GET("/threads/:tid/checkpoints/:ckpt", s.WorkersReadCheckpoint)
 }
 
-// WorkersRegister — POST /workers/register  (kind: write)
-//   - INSERT workers (worker_id, graphs, capacity, status='online', lease_expires_at)
-//   - FOR EACH graph: INSERT INTO graphs ON CONFLICT DO NOTHING
-func (s *Server) WorkersRegister(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (WorkersRegister request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	// projection-only write (not event-sourced — no outbox):
-	//   INSERT workers (worker_id, graphs, capacity, status='online', lease_expires_at)
-	//   FOR EACH graph: INSERT INTO graphs ON CONFLICT DO NOTHING
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// WorkersRegister — POST /workers/register  (kind: write) — hand-written in workers.go
 
-// WorkersHeartbeat — POST /workers/{id}/heartbeat  (kind: write)
-//   - UPDATE workers SET status=:status, lease_expires_at=now()+60s, active_runs=:n WHERE id=:id AND lease_expires_at > now()
-func (s *Server) WorkersHeartbeat(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (WorkersHeartbeat request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	// projection-only write (not event-sourced — no outbox):
-	//   UPDATE workers SET status=:status, lease_expires_at=now()+60s, active_runs=:n WHERE id=:id AND lease_expires_at > now()
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// WorkersHeartbeat — POST /workers/{id}/heartbeat  (kind: write) — hand-written in workers.go
 
-// WorkersDeregister — POST /workers/{id}/deregister  (kind: write)
-//   - UPDATE workers SET status='offline' WHERE id = :id
-//   - UPDATE runs SET status='queued' WHERE worker_id=:id AND status='in_progress' (requeue)
-func (s *Server) WorkersDeregister(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (WorkersDeregister request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	// projection-only write (not event-sourced — no outbox):
-	//   UPDATE workers SET status='offline' WHERE id = :id
-	//   UPDATE runs SET status='queued' WHERE worker_id=:id AND status='in_progress' (requeue)
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// WorkersDeregister — POST /workers/{id}/deregister  (kind: write) — hand-written in workers.go
 
 // WorkersClaim — POST /workers/{id}/runs/claim  (kind: write)
 //   - SELECT runs WHERE status='queued' AND graph_id IN (worker graphs) ORDER BY priority DESC, created_at FOR UPDATE SKIP LOCKED LIMIT :max_runs

--- a/controlplane/endpoints/workers_integration_test.go
+++ b/controlplane/endpoints/workers_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -159,5 +160,82 @@ func TestWorkerEventsLifecycle(t *testing.T) {
 	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1`, rid).Scan(&oc)
 	if oc < 3 {
 		t.Errorf("outbox events: want >=3, got %d", oc)
+	}
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+func itoa64(n int64) string { return strconv.FormatInt(n, 10) }
+
+func TestWorkerCheckpoints(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE workers, runs, snapshots, events, outbox, event_streams, assistants, threads CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithWorkers()
+	wid := uuid.NewString()
+	var tid, aid, rid string
+	_ = testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'queued') RETURNING id`, tid, aid).Scan(&rid)
+	// runs.worker_id FKs workers(worker_id) (migration 005) — in the real
+	// protocol the worker already exists via /workers/register before it ever
+	// calls the events endpoint, so seed it directly here (see TestWorkerEventsLifecycle).
+	_, _ = testPool.Exec(ctx, `INSERT INTO workers (worker_id) VALUES ($1)`, wid)
+
+	// lease the run first (creates the event_stream that snapshots FK-references)
+	started := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/runs/"+rid+"/events", `{"events":[{"type":"run.started"}]}`)
+	var rs RunStartedResponse
+	_ = json.Unmarshal(started.Body.Bytes(), &rs)
+
+	cp := "/api/v1/threads/" + tid + "/checkpoints"
+	body := func(v int, st string) string {
+		return `{"run_id":"` + rid + `","lease_epoch":` + itoa(rs.LeaseEpoch) + `,"version":` + itoa(v) + `,"state":` + st + `}`
+	}
+
+	// write checkpoint v1
+	if rec := doJSON(t, e, http.MethodPost, cp, body(1, `{"count":1}`)); rec.Code != http.StatusOK {
+		t.Fatalf("write v1: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// upsert v1 (same version) is idempotent -> still 200, still one row
+	if rec := doJSON(t, e, http.MethodPost, cp, body(1, `{"count":1}`)); rec.Code != http.StatusOK {
+		t.Fatalf("upsert v1: want 200, got %d", rec.Code)
+	}
+	var cnt int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM snapshots WHERE aggregate_id=$1`, rid).Scan(&cnt)
+	if cnt != 1 {
+		t.Errorf("after upsert: want 1 snapshot, got %d", cnt)
+	}
+	// write v2
+	v2rec := doJSON(t, e, http.MethodPost, cp, body(2, `{"count":2}`))
+	var v2resp CheckpointWriteResponse
+	_ = json.Unmarshal(v2rec.Body.Bytes(), &v2resp)
+
+	// read v2 by id -> proves /checkpoints/{ckpt} (param route) still resolves
+	// correctly now that /checkpoints/latest (static route) is also registered.
+	readRec := doJSON(t, e, http.MethodGet, cp+"/"+itoa64(v2resp.CheckpointID), "")
+	if readRec.Code != http.StatusOK {
+		t.Fatalf("read by id: want 200, got %d: %s", readRec.Code, readRec.Body.String())
+	}
+	var readGot CheckpointResponse
+	_ = json.Unmarshal(readRec.Body.Bytes(), &readGot)
+	if readGot.Version != 2 {
+		t.Errorf("read by id version: want 2, got %d", readGot.Version)
+	}
+
+	// stale epoch -> 409
+	if rec := doJSON(t, e, http.MethodPost, cp, `{"run_id":"`+rid+`","lease_epoch":999,"version":3,"state":{}}`); rec.Code != http.StatusConflict {
+		t.Errorf("stale checkpoint: want 409, got %d", rec.Code)
+	}
+
+	// resume lookup: latest checkpoint for run -> version 2
+	rec := doJSON(t, e, http.MethodGet, cp+"/latest?run_id="+rid, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("latest: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got CheckpointResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.Version != 2 {
+		t.Errorf("latest version: want 2, got %d", got.Version)
 	}
 }

--- a/controlplane/endpoints/workers_integration_test.go
+++ b/controlplane/endpoints/workers_integration_test.go
@@ -1,0 +1,85 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+func newTestServerWithWorkers() *echo.Echo {
+	e := echo.New()
+	s := &Server{Tenant: testPool}
+	g := e.Group("/api/v1")
+	s.RegisterWorkers(g)
+	return e
+}
+
+func TestWorkerLifecycle(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE workers, runs, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithWorkers()
+	wid := uuid.NewString()
+
+	// register
+	if rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/register",
+		`{"worker_id":"`+wid+`","graphs":["counter"],"capacity":4}`); rec.Code != http.StatusOK {
+		t.Fatalf("register: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var w struct {
+		Status   string `json:"status"`
+		Capacity int    `json:"capacity"`
+	}
+	if err := testPool.QueryRow(ctx, `SELECT status, capacity FROM workers WHERE worker_id=$1`, wid).Scan(&w.Status, &w.Capacity); err != nil {
+		t.Fatal(err)
+	}
+	if w.Status != "online" || w.Capacity != 4 {
+		t.Errorf("registered worker: got status=%s capacity=%d", w.Status, w.Capacity)
+	}
+
+	// heartbeat (lease valid)
+	rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/heartbeat", `{"status":"online","active_runs":1}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var hb WorkerHeartbeatResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &hb)
+	if hb.Commands == nil {
+		t.Error("heartbeat: commands should be non-nil (empty slice)")
+	}
+
+	// deregister requeues in-flight runs
+	rid := seedInProgressRun(t, ctx, wid) // helper below
+	if rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/deregister", `{}`); rec.Code != http.StatusNoContent {
+		t.Fatalf("deregister: want 204, got %d", rec.Code)
+	}
+	var status string
+	var workerID *string
+	if err := testPool.QueryRow(ctx, `SELECT status, worker_id::text FROM runs WHERE id=$1`, rid).Scan(&status, &workerID); err != nil {
+		t.Fatal(err)
+	}
+	if status != "queued" || workerID != nil {
+		t.Errorf("deregister requeue: want queued/null worker, got %s/%v", status, workerID)
+	}
+}
+
+// seedInProgressRun inserts an assistant + an in_progress run held by wid.
+func seedInProgressRun(t *testing.T, ctx context.Context, wid string) string {
+	t.Helper()
+	var aid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	var rid string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO runs (assistant_id, status, worker_id) VALUES ($1, 'in_progress', $2) RETURNING id`,
+		aid, wid).Scan(&rid); err != nil {
+		t.Fatal(err)
+	}
+	return rid
+}

--- a/controlplane/endpoints/workers_integration_test.go
+++ b/controlplane/endpoints/workers_integration_test.go
@@ -83,3 +83,81 @@ func seedInProgressRun(t *testing.T, ctx context.Context, wid string) string {
 	}
 	return rid
 }
+
+func TestWorkerEventsLifecycle(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE workers, runs, execution_history, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithWorkers()
+	wid := uuid.NewString()
+	var aid, rid string
+	// The events endpoint's run.started sets runs.worker_id, which FKs to
+	// workers(worker_id) (migration 005) — in the real protocol the worker
+	// already exists via /workers/register before it ever calls this
+	// endpoint, so seed that row directly here.
+	_, _ = testPool.Exec(ctx, `INSERT INTO workers (worker_id) VALUES ($1)`, wid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid)
+	_ = testPool.QueryRow(ctx, `INSERT INTO runs (assistant_id, status) VALUES ($1,'queued') RETURNING id`, aid).Scan(&rid)
+
+	base := "/api/v1/workers/" + wid + "/runs/" + rid + "/events"
+
+	// run.started leases the run and returns epoch 1
+	rec := doJSON(t, e, http.MethodPost, base, `{"events":[{"type":"run.started"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.started: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var rs RunStartedResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &rs)
+	if rs.LeaseEpoch != 1 {
+		t.Fatalf("run.started epoch: want 1, got %d", rs.LeaseEpoch)
+	}
+	var st string
+	var le int
+	_ = testPool.QueryRow(ctx, `SELECT status, lease_epoch FROM runs WHERE id=$1`, rid).Scan(&st, &le)
+	if st != "in_progress" || le != 1 {
+		t.Errorf("after start: want in_progress/epoch1, got %s/%d", st, le)
+	}
+
+	// node_completed with correct epoch -> execution_history row + 200
+	rec = doJSON(t, e, http.MethodPost, base,
+		`{"events":[{"type":"execution.node_completed","lease_epoch":1,"node_id":"A","node_type":"tool","node_status":"completed"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("node event: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var n int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM execution_history WHERE run_id=$1`, rid).Scan(&n)
+	if n != 1 {
+		t.Errorf("execution_history: want 1, got %d", n)
+	}
+
+	// stale epoch -> 409
+	rec = doJSON(t, e, http.MethodPost, base,
+		`{"events":[{"type":"execution.node_completed","lease_epoch":0,"node_id":"A","node_type":"tool","node_status":"completed"}]}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("stale epoch: want 409, got %d", rec.Code)
+	}
+
+	// run.completed -> completed
+	rec = doJSON(t, e, http.MethodPost, base, `{"events":[{"type":"run.completed","lease_epoch":1}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("run.completed: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	_ = testPool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&st)
+	if st != "completed" {
+		t.Errorf("after complete: want completed, got %s", st)
+	}
+
+	// run.started on a terminal run -> 409
+	rec = doJSON(t, e, http.MethodPost, base, `{"events":[{"type":"run.started"}]}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("start on terminal: want 409, got %d", rec.Code)
+	}
+
+	// outbox carries run.started + node_completed + run.completed
+	var oc int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1`, rid).Scan(&oc)
+	if oc < 3 {
+		t.Errorf("outbox events: want >=3, got %d", oc)
+	}
+}

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -659,6 +659,7 @@ groups:
         steps:
           - "INSERT workers (worker_id, graphs, capacity, status='online', lease_expires_at)"
           - "FOR EACH graph: INSERT INTO graphs ON CONFLICT DO NOTHING"
+        custom: true
       - name: heartbeat
         method: POST
         path: /workers/{id}/heartbeat
@@ -666,6 +667,7 @@ groups:
         outbox: false
         returns: "commands: drain | shutdown | update_config (if pending)"
         steps: ["UPDATE workers SET status=:status, lease_expires_at=now()+60s, active_runs=:n WHERE id=:id AND lease_expires_at > now()"]
+        custom: true
       - name: deregister
         method: POST
         path: /workers/{id}/deregister
@@ -674,6 +676,7 @@ groups:
         steps:
           - "UPDATE workers SET status='offline' WHERE id = :id"
           - "UPDATE runs SET status='queued' WHERE worker_id=:id AND status='in_progress' (requeue)"
+        custom: true
       - name: claim
         method: POST
         path: /workers/{id}/runs/claim

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -705,6 +705,7 @@ groups:
           - "INSERT events: execution.node_started / node_completed / node_failed"
           - "INSERT outbox (same TX)"
           - "pg_notify('outbox_new','')"
+        custom: true
       - name: write_checkpoint
         method: POST
         path: /threads/{tid}/checkpoints

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -714,6 +714,7 @@ groups:
         steps:
           - "INSERT snapshots (stream_id, aggregate_type='Run', aggregate_id=run_id, version, state=channel_values)"
           - "Metadata: parent_checkpoint_id, node, channel_versions, pending_sends"
+        custom: true
       - name: read_checkpoint
         method: GET
         path: /threads/{tid}/checkpoints/{ckpt}
@@ -721,6 +722,13 @@ groups:
         outbox: false
         returns: "channel_values, channel_versions, pending_sends, node"
         steps: ["SELECT * FROM snapshots WHERE id = :ckpt AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = :tid)"]
+        custom: true
+      - name: latest_checkpoint
+        method: GET
+        path: /threads/{tid}/checkpoints/latest
+        kind: read
+        outbox: false
+        custom: true
 
   # ============================================================== AUTH
   - name: auth

--- a/controlplane/nats/consumers.go
+++ b/controlplane/nats/consumers.go
@@ -26,7 +26,7 @@ type consumerSpec struct {
 // WORKER_COMMANDS by the command family they handle.
 var tenantConsumers = []consumerSpec{
 	{name: "run-processor", stream: "RUNS", ackWait: 30 * time.Second},
-	{name: "graph-executor", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.graph.execute", ackWait: 5 * time.Minute},
+	{name: "graph-executor", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.graph.execute", ackWait: 5 * time.Minute, maxDeliver: 5},
 	{name: "llm-worker", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.llm.invoke", ackWait: 2 * time.Minute},
 	{name: "tool-worker", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.tool.execute", ackWait: 1 * time.Minute},
 }

--- a/controlplane/nats/nats_integration_test.go
+++ b/controlplane/nats/nats_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats-server/v2/server"
 	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -132,6 +133,25 @@ func applyTenantMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 		}
 	}
 	return nil
+}
+
+// connectJS dials the embedded test NATS server and returns a plain
+// connection plus its JetStream context. Callers own the Conn (close
+// or drain it); streams/consumers are not declared here — call
+// EnsureStreams/EnsureConsumers explicitly, as nats.Connect does that
+// as a side effect and tests want that step visible.
+func connectJS(t *testing.T) (*natsgo.Conn, jetstream.JetStream) {
+	t.Helper()
+	conn, err := natsgo.Connect(natsURL)
+	if err != nil {
+		t.Fatalf("connectJS: connect: %v", err)
+	}
+	js, err := jetstream.New(conn)
+	if err != nil {
+		conn.Close()
+		t.Fatalf("connectJS: jetstream: %v", err)
+	}
+	return conn, js
 }
 
 func freePort() (int, error) {

--- a/controlplane/nats/run_processor.go
+++ b/controlplane/nats/run_processor.go
@@ -9,18 +9,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/nats-io/nats.go/jetstream"
 )
 
+// RunProcessor's Stop() safety mirrors Relay/CleanupWorker in this
+// package: the stop channel is allocated in the constructor (not in
+// Start), so Stop can be called safely from any goroutine at any time
+// — including before Start runs — with no data race and no silent
+// no-op.
 type RunProcessor struct {
-	js   jetstream.JetStream
-	pub  *Publisher
-	stop context.CancelFunc
+	js     jetstream.JetStream
+	pub    *Publisher
+	stopCh chan struct{}
 }
 
 func NewRunProcessor(js jetstream.JetStream, pub *Publisher) *RunProcessor {
-	return &RunProcessor{js: js, pub: pub}
+	return &RunProcessor{js: js, pub: pub, stopCh: make(chan struct{})}
 }
 
 // runCreatedPayload is the subset of the run.created event the dispatcher needs.
@@ -33,15 +40,17 @@ type runCreatedPayload struct {
 }
 
 // Start binds the durable run-processor consumer and blocks, dispatching each
-// run.created as a worker.graph.execute command until ctx is cancelled.
+// run.created as a worker.graph.execute command until ctx is cancelled or
+// Stop is called.
 func (rp *RunProcessor) Start(ctx context.Context) error {
-	ctx, rp.stop = context.WithCancel(ctx)
 	cons, err := rp.js.Consumer(ctx, "RUNS", "run-processor")
 	if err != nil {
 		return fmt.Errorf("run-processor: bind consumer: %w", err)
 	}
 	cc, err := cons.Consume(func(msg jetstream.Msg) {
 		if err := rp.dispatch(ctx, msg); err != nil {
+			slog.Warn("run-processor: dispatch failed, nak for redelivery",
+				"subject", msg.Subject(), "err", err)
 			_ = msg.Nak() // transient: let it redeliver
 			return
 		}
@@ -51,20 +60,27 @@ func (rp *RunProcessor) Start(ctx context.Context) error {
 		return fmt.Errorf("run-processor: consume: %w", err)
 	}
 	defer cc.Stop()
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-rp.stopCh:
+	}
 	return nil
 }
 
 func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
 	// Only run.created triggers dispatch; ignore other run.* subjects on RUNS.
-	if !hasSuffix(msg.Subject(), "run.created") {
+	if !strings.HasSuffix(msg.Subject(), "run.created") {
 		return nil
 	}
 	var p runCreatedPayload
 	if err := json.Unmarshal(msg.Data(), &p); err != nil {
+		slog.Warn("run-processor: malformed run.created payload, dropping",
+			"subject", msg.Subject(), "err", err)
 		return nil // malformed → drop (ack); nothing to retry
 	}
 	if p.RunID == "" {
+		slog.Warn("run-processor: run.created missing run_id, dropping",
+			"subject", msg.Subject())
 		return nil
 	}
 	cmd := map[string]any{
@@ -75,12 +91,12 @@ func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
 	return rp.pub.PublishWithID(ctx, SubjectFor("worker.graph.execute"), p.RunID, cmd)
 }
 
+// Stop signals Start to exit. Safe to call from any goroutine at any
+// time, including before Start runs. Idempotent.
 func (rp *RunProcessor) Stop() {
-	if rp.stop != nil {
-		rp.stop()
+	select {
+	case <-rp.stopCh:
+	default:
+		close(rp.stopCh)
 	}
-}
-
-func hasSuffix(s, suf string) bool {
-	return len(s) >= len(suf) && s[len(s)-len(suf):] == suf
 }

--- a/controlplane/nats/run_processor.go
+++ b/controlplane/nats/run_processor.go
@@ -1,0 +1,86 @@
+// run-processor: the dispatch consumer. Drains the RUNS stream (filter
+// run.created) and turns each queued run into a worker.graph.execute command on
+// WORKER_COMMANDS, with Nats-Msg-Id = run_id so a duplicate run.created yields a
+// single command. Thin dispatcher — it does not mutate run state; the worker
+// leases via run.started. Source: spec/models/d2/nats.d2 + endpoint-queries.d2.
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type RunProcessor struct {
+	js   jetstream.JetStream
+	pub  *Publisher
+	stop context.CancelFunc
+}
+
+func NewRunProcessor(js jetstream.JetStream, pub *Publisher) *RunProcessor {
+	return &RunProcessor{js: js, pub: pub}
+}
+
+// runCreatedPayload is the subset of the run.created event the dispatcher needs.
+type runCreatedPayload struct {
+	RunID       string          `json:"run_id"`
+	ThreadID    string          `json:"thread_id,omitempty"`
+	AssistantID string          `json:"assistant_id"`
+	GraphID     string          `json:"graph_id,omitempty"`
+	Input       json.RawMessage `json:"input,omitempty"`
+}
+
+// Start binds the durable run-processor consumer and blocks, dispatching each
+// run.created as a worker.graph.execute command until ctx is cancelled.
+func (rp *RunProcessor) Start(ctx context.Context) error {
+	ctx, rp.stop = context.WithCancel(ctx)
+	cons, err := rp.js.Consumer(ctx, "RUNS", "run-processor")
+	if err != nil {
+		return fmt.Errorf("run-processor: bind consumer: %w", err)
+	}
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		if err := rp.dispatch(ctx, msg); err != nil {
+			_ = msg.Nak() // transient: let it redeliver
+			return
+		}
+		_ = msg.Ack()
+	})
+	if err != nil {
+		return fmt.Errorf("run-processor: consume: %w", err)
+	}
+	defer cc.Stop()
+	<-ctx.Done()
+	return nil
+}
+
+func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
+	// Only run.created triggers dispatch; ignore other run.* subjects on RUNS.
+	if !hasSuffix(msg.Subject(), "run.created") {
+		return nil
+	}
+	var p runCreatedPayload
+	if err := json.Unmarshal(msg.Data(), &p); err != nil {
+		return nil // malformed → drop (ack); nothing to retry
+	}
+	if p.RunID == "" {
+		return nil
+	}
+	cmd := map[string]any{
+		"run_id": p.RunID, "thread_id": p.ThreadID,
+		"assistant_id": p.AssistantID, "graph_id": p.GraphID, "input": p.Input,
+	}
+	// Nats-Msg-Id = run_id → one command per run even if run.created duplicates.
+	return rp.pub.PublishWithID(ctx, SubjectFor("worker.graph.execute"), p.RunID, cmd)
+}
+
+func (rp *RunProcessor) Stop() {
+	if rp.stop != nil {
+		rp.stop()
+	}
+}
+
+func hasSuffix(s, suf string) bool {
+	return len(s) >= len(suf) && s[len(s)-len(suf):] == suf
+}

--- a/controlplane/nats/run_processor.go
+++ b/controlplane/nats/run_processor.go
@@ -2,16 +2,30 @@
 // run.created) and turns each queued run into a worker.graph.execute command on
 // WORKER_COMMANDS, with Nats-Msg-Id = run_id so a duplicate run.created yields a
 // single command. Thin dispatcher — it does not mutate run state; the worker
-// leases via run.started. Source: spec/models/d2/nats.d2 + endpoint-queries.d2.
+// leases via run.started.
+//
+// The relay (relay.go's envelope()) publishes run.created as an ENVELOPE —
+// {event_id, aggregate_type, aggregate_id, event_type, payload, metadata} —
+// not a flat {run_id, ...} object. The run's id is the envelope's
+// aggregate_id. The dispatcher enriches the rest of the worker.graph.execute
+// command (thread_id, assistant_id, graph_id) from the runs table rather than
+// parsing the nested payload, so it stays correct regardless of exactly what
+// the run.created event payload happens to carry.
+//
+// Source: spec/models/d2/nats.d2 + endpoint-queries.d2.
 package nats
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -23,20 +37,24 @@ import (
 type RunProcessor struct {
 	js     jetstream.JetStream
 	pub    *Publisher
+	pool   *pgxpool.Pool
 	stopCh chan struct{}
 }
 
-func NewRunProcessor(js jetstream.JetStream, pub *Publisher) *RunProcessor {
-	return &RunProcessor{js: js, pub: pub, stopCh: make(chan struct{})}
+// NewRunProcessor builds a RunProcessor. pool is a read-only handle on the
+// tenant DB (the same one endpoints.Server writes runs to) — used to enrich
+// each run.created envelope's aggregate_id into the full worker.graph.execute
+// command.
+func NewRunProcessor(js jetstream.JetStream, pub *Publisher, pool *pgxpool.Pool) *RunProcessor {
+	return &RunProcessor{js: js, pub: pub, pool: pool, stopCh: make(chan struct{})}
 }
 
-// runCreatedPayload is the subset of the run.created event the dispatcher needs.
-type runCreatedPayload struct {
-	RunID       string          `json:"run_id"`
-	ThreadID    string          `json:"thread_id,omitempty"`
-	AssistantID string          `json:"assistant_id"`
-	GraphID     string          `json:"graph_id,omitempty"`
-	Input       json.RawMessage `json:"input,omitempty"`
+// runEnvelope is the subset of the outbox-relay envelope (relay.go's
+// envelope()) the dispatcher needs. The run id lives at aggregate_id, not in
+// the nested payload — see the package doc comment above.
+type runEnvelope struct {
+	AggregateID string `json:"aggregate_id"`
+	EventType   string `json:"event_type"`
 }
 
 // Start binds the durable run-processor consumer and blocks, dispatching each
@@ -72,23 +90,53 @@ func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
 	if !strings.HasSuffix(msg.Subject(), "run.created") {
 		return nil
 	}
-	var p runCreatedPayload
-	if err := json.Unmarshal(msg.Data(), &p); err != nil {
-		slog.Warn("run-processor: malformed run.created payload, dropping",
+	var env runEnvelope
+	if err := json.Unmarshal(msg.Data(), &env); err != nil {
+		slog.Warn("run-processor: malformed run.created envelope, dropping",
 			"subject", msg.Subject(), "err", err)
 		return nil // malformed → drop (ack); nothing to retry
 	}
-	if p.RunID == "" {
-		slog.Warn("run-processor: run.created missing run_id, dropping",
-			"subject", msg.Subject())
+	if env.AggregateID == "" || env.EventType != "run.created" {
+		slog.Warn("run-processor: run.created envelope missing aggregate_id or wrong event_type, dropping",
+			"subject", msg.Subject(), "aggregate_id", env.AggregateID, "event_type", env.EventType)
 		return nil
 	}
+	runID, err := uuid.Parse(env.AggregateID)
+	if err != nil {
+		slog.Warn("run-processor: run.created aggregate_id is not a valid UUID, dropping",
+			"subject", msg.Subject(), "aggregate_id", env.AggregateID, "err", err)
+		return nil
+	}
+
+	// Enrich from the DB: the envelope only reliably gives us the run id
+	// (aggregate_id). thread_id and graph_id are nullable (stateless runs,
+	// runs not yet bound to a graph); assistant_id is NOT NULL.
+	var threadID *uuid.UUID
+	var assistantID uuid.UUID
+	var graphID *string
+	err = rp.pool.QueryRow(ctx,
+		`SELECT thread_id, assistant_id, graph_id FROM runs WHERE id = $1`, runID,
+	).Scan(&threadID, &assistantID, &graphID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Run no longer exists (e.g. deleted) — nothing to dispatch.
+			slog.Warn("run-processor: run.created references a run that no longer exists, dropping",
+				"run_id", runID)
+			return nil
+		}
+		return fmt.Errorf("run-processor: enrich run %s: %w", runID, err) // transient — Nak, redeliver
+	}
+
+	// Keys match worker.GraphCommand's JSON tags exactly (run_id, thread_id,
+	// assistant_id, graph_id) — see controlplane/worker/runner.go.
 	cmd := map[string]any{
-		"run_id": p.RunID, "thread_id": p.ThreadID,
-		"assistant_id": p.AssistantID, "graph_id": p.GraphID, "input": p.Input,
+		"run_id":       runID.String(),
+		"thread_id":    threadID,
+		"assistant_id": assistantID.String(),
+		"graph_id":     graphID,
 	}
 	// Nats-Msg-Id = run_id → one command per run even if run.created duplicates.
-	return rp.pub.PublishWithID(ctx, SubjectFor("worker.graph.execute"), p.RunID, cmd)
+	return rp.pub.PublishWithID(ctx, SubjectFor("worker.graph.execute"), runID.String(), cmd)
 }
 
 // Stop signals Start to exit. Safe to call from any goroutine at any

--- a/controlplane/nats/run_processor_test.go
+++ b/controlplane/nats/run_processor_test.go
@@ -7,9 +7,14 @@ import (
 	"time"
 
 	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/google/uuid"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
+// TestRunProcessorDispatch proves the run-processor parses the REAL relay
+// envelope (aggregate_id, event_type — see relay.go's envelope()), not a
+// flat {run_id, ...} payload the relay never emits, and enriches the
+// worker.graph.execute command from the runs table.
 func TestRunProcessorDispatch(t *testing.T) {
 	ctx := context.Background()
 	nc, js := connectJS(t) // helper in this package's test files; see nats_integration_test.go
@@ -18,6 +23,23 @@ func TestRunProcessorDispatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+
+	resetTablesAndOutbox(t)
+
+	// Seed an assistant + a run on a thread — the run-processor enriches
+	// the dispatched command from these rows.
+	var threadID, assistantID, runID uuid.UUID
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&assistantID); err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, graph_id, status) VALUES ($1,$2,'counter','queued') RETURNING id`,
+		threadID, assistantID).Scan(&runID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -32,7 +54,7 @@ func TestRunProcessorDispatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js))
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), testPool)
 	go func() { _ = rp.Start(ctx) }()
 	defer rp.Stop()
 
@@ -45,15 +67,23 @@ func TestRunProcessorDispatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Publish a run.created onto RUNS (Nats-Msg-Id = run_id).
+	// Publish the REAL relay envelope for run.created onto RUNS (Nats-Msg-Id
+	// = run_id) — constructed exactly as relay.go's envelope() does: the run
+	// id is aggregate_id, not a top-level run_id.
 	pub := dnats.NewPublisher(js)
-	runID := "11111111-1111-1111-1111-111111111111"
-	payload := map[string]any{"run_id": runID, "assistant_id": "22222222-2222-2222-2222-222222222222", "graph_id": "counter"}
-	if err := pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID, payload); err != nil {
+	envelope := map[string]any{
+		"event_id":       uuid.New().String(),
+		"aggregate_type": "Run",
+		"aggregate_id":   runID.String(),
+		"event_type":     "run.created",
+		"payload":        map[string]any{},
+		"metadata":       map[string]any{},
+	}
+	if err := pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID.String(), envelope); err != nil {
 		t.Fatal(err)
 	}
 	// Publish the SAME run.created again → dedup → run-processor sees one.
-	_ = pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID, payload)
+	_ = pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID.String(), envelope)
 
 	batch, err := cons.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
 	if err != nil {
@@ -68,8 +98,11 @@ func TestRunProcessorDispatch(t *testing.T) {
 	}
 	var cmd map[string]any
 	_ = json.Unmarshal(got.Data(), &cmd)
-	if cmd["run_id"] != runID {
+	if cmd["run_id"] != runID.String() {
 		t.Errorf("command run_id: want %s, got %v", runID, cmd["run_id"])
+	}
+	if cmd["thread_id"] != threadID.String() {
+		t.Errorf("command thread_id: want %s, got %v", threadID, cmd["thread_id"])
 	}
 	_ = got.Ack()
 

--- a/controlplane/nats/run_processor_test.go
+++ b/controlplane/nats/run_processor_test.go
@@ -21,6 +21,17 @@ func TestRunProcessorDispatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Purge RUNS so the dedup assertion below is self-contained: prior
+	// tests in this package share the same embedded NATS server and its
+	// streams carry residual messages (see TestRelayDedup, same fix).
+	runStream, err := js.Stream(ctx, "RUNS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runStream.Purge(ctx); err != nil {
+		t.Fatal(err)
+	}
+
 	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js))
 	go func() { _ = rp.Start(ctx) }()
 	defer rp.Stop()

--- a/controlplane/nats/run_processor_test.go
+++ b/controlplane/nats/run_processor_test.go
@@ -1,0 +1,77 @@
+package nats_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestRunProcessorDispatch(t *testing.T) {
+	ctx := context.Background()
+	nc, js := connectJS(t) // helper in this package's test files; see nats_integration_test.go
+	defer nc.Close()
+	if err := dnats.EnsureStreams(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js))
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	// Subscribe to WORKER_COMMANDS to observe the dispatched command.
+	cons, err := js.CreateOrUpdateConsumer(ctx, "WORKER_COMMANDS", jetstream.ConsumerConfig{
+		FilterSubject: "duragraph.worker_commands.worker.graph.execute",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Publish a run.created onto RUNS (Nats-Msg-Id = run_id).
+	pub := dnats.NewPublisher(js)
+	runID := "11111111-1111-1111-1111-111111111111"
+	payload := map[string]any{"run_id": runID, "assistant_id": "22222222-2222-2222-2222-222222222222", "graph_id": "counter"}
+	if err := pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID, payload); err != nil {
+		t.Fatal(err)
+	}
+	// Publish the SAME run.created again → dedup → run-processor sees one.
+	_ = pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID, payload)
+
+	batch, err := cons.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got jetstream.Msg
+	for m := range batch.Messages() {
+		got = m
+	}
+	if got == nil {
+		t.Fatal("no worker.graph.execute command dispatched")
+	}
+	var cmd map[string]any
+	_ = json.Unmarshal(got.Data(), &cmd)
+	if cmd["run_id"] != runID {
+		t.Errorf("command run_id: want %s, got %v", runID, cmd["run_id"])
+	}
+	_ = got.Ack()
+
+	// No second command (RUNS dedup on Nats-Msg-Id → single command).
+	batch2, err := cons.Fetch(1, jetstream.FetchMaxWait(1*time.Second))
+	if err != nil {
+		t.Fatalf("fetch2: %v", err)
+	}
+	n := 0
+	for range batch2.Messages() {
+		n++
+	}
+	if n != 0 {
+		t.Errorf("expected only one dispatched command (dedup), got a second")
+	}
+}

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -98,15 +98,17 @@ func (c *Config) defaults() {
 // mounted on Echo, relay goroutines running. Run blocks until a
 // SIGINT/SIGTERM arrives or the context cancels; Shutdown drains.
 type Server struct {
-	cfg     Config
-	tenant  *pgxpool.Pool
-	plat    *pgxpool.Pool
-	relay   *nats.Relay
-	cleanup *nats.CleanupWorker
-	echo    *echo.Echo
+	cfg          Config
+	tenant       *pgxpool.Pool
+	plat         *pgxpool.Pool
+	relay        *nats.Relay
+	cleanup      *nats.CleanupWorker
+	runProcessor *nats.RunProcessor
+	echo         *echo.Echo
 
 	relayDone   chan error
 	cleanupDone chan error
+	rpDone      chan error
 
 	closeOnce sync.Once
 }
@@ -127,6 +129,7 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		cfg:         cfg,
 		relayDone:   make(chan error, 1),
 		cleanupDone: make(chan error, 1),
+		rpDone:      make(chan error, 1),
 	}
 
 	// --- pgxpools ---
@@ -192,6 +195,10 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 			time.Hour,
 			7, // 7-day retention per CLAUDE.md default
 		)
+		// run-processor: dispatches run.created (via the relay above) as
+		// worker.graph.execute commands, enriched from the tenant pool. See
+		// controlplane/nats/run_processor.go.
+		s.runProcessor = nats.NewRunProcessor(js, publisher, s.tenant)
 		// nc lives for the relay's lifetime; closed on Shutdown via
 		// the relay's Stop → publisher Drain. For the SSE subscriber,
 		// there's a separate NewSubscriberFromConn path (TODO when
@@ -239,6 +246,9 @@ func (s *Server) Run(ctx context.Context) error {
 			go func() { s.cleanupDone <- s.cleanup.Start(ctx) }()
 		}
 	}
+	if s.runProcessor != nil && s.cfg.Relays {
+		go func() { s.rpDone <- s.runProcessor.Start(ctx) }()
+	}
 
 	// --- HTTP ---
 	httpErr := make(chan error, 1)
@@ -284,6 +294,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.cleanup != nil {
 		s.cleanup.Stop()
 	}
+	if s.runProcessor != nil {
+		s.runProcessor.Stop()
+	}
 	// Wait for those goroutines to exit (bounded by DrainTimeout).
 	select {
 	case <-s.relayDone:
@@ -292,6 +305,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.cleanup != nil {
 		select {
 		case <-s.cleanupDone:
+		case <-shutCtx.Done():
+		}
+	}
+	if s.runProcessor != nil {
+		select {
+		case <-s.rpDone:
 		case <-shutCtx.Done():
 		}
 	}

--- a/controlplane/server/server_integration_test.go
+++ b/controlplane/server/server_integration_test.go
@@ -14,10 +14,13 @@ import (
 	"testing"
 	"time"
 
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
 	dgserver "github.com/duragraph/duragraph/controlplane/server"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -410,5 +413,125 @@ func TestServer_Relay_Wired(t *testing.T) {
 	// Shutdown via ctx cancel — Run returns after Shutdown drains.
 	cancel()
 	// Give Run a moment to finish; the deferred srv.Close() will tidy up.
+	time.Sleep(500 * time.Millisecond)
+}
+
+// TestServerStartsRunProcessor proves New/Run actually starts the
+// run-processor goroutine (not just the relay) when NATSURL is set and
+// Relays=true: a run.created envelope — built exactly like relay.go's
+// envelope(), aggregate_id = the run id — dispatches a
+// worker.graph.execute command onto WORKER_COMMANDS, driven through the
+// real composition root rather than a standalone nats.RunProcessor
+// (mirrors controlplane/nats/run_processor_test.go's
+// TestRunProcessorDispatch, but through *server.Server).
+func TestServerStartsRunProcessor(t *testing.T) {
+	ctx := context.Background()
+	resetTables(t)
+	addr, err := freeAddr()
+	if err != nil {
+		t.Fatalf("free addr: %v", err)
+	}
+	srv, err := dgserver.New(ctx, dgserver.Config{
+		TenantDSN:    tenantDSN,
+		Migrate:      false, // applied once in TestMain
+		NATSURL:      natsURL,
+		Relays:       true,
+		ListenerDSN:  tenantDSN, // no pooler in tests; reuse DSN
+		Addr:         addr,
+		DrainTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer srv.Close()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = srv.Run(runCtx) }()
+	waitForListen(t, addr)
+
+	pool, err := pgxpool.New(ctx, tenantDSN)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	// Seed a thread + assistant + a queued run directly — the
+	// run-processor enriches the dispatched command from these rows via
+	// the envelope's aggregate_id, same as TestRunProcessorDispatch.
+	var threadID, assistantID, runID uuid.UUID
+	if err := pool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatalf("seed thread: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&assistantID); err != nil {
+		t.Fatalf("seed assistant: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, graph_id, status) VALUES ($1,$2,'counter','queued') RETURNING id`,
+		threadID, assistantID).Scan(&runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	// A separate NATS connection to publish the run.created envelope and
+	// observe WORKER_COMMANDS — independent of the server's own internal
+	// connection, exactly as a real relay-publisher / worker process would
+	// be.
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+
+	cons, err := js.CreateOrUpdateConsumer(ctx, "WORKER_COMMANDS", jetstream.ConsumerConfig{
+		FilterSubject: "duragraph.worker_commands.worker.graph.execute",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+
+	// Publish the REAL relay envelope for run.created onto RUNS — mirrors
+	// relay.go's envelope(): the run id is aggregate_id, not a top-level
+	// run_id.
+	envelope := map[string]any{
+		"event_id":       uuid.New().String(),
+		"aggregate_type": "Run",
+		"aggregate_id":   runID.String(),
+		"event_type":     "run.created",
+		"payload":        map[string]any{},
+		"metadata":       map[string]any{},
+	}
+	pub := dnats.NewPublisher(js)
+	if err := pub.PublishWithID(ctx, dnats.SubjectFor("run.created"), runID.String(), envelope); err != nil {
+		t.Fatalf("publish run.created: %v", err)
+	}
+
+	batch, err := cons.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got jetstream.Msg
+	for m := range batch.Messages() {
+		got = m
+	}
+	if got == nil {
+		t.Fatal("no worker.graph.execute command dispatched — server did not start the run-processor")
+	}
+	var cmd map[string]any
+	if err := json.Unmarshal(got.Data(), &cmd); err != nil {
+		t.Fatalf("decode command: %v", err)
+	}
+	if cmd["run_id"] != runID.String() {
+		t.Errorf("command run_id: want %s, got %v", runID, cmd["run_id"])
+	}
+	if cmd["thread_id"] != threadID.String() {
+		t.Errorf("command thread_id: want %s, got %v", threadID, cmd["thread_id"])
+	}
+	_ = got.Ack()
+
+	cancel()
 	time.Sleep(500 * time.Millisecond)
 }

--- a/controlplane/server/server_integration_test.go
+++ b/controlplane/server/server_integration_test.go
@@ -485,6 +485,32 @@ func TestServerStartsRunProcessor(t *testing.T) {
 		t.Fatalf("ensure consumers: %v", err)
 	}
 
+	// Purge RUNS and WORKER_COMMANDS so this test is self-contained: the
+	// embedded NATS server (and its streams) is shared across every test
+	// in this package via TestMain, and a prior run of this same test
+	// (e.g. -count=3) leaves its own worker.graph.execute command sitting
+	// in WORKER_COMMANDS and its run.created envelope in RUNS. Without
+	// purging, the observer below can fetch a PREVIOUS run's leftover
+	// command instead of the one this test just published. Mirrors
+	// TestRunProcessorDispatch's RUNS purge in
+	// controlplane/nats/run_processor_test.go, extended to
+	// WORKER_COMMANDS since here we're asserting on the dispatched
+	// command, not just the dedup behavior.
+	runStream, err := js.Stream(ctx, "RUNS")
+	if err != nil {
+		t.Fatalf("get RUNS stream: %v", err)
+	}
+	if err := runStream.Purge(ctx); err != nil {
+		t.Fatalf("purge RUNS: %v", err)
+	}
+	workerCommandsStream, err := js.Stream(ctx, "WORKER_COMMANDS")
+	if err != nil {
+		t.Fatalf("get WORKER_COMMANDS stream: %v", err)
+	}
+	if err := workerCommandsStream.Purge(ctx); err != nil {
+		t.Fatalf("purge WORKER_COMMANDS: %v", err)
+	}
+
 	cons, err := js.CreateOrUpdateConsumer(ctx, "WORKER_COMMANDS", jetstream.ConsumerConfig{
 		FilterSubject: "duragraph.worker_commands.worker.graph.execute",
 		AckPolicy:     jetstream.AckExplicitPolicy,
@@ -509,13 +535,25 @@ func TestServerStartsRunProcessor(t *testing.T) {
 		t.Fatalf("publish run.created: %v", err)
 	}
 
-	batch, err := cons.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
-	if err != nil {
-		t.Fatalf("fetch: %v", err)
-	}
+	// The run.created → relay-equivalent publish → RUNS → run-processor →
+	// enrich (DB read) → WORKER_COMMANDS pipeline is fully async, and with
+	// WORKER_COMMANDS now purged (so no stale command can satisfy the
+	// fetch) the only message that CAN appear is this run's own command.
+	// Retry the Fetch with a bounded overall deadline so the test waits
+	// out the pipeline instead of racing it.
 	var got jetstream.Msg
-	for m := range batch.Messages() {
-		got = m
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		batch, err := cons.Fetch(1, jetstream.FetchMaxWait(2*time.Second))
+		if err != nil {
+			t.Fatalf("fetch: %v", err)
+		}
+		for m := range batch.Messages() {
+			got = m
+		}
+		if got != nil {
+			break
+		}
 	}
 	if got == nil {
 		t.Fatal("no worker.graph.execute command dispatched — server did not start the run-processor")
@@ -532,6 +570,11 @@ func TestServerStartsRunProcessor(t *testing.T) {
 	}
 	_ = got.Ack()
 
+	// Only cancel the server's context (and let the deferred srv.Close()
+	// shut it down) AFTER the command has been observed and asserted on —
+	// canceling earlier races the run-processor's enrich step against
+	// shutdown and can starve the command out of WORKER_COMMANDS entirely
+	// (see WARN "enrich run ...: context canceled" in the pre-fix logs).
 	cancel()
 	time.Sleep(500 * time.Millisecond)
 }

--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -1,0 +1,179 @@
+// HTTP client for the worker↔control-plane protocol (see
+// controlplane/endpoints/workers.go for the server side). Deliberately
+// decoupled from controlplane/endpoints — it only speaks HTTP/JSON, so a
+// worker process never needs the server's dependency graph (Postgres pool,
+// echo, etc).
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// ErrStaleLease is returned by any epoch-fenced call (NodeCompleted,
+// RunCompleted, RunFailed, WriteCheckpoint) when the server responds 409 —
+// another worker has since re-leased the run.
+var ErrStaleLease = errors.New("worker: stale lease (409)")
+
+// Client talks to the control-plane's worker endpoints on behalf of one
+// worker process.
+type Client struct {
+	baseURL  string
+	workerID uuid.UUID
+	http     *http.Client
+}
+
+// NewClient builds a Client. baseURL is the control-plane's root (e.g.
+// "http://localhost:8080"); the client appends "/api/v1/..." itself.
+func NewClient(baseURL string, workerID uuid.UUID, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: baseURL, workerID: workerID, http: httpClient}
+}
+
+// Register upserts this worker as online, advertising the graphs it can run
+// and its concurrency capacity. POST /api/v1/workers/register.
+func (c *Client) Register(ctx context.Context, graphs []string, capacity int) error {
+	req := struct {
+		WorkerID uuid.UUID `json:"worker_id"`
+		Graphs   []string  `json:"graphs"`
+		Capacity int       `json:"capacity"`
+	}{WorkerID: c.workerID, Graphs: graphs, Capacity: capacity}
+	_, err := c.doJSON(ctx, http.MethodPost, "/api/v1/workers/register", req, nil)
+	return err
+}
+
+// Heartbeat renews this worker's lease. POST /api/v1/workers/{id}/heartbeat.
+func (c *Client) Heartbeat(ctx context.Context, activeRuns int) error {
+	req := struct {
+		Status     string `json:"status"`
+		ActiveRuns int    `json:"active_runs"`
+	}{Status: "online", ActiveRuns: activeRuns}
+	_, err := c.doJSON(ctx, http.MethodPost, "/api/v1/workers/"+c.workerID.String()+"/heartbeat", req, nil)
+	return err
+}
+
+// Deregister marks this worker offline, requeuing any runs it held.
+// POST /api/v1/workers/{id}/deregister.
+func (c *Client) Deregister(ctx context.Context) error {
+	_, err := c.doJSON(ctx, http.MethodPost, "/api/v1/workers/"+c.workerID.String()+"/deregister", struct{}{}, nil)
+	return err
+}
+
+// RunStarted leases runID to this worker and establishes (or bumps) its
+// lease_epoch. POST /api/v1/workers/{id}/runs/{rid}/events with a single
+// run.started event.
+func (c *Client) RunStarted(ctx context.Context, runID uuid.UUID) (int, error) {
+	body := eventsRequest{Events: []workerEvent{{Type: "run.started"}}}
+	var resp runStartedResponse
+	if _, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, &resp); err != nil {
+		return 0, err
+	}
+	return resp.LeaseEpoch, nil
+}
+
+// NodeCompleted records a completed node execution, fenced on epoch.
+func (c *Client) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
+	body := eventsRequest{Events: []workerEvent{{
+		Type:       "execution.node_completed",
+		LeaseEpoch: epoch,
+		NodeID:     nodeID,
+		NodeType:   nodeType,
+		NodeStatus: "completed",
+	}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
+// RunCompleted marks runID completed, fenced on epoch.
+func (c *Client) RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error {
+	body := eventsRequest{Events: []workerEvent{{Type: "run.completed", LeaseEpoch: epoch}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
+// RunFailed marks runID failed with reason, fenced on epoch.
+func (c *Client) RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error {
+	body := eventsRequest{Events: []workerEvent{{Type: "run.failed", LeaseEpoch: epoch, Error: &reason}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
+// WriteCheckpoint upserts a run snapshot, fenced on epoch.
+// POST /api/v1/threads/{tid}/checkpoints.
+func (c *Client) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error {
+	body := checkpointWriteRequest{RunID: runID, LeaseEpoch: epoch, Version: version, State: json.RawMessage(state)}
+	_, err := c.doJSON(ctx, http.MethodPost, "/api/v1/threads/"+threadID.String()+"/checkpoints", body, nil)
+	return err
+}
+
+// LatestCheckpoint fetches the highest-version snapshot for runID, for worker
+// resume. GET /api/v1/threads/{tid}/checkpoints/latest?run_id={rid}. A 404
+// (no checkpoint yet) is not an error: found is false, err is nil.
+func (c *Client) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (version int, state []byte, found bool, err error) {
+	path := "/api/v1/threads/" + threadID.String() + "/checkpoints/latest?run_id=" + runID.String()
+	var resp checkpointResponse
+	status, err := c.doJSON(ctx, http.MethodGet, path, nil, &resp)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return 0, nil, false, nil
+		}
+		return 0, nil, false, err
+	}
+	return resp.Version, []byte(resp.State), true, nil
+}
+
+// eventsPath builds the worker events endpoint path for runID.
+func (c *Client) eventsPath(runID uuid.UUID) string {
+	return "/api/v1/workers/" + c.workerID.String() + "/runs/" + runID.String() + "/events"
+}
+
+// doJSON POSTs/GETs body (marshaled as JSON, unless nil) to path, decodes a
+// 2xx response into out (unless nil), and maps errors: 409 -> ErrStaleLease,
+// any other non-2xx -> a wrapped error carrying status + body. Returns the
+// HTTP status code (0 if the request never got a response) alongside the
+// error so callers like LatestCheckpoint can special-case 404 without a
+// second round trip.
+func (c *Client) doJSON(ctx context.Context, method, path string, body, out any) (int, error) {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, fmt.Errorf("worker: marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return 0, fmt.Errorf("worker: build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("worker: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if out != nil && len(respBody) > 0 {
+			if err := json.Unmarshal(respBody, out); err != nil {
+				return resp.StatusCode, fmt.Errorf("worker: decode response: %w", err)
+			}
+		}
+		return resp.StatusCode, nil
+	}
+	if resp.StatusCode == http.StatusConflict {
+		return resp.StatusCode, ErrStaleLease
+	}
+	return resp.StatusCode, fmt.Errorf("worker: %s %s: status %d: %s", method, path, resp.StatusCode, string(respBody))
+}

--- a/controlplane/worker/client_test.go
+++ b/controlplane/worker/client_test.go
@@ -1,0 +1,66 @@
+package worker_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	"github.com/duragraph/duragraph/controlplane/worker"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+func TestClientLifecycleAndCheckpoints(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t) // helper: testcontainer PG + tenant migrations (see worker_testmain_test.go)
+	e := echo.New()
+	g := e.Group("/api/v1")
+	(&endpoints.Server{Tenant: pool}).RegisterWorkers(g)
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	wid := uuid.New()
+	cl := worker.NewClient(srv.URL, wid, srv.Client())
+
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	tid, _, rid := seedThreadAssistantRun(t, ctx, pool) // queued run on a thread
+	epoch, err := cl.RunStarted(ctx, rid)
+	if err != nil || epoch != 1 {
+		t.Fatalf("run started: epoch=%d err=%v", epoch, err)
+	}
+	if err := cl.WriteCheckpoint(ctx, tid, rid, epoch, 1, []byte(`{"count":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	v, state, found, err := cl.LatestCheckpoint(ctx, tid, rid)
+	if err != nil || !found || v != 1 || string(state) != `{"count":1}` {
+		t.Fatalf("latest: v=%d found=%v state=%s err=%v", v, found, state, err)
+	}
+	if err := cl.NodeCompleted(ctx, rid, epoch, "A", "tool"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.RunCompleted(ctx, rid, epoch); err != nil {
+		t.Fatal(err)
+	}
+	// stale lease surfaces as ErrStaleLease
+	if err := cl.NodeCompleted(ctx, rid, 999, "B", "tool"); err != worker.ErrStaleLease {
+		t.Fatalf("stale lease: want ErrStaleLease, got %v", err)
+	}
+}
+
+func TestCounterExecutor(t *testing.T) {
+	ex := worker.CounterExecutor{}
+	if got := ex.Nodes(); len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("nodes: %v", got)
+	}
+	st := ex.Run(0, map[string]int{})
+	if st["count"] != 1 {
+		t.Errorf("A: want count=1, got %d", st["count"])
+	}
+	st = ex.Run(1, st)
+	if st["count"] != 2 {
+		t.Errorf("B: want count=2, got %d", st["count"])
+	}
+}

--- a/controlplane/worker/execution_integration_test.go
+++ b/controlplane/worker/execution_integration_test.go
@@ -34,10 +34,16 @@ func TestExecuteRunEndToEnd(t *testing.T) {
 	purgeStream(t, ctx, js, "RUNS")
 	purgeStream(t, ctx, js, "WORKER_COMMANDS")
 
-	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	_, _, rid := seedThreadAssistantRun(t, ctx, pool)
+	// The run-processor enriches worker.graph.execute from the runs row via
+	// aggregate_id, so the seeded run needs graph_id set for the worker to
+	// pick the right executor.
+	if _, err := pool.Exec(ctx, `UPDATE runs SET graph_id = 'counter' WHERE id = $1`, rid); err != nil {
+		t.Fatalf("set graph_id: %v", err)
+	}
 
 	// run-processor: turns run.created into a worker.graph.execute command.
-	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js))
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
 	go func() { _ = rp.Start(ctx) }()
 	defer rp.Stop()
 
@@ -50,16 +56,19 @@ func TestExecuteRunEndToEnd(t *testing.T) {
 	runner := worker.NewRunner(js, cl, worker.CounterExecutor{})
 	go func() { _ = runner.Start(ctx) }()
 
-	// Publish run.created — thread_id included so the worker can read/write
-	// checkpoints on it, matching the real endpoint's payload shape
-	// (controlplane/endpoints/runs_gen.go: {thread_id, assistant_id, input}).
-	payload := map[string]any{
-		"run_id":       rid.String(),
-		"thread_id":    tid.String(),
-		"assistant_id": aid.String(),
-		"graph_id":     "counter",
+	// Publish the REAL relay envelope for run.created onto RUNS — the run id
+	// is the envelope's aggregate_id (relay.go's envelope()), not a
+	// top-level run_id. The run-processor enriches thread_id/assistant_id/
+	// graph_id from the runs row seeded above.
+	envelope := map[string]any{
+		"event_id":       uuid.New().String(),
+		"aggregate_type": "Run",
+		"aggregate_id":   rid.String(),
+		"event_type":     "run.created",
+		"payload":        map[string]any{},
+		"metadata":       map[string]any{},
 	}
-	if err := dnats.NewPublisher(js).PublishWithID(ctx, dnats.SubjectFor("run.created"), rid.String(), payload); err != nil {
+	if err := dnats.NewPublisher(js).PublishWithID(ctx, dnats.SubjectFor("run.created"), rid.String(), envelope); err != nil {
 		t.Fatalf("publish run.created: %v", err)
 	}
 

--- a/controlplane/worker/execution_integration_test.go
+++ b/controlplane/worker/execution_integration_test.go
@@ -1,0 +1,217 @@
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// TestExecuteRunEndToEnd proves the full reliability pipeline end to end:
+// a queued run's run.created is published to RUNS, the run-processor
+// dispatches it as a worker.graph.execute command on WORKER_COMMANDS, and a
+// live Runner consumes it and drives the 2-step counter graph to
+// completion — 2 execution_history rows (A, B) and 2 checkpoints (v1, v2).
+func TestExecuteRunEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+
+	// run-processor: turns run.created into a worker.graph.execute command.
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js))
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	// A live worker + Runner consuming the graph-executor consumer.
+	wid := uuid.New()
+	cl := worker.NewClient(serverURL, wid, nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, worker.CounterExecutor{})
+	go func() { _ = runner.Start(ctx) }()
+
+	// Publish run.created — thread_id included so the worker can read/write
+	// checkpoints on it, matching the real endpoint's payload shape
+	// (controlplane/endpoints/runs_gen.go: {thread_id, assistant_id, input}).
+	payload := map[string]any{
+		"run_id":       rid.String(),
+		"thread_id":    tid.String(),
+		"assistant_id": aid.String(),
+		"graph_id":     "counter",
+	}
+	if err := dnats.NewPublisher(js).PublishWithID(ctx, dnats.SubjectFor("run.created"), rid.String(), payload); err != nil {
+		t.Fatalf("publish run.created: %v", err)
+	}
+
+	waitForRunStatus(t, ctx, pool, rid, "completed", 10*time.Second)
+
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+	assertMaxSnapshotVersion(t, ctx, pool, rid, 2)
+
+	var snapCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM snapshots WHERE aggregate_id=$1`, rid).Scan(&snapCount); err != nil {
+		t.Fatal(err)
+	}
+	if snapCount != 2 {
+		t.Errorf("snapshots: want 2 rows (v1, v2), got %d", snapCount)
+	}
+}
+
+// TestDurableResume is the reliability proof: a first Runner executes node
+// A, writes checkpoint v1, then "dies" before node B (StopAfterNode
+// simulates the crash deterministically — no ack, no RunCompleted, no
+// reliance on the 5-minute ack_wait). A second Runner processes the very
+// same command — as JetStream would redeliver it after the first worker's
+// lease expired — and must resume at node B rather than re-running node A.
+func TestDurableResume(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter"}
+
+	// Worker 1: dies right after node A's checkpoint (before node B).
+	wid1 := uuid.New()
+	cl1 := worker.NewClient(serverURL, wid1, nil)
+	if err := cl1.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register worker1: %v", err)
+	}
+	r1 := worker.NewRunner(nil, cl1, worker.CounterExecutor{})
+	r1.StopAfterNode = 0 // simulate death before starting node index 1 (B)
+
+	acked1, err1 := r1.ProcessOne(ctx, cmd)
+	if err1 != nil {
+		t.Fatalf("first ProcessOne: unexpected error: %v", err1)
+	}
+	if acked1 {
+		t.Fatal("first ProcessOne: want acked=false (simulated death before node B), got true")
+	}
+
+	// After the "crash": node A ran once, checkpoint v1 exists, run is still
+	// in_progress (never reached RunCompleted).
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+	assertRunStatus(t, ctx, pool, rid, "in_progress")
+	assertMaxSnapshotVersion(t, ctx, pool, rid, 1)
+
+	// Worker 2: a fresh Runner picks up the same command (what JetStream's
+	// redelivery would hand it after worker 1's lease/ack_wait expired).
+	wid2 := uuid.New()
+	cl2 := worker.NewClient(serverURL, wid2, nil)
+	if err := cl2.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register worker2: %v", err)
+	}
+	r2 := worker.NewRunner(nil, cl2, worker.CounterExecutor{})
+
+	acked2, err2 := r2.ProcessOne(ctx, cmd)
+	if err2 != nil {
+		t.Fatalf("second ProcessOne: unexpected error: %v", err2)
+	}
+	if !acked2 {
+		t.Fatal("second ProcessOne: want acked=true (run completed), got false")
+	}
+
+	// THE PROOF: node A ran exactly ONCE across both attempts (resume
+	// skipped it) — checkpoint-based resume, not re-execution.
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertMaxSnapshotVersion(t, ctx, pool, rid, 2)
+
+	// The dead worker (still holding epoch 1) can no longer write: the live
+	// lease is now epoch 2, so its event is fenced off as stale.
+	if err := cl1.NodeCompleted(ctx, rid, 1, "B", "tool"); !errors.Is(err, worker.ErrStaleLease) {
+		t.Errorf("dead worker's replayed write: want ErrStaleLease, got %v", err)
+	}
+}
+
+// purgeStream drops all messages from a JetStream stream so residual
+// deliveries from earlier tests in this package (sharing one embedded NATS
+// server across the whole binary) can't leak into this test's assertions.
+func purgeStream(t *testing.T, ctx context.Context, js jetstream.JetStream, name string) {
+	t.Helper()
+	stream, err := js.Stream(ctx, name)
+	if err != nil {
+		t.Fatalf("stream %s: %v", name, err)
+	}
+	if err := stream.Purge(ctx); err != nil {
+		t.Fatalf("purge %s: %v", name, err)
+	}
+}
+
+// waitForRunStatus polls until runs.status for rid equals want or timeout
+// elapses.
+func waitForRunStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var got string
+	for time.Now().Before(deadline) {
+		if err := pool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&got); err != nil {
+			t.Fatalf("select run status: %v", err)
+		}
+		if got == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("run status: want %q within %s, got %q", want, timeout, got)
+}
+
+// assertRunStatus checks runs.status for rid equals want, right now.
+func assertRunStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID, want string) {
+	t.Helper()
+	var got string
+	if err := pool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&got); err != nil {
+		t.Fatalf("select run status: %v", err)
+	}
+	if got != want {
+		t.Errorf("run status: want %q, got %q", want, got)
+	}
+}
+
+// assertNodeCount checks how many execution_history rows exist for
+// (rid, nodeID).
+func assertNodeCount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID, nodeID string, want int) {
+	t.Helper()
+	var got int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM execution_history WHERE run_id=$1 AND node_id=$2`, rid, nodeID).Scan(&got); err != nil {
+		t.Fatalf("select execution_history count for %s: %v", nodeID, err)
+	}
+	if got != want {
+		t.Errorf("execution_history[node_id=%s]: want %d, got %d", nodeID, want, got)
+	}
+}
+
+// assertMaxSnapshotVersion checks max(version) over snapshots for rid.
+func assertMaxSnapshotVersion(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID, want int) {
+	t.Helper()
+	var got int
+	if err := pool.QueryRow(ctx, `SELECT max(version) FROM snapshots WHERE aggregate_id=$1`, rid).Scan(&got); err != nil {
+		t.Fatalf("select max snapshot version: %v", err)
+	}
+	if got != want {
+		t.Errorf("max snapshot version: want %d, got %d", want, got)
+	}
+}

--- a/controlplane/worker/executor.go
+++ b/controlplane/worker/executor.go
@@ -1,0 +1,21 @@
+// The 2-step counter graph — the thin executor that proves durable execution.
+// Node A sets count=1, node B sets count=2. A checkpoint is written after each
+// node so a crash between them resumes at B (not A). Deliberately trivial; the
+// real graph engine is a later cycle.
+package worker
+
+type CounterExecutor struct{}
+
+// Nodes returns the ordered node ids.
+func (CounterExecutor) Nodes() []string { return []string{"A", "B"} }
+
+// Run applies node[step] to state and returns the new state. Node A → count=1,
+// node B → count=2 (idempotent given step).
+func (CounterExecutor) Run(step int, state map[string]int) map[string]int {
+	out := map[string]int{}
+	for k, v := range state {
+		out[k] = v
+	}
+	out["count"] = step + 1
+	return out
+}

--- a/controlplane/worker/protocol.go
+++ b/controlplane/worker/protocol.go
@@ -1,0 +1,53 @@
+// Small local copies of the worker↔control-plane wire shapes. The worker
+// package must not import controlplane/endpoints (that would pull in the
+// server's dependency graph), so these structs mirror the JSON tags of
+// endpoints.WorkerEvent / WorkerEventsRequest / RunStartedResponse /
+// CheckpointWriteRequest / CheckpointResponse (see
+// controlplane/endpoints/worker_types.go) exactly, field for field.
+package worker
+
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+// workerEvent mirrors endpoints.WorkerEvent.
+type workerEvent struct {
+	Type       string          `json:"type"`
+	LeaseEpoch int             `json:"lease_epoch,omitempty"`
+	NodeID     string          `json:"node_id,omitempty"`
+	NodeType   string          `json:"node_type,omitempty"`
+	NodeStatus string          `json:"node_status,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	Output     json.RawMessage `json:"output,omitempty"`
+	DurationMs *int            `json:"duration_ms,omitempty"`
+	Error      *string         `json:"error,omitempty"`
+}
+
+// eventsRequest mirrors endpoints.WorkerEventsRequest.
+type eventsRequest struct {
+	Events []workerEvent `json:"events"`
+}
+
+// runStartedResponse mirrors endpoints.RunStartedResponse.
+type runStartedResponse struct {
+	LeaseEpoch int `json:"lease_epoch"`
+}
+
+// checkpointWriteRequest mirrors endpoints.CheckpointWriteRequest.
+type checkpointWriteRequest struct {
+	RunID      uuid.UUID       `json:"run_id"`
+	LeaseEpoch int             `json:"lease_epoch"`
+	Version    int             `json:"version"`
+	State      json.RawMessage `json:"state"`
+}
+
+// checkpointResponse mirrors endpoints.CheckpointResponse (used to decode the
+// GET .../checkpoints/latest response).
+type checkpointResponse struct {
+	CheckpointID int64           `json:"checkpoint_id"`
+	RunID        uuid.UUID       `json:"run_id"`
+	Version      int             `json:"version"`
+	State        json.RawMessage `json:"state"`
+}

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -1,0 +1,190 @@
+// The worker Runner — consumes worker.graph.execute commands from the
+// graph-executor durable consumer (WORKER_COMMANDS stream, ack_wait=5m,
+// maxDeliver=5) and drives CounterExecutor's 2-step graph with the ack
+// discipline that makes execution durable across a worker crash:
+//
+//   - RunStarted leases the run and bumps its lease_epoch. A stale lease
+//     (409, someone else already owns or finished this run) means there is
+//     nothing left to do — ack. A transient error means retry — Nak.
+//   - Before running node N, the runner checks the run's latest checkpoint.
+//     A checkpoint of version v means nodes 0..v-1 already ran, so execution
+//     resumes at step v — the node that already completed is never re-run,
+//     even if the command is redelivered after a crash.
+//   - After each node: WriteCheckpoint then NodeCompleted, both fenced on
+//     the epoch obtained from RunStarted. A stale-lease response here means
+//     another worker has since re-leased the run (e.g. because this worker
+//     died and JetStream redelivered the command to a second Runner) — stop
+//     and ack, since the newer worker owns the run now. A transient error
+//     means Nak so JetStream redelivers.
+//   - After the last node: RunCompleted, fenced the same way.
+//
+// Source: spec/models/d2 workers block + the worker-execution design doc.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Runner consumes worker.graph.execute commands and executes them against
+// CounterExecutor.
+type Runner struct {
+	js jetstream.JetStream
+	cl *Client
+	ex CounterExecutor
+
+	// StopAfterNode is a test hook that simulates a worker crash: when >= 0,
+	// ProcessOne returns (acked=false, nil) — without acking, without
+	// running or checkpointing any further node — as soon as it is about to
+	// start the node AFTER StopAfterNode. Default -1 (disabled; run to
+	// completion normally). Exported so execution_integration_test.go
+	// (package worker_test) can drive TestDurableResume deterministically,
+	// without waiting on the 5-minute ack_wait for a real redelivery.
+	StopAfterNode int
+}
+
+// NewRunner builds a Runner bound to js, cl, and ex. StopAfterNode defaults
+// to -1 (disabled).
+func NewRunner(js jetstream.JetStream, cl *Client, ex CounterExecutor) *Runner {
+	return &Runner{js: js, cl: cl, ex: ex, StopAfterNode: -1}
+}
+
+// GraphCommand is the worker.graph.execute payload shape, matching what
+// nats.RunProcessor.dispatch publishes (run_id, thread_id, assistant_id,
+// graph_id, input). Exported so tests can construct/decode commands without
+// duplicating the shape.
+type GraphCommand struct {
+	RunID       uuid.UUID       `json:"run_id"`
+	ThreadID    uuid.UUID       `json:"thread_id"`
+	AssistantID uuid.UUID       `json:"assistant_id,omitempty"`
+	GraphID     string          `json:"graph_id,omitempty"`
+	Input       json.RawMessage `json:"input,omitempty"`
+}
+
+// Start binds the graph-executor durable consumer (WORKER_COMMANDS,
+// filter worker.graph.execute) and processes messages until ctx is
+// cancelled. Each message: InProgress() (so JetStream doesn't consider it
+// stalled while we work), decode, ProcessOne, then Ack on success/terminal
+// or Nak to let JetStream redeliver.
+func (r *Runner) Start(ctx context.Context) error {
+	cons, err := r.js.Consumer(ctx, "WORKER_COMMANDS", "graph-executor")
+	if err != nil {
+		return fmt.Errorf("runner: bind graph-executor consumer: %w", err)
+	}
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		if ierr := msg.InProgress(); ierr != nil {
+			slog.Warn("runner: InProgress failed", "err", ierr)
+		}
+		var cmd GraphCommand
+		if uerr := json.Unmarshal(msg.Data(), &cmd); uerr != nil {
+			slog.Warn("runner: malformed worker.graph.execute command, dropping", "err", uerr)
+			_ = msg.Ack() // malformed: nothing to retry, ack so it doesn't jam the consumer
+			return
+		}
+		acked, perr := r.ProcessOne(ctx, cmd)
+		if perr != nil {
+			slog.Warn("runner: processOne error", "run_id", cmd.RunID, "acked", acked, "err", perr)
+		}
+		if acked {
+			_ = msg.Ack()
+		} else {
+			_ = msg.Nak()
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("runner: consume: %w", err)
+	}
+	defer cc.Stop()
+	<-ctx.Done()
+	return nil
+}
+
+// ProcessOne executes cmd's run against CounterExecutor with checkpoint
+// resume, following the control flow documented on Runner and in the task
+// brief. Returns acked=true when the message should be Acked (success,
+// terminal/stale-lease outcomes with nothing left to do) and acked=false
+// when it should be Nak'd for redelivery (transient errors, or the
+// StopAfterNode test hook simulating a crash).
+//
+// Exported (not the brief's literal lowercase "processOne") because the
+// integration tests live in the external worker_test package alongside
+// Task 7's shared Postgres/NATS test harness (newPool,
+// seedThreadAssistantRun, testPool) — an internal-package test file could
+// call an unexported method but could not reach that harness, since Go
+// external test packages are not importable from internal ones. Behavior
+// matches the brief's processOne exactly; only the exported name differs.
+func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, err error) {
+	epoch, err := r.cl.RunStarted(ctx, cmd.RunID)
+	if err != nil {
+		if errors.Is(err, ErrStaleLease) {
+			// Run is already terminal (or was claimed and finished by
+			// someone else) — nothing to do. Ack.
+			return true, nil
+		}
+		return false, err // transient — Nak, redeliver
+	}
+
+	resumeFrom := 0
+	var state map[string]int
+	v, raw, found, lerr := r.cl.LatestCheckpoint(ctx, cmd.ThreadID, cmd.RunID)
+	if lerr != nil {
+		return false, lerr // transient — Nak, redeliver
+	}
+	if found {
+		// version v = count of completed nodes (1-based), so resume at
+		// step index v: nodes 0..v-1 already ran and must not run again.
+		resumeFrom = v
+		if len(raw) > 0 {
+			if uerr := json.Unmarshal(raw, &state); uerr != nil {
+				return false, fmt.Errorf("runner: decode checkpoint state: %w", uerr)
+			}
+		}
+	}
+	if state == nil {
+		state = map[string]int{}
+	}
+
+	nodes := r.ex.Nodes()
+	for step := resumeFrom; step < len(nodes); step++ {
+		if r.StopAfterNode >= 0 && step > r.StopAfterNode {
+			// Test hook: simulate a crash after StopAfterNode completed and
+			// checkpointed, before starting the next node. No ack — the
+			// command must be redelivered (to a fresh Runner in the resume
+			// test) for the run to actually finish.
+			return false, nil
+		}
+
+		state = r.ex.Run(step, state)
+
+		stateJSON, merr := json.Marshal(state)
+		if merr != nil {
+			return false, fmt.Errorf("runner: encode state: %w", merr)
+		}
+		if werr := r.cl.WriteCheckpoint(ctx, cmd.ThreadID, cmd.RunID, epoch, step+1, stateJSON); werr != nil {
+			if errors.Is(werr, ErrStaleLease) {
+				return true, nil // superseded by a newer lease — stop, ack
+			}
+			return false, werr // transient — Nak, redeliver
+		}
+		if nerr := r.cl.NodeCompleted(ctx, cmd.RunID, epoch, nodes[step], "tool"); nerr != nil {
+			if errors.Is(nerr, ErrStaleLease) {
+				return true, nil
+			}
+			return false, nerr
+		}
+	}
+
+	if cerr := r.cl.RunCompleted(ctx, cmd.RunID, epoch); cerr != nil {
+		if errors.Is(cerr, ErrStaleLease) {
+			return true, nil
+		}
+		return false, cerr
+	}
+	return true, nil
+}

--- a/controlplane/worker/worker_testmain_test.go
+++ b/controlplane/worker/worker_testmain_test.go
@@ -1,0 +1,116 @@
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// testPool connects to a real Postgres (testcontainers) with the tenant
+// migrations applied. Populated by TestMain. Task 8's
+// execution_integration_test.go (package worker_test) reuses newPool and
+// seedThreadAssistantRun below.
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	pg, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("tenant"),
+		tcpostgres.WithUsername("t"),
+		tcpostgres.WithPassword("t"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "postgres testcontainer: %v\n", err)
+		os.Exit(1)
+	}
+	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dsn: %v\n", err)
+		os.Exit(1)
+	}
+	testPool, err = pgxpool.New(ctx, dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pool: %v\n", err)
+		os.Exit(1)
+	}
+	if err := applyTenantMigrations(ctx, testPool); err != nil {
+		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	testPool.Close()
+	_ = pg.Terminate(ctx)
+	os.Exit(code)
+}
+
+// applyTenantMigrations runs every tenant *.up.sql in order against the pool.
+// Mirrors controlplane/endpoints/assistants_integration_test.go.
+func applyTenantMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	dir := filepath.Join("..", "db", "migrations", "tenant")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var ups []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			ups = append(ups, e.Name())
+		}
+	}
+	sort.Strings(ups)
+	for _, name := range ups {
+		sqlBytes, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+		if _, err := pool.Exec(ctx, string(sqlBytes)); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// newPool returns the shared testcontainer pool, truncated so each test
+// starts from an empty schema.
+func newPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		"TRUNCATE workers, runs, execution_history, snapshots, events, outbox, event_streams, assistants, threads CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	return testPool
+}
+
+// seedThreadAssistantRun inserts a thread, an assistant, and a queued run on
+// that thread, returning their ids.
+func seedThreadAssistantRun(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (threadID, assistantID, runID uuid.UUID) {
+	t.Helper()
+	if err := pool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&assistantID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'queued') RETURNING id`,
+		threadID, assistantID).Scan(&runID); err != nil {
+		t.Fatal(err)
+	}
+	return threadID, assistantID, runID
+}

--- a/controlplane/worker/worker_testmain_test.go
+++ b/controlplane/worker/worker_testmain_test.go
@@ -3,6 +3,8 @@ package worker_test
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,21 +12,33 @@ import (
 	"testing"
 	"time"
 
+	"github.com/duragraph/duragraph/controlplane/endpoints"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/labstack/echo/v4"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // testPool connects to a real Postgres (testcontainers) with the tenant
-// migrations applied. Populated by TestMain. Task 8's
-// execution_integration_test.go (package worker_test) reuses newPool and
-// seedThreadAssistantRun below.
-var testPool *pgxpool.Pool
+// migrations applied. natsURL points at an embedded in-process JetStream
+// server; serverURL points at an httptest server mounting the worker
+// endpoints over testPool. All three are populated by TestMain and shared
+// across every test in this package (both worker_test and Task 8's
+// execution_integration_test.go). newPool and seedThreadAssistantRun below
+// are reused by Task 8 directly.
+var (
+	testPool  *pgxpool.Pool
+	natsURL   string
+	serverURL string
+)
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
+
+	// --- Postgres testcontainer with tenant migrations applied ---
 	pg, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("tenant"),
@@ -53,10 +67,62 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
 		os.Exit(1)
 	}
+
+	// --- embedded NATS server (JetStream) — mirrors
+	// controlplane/nats/nats_integration_test.go's TestMain ---
+	portSrv, err := freePort()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "free-port: %v\n", err)
+		os.Exit(1)
+	}
+	dataDir, err := os.MkdirTemp("", "duragraph-worker-nats-test-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mkdtemp: %v\n", err)
+		os.Exit(1)
+	}
+	natsSrv, err := server.NewServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      portSrv,
+		JetStream: true,
+		StoreDir:  filepath.Join(dataDir, "js"),
+		NoSigs:    true,
+		NoLog:     true,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nats new: %v\n", err)
+		os.Exit(1)
+	}
+	go natsSrv.Start()
+	if !natsSrv.ReadyForConnections(10 * time.Second) {
+		fmt.Fprintln(os.Stderr, "nats: did not become ready")
+		os.Exit(1)
+	}
+	natsURL = fmt.Sprintf("nats://127.0.0.1:%d", portSrv)
+
+	// --- httptest server mounting the worker endpoints over testPool ---
+	e := echo.New()
+	g := e.Group("/api/v1")
+	(&endpoints.Server{Tenant: testPool}).RegisterWorkers(g)
+	httpSrv := httptest.NewServer(e)
+	serverURL = httpSrv.URL
+
 	code := m.Run()
+	httpSrv.Close()
+	natsSrv.Shutdown()
+	os.RemoveAll(dataDir)
 	testPool.Close()
 	_ = pg.Terminate(ctx)
 	os.Exit(code)
+}
+
+// freePort finds an available TCP port for the embedded NATS server.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // applyTenantMigrations runs every tenant *.up.sql in order against the pool.


### PR DESCRIPTION
## Worker execution path — thin vertical slice with durable checkpoints

Builds the reliable execution path for the rebuilt control plane: a queued run is
dispatched over NATS to a worker that executes a graph with **explicit-ack
redelivery** and **durable checkpoint resume**. Grounded in the structural d2
(`workers.d2`, `nats.d2`, `endpoint-queries.d2`, `postgres.d2`); the `code-*.d2`
files (old `internal/` design) are excluded.

### Flow
```
create run → run.created → outbox → relay → RUNS stream
run-processor consumer: reads envelope aggregate_id = run_id, enriches
  thread_id/assistant_id/graph_id from the runs table → publishes
  worker.graph.execute (WORKER_COMMANDS, Nats-Msg-Id = run_id)
worker (cmd/worker): durable pull consumer (graph-executor, ack_wait=5m, AckExplicit)
  → POST events run.started (leases run: in_progress, worker_id, lease_epoch++)
  → per node: WriteCheckpoint(version) + POST node_completed  (epoch-fenced)
  → POST run.completed → Ack
  transient error → Nak (redeliver); msg.InProgress() heartbeats
crash mid-run → un-acked → ack_wait redelivers → fresh worker reads latest
  checkpoint and RESUMES from the next node (not from zero); stale worker fenced by lease_epoch
```

### What's in it
- **Worker HTTP endpoints** (`controlplane/endpoints/workers.go`, generator `custom` flag): register, heartbeat, deregister, events (run lifecycle + node events), write/read/latest checkpoint. All state-mutating writes are **atomically epoch-fenced in-SQL** (0 rows → 409); fencing is `lease_epoch` only (runs has no `lease_expires_at`).
- **run-processor** dispatch consumer + `max_deliver=5` on `graph-executor`.
- **Worker binary** `cmd/worker/` + `controlplane/worker/` (NATS consumer, ack loop, HTTP client, 2-step counter executor).
- **Migration 006** — `snapshots (stream_id, version)` unique, for idempotent checkpoint upsert under redelivery.
- Server wires the run-processor alongside the relay.

### Testing
Testcontainers Postgres + embedded in-process NATS (no build tag, runs in standard CI).
- **`TestDurableResume` is the reliability proof**: worker runs node A + checkpoint 1, "dies" without acking; a fresh worker resumes and runs node B — asserting node A executed **exactly once** (verified at the `execution_history` DB level). Passes under `-race`.
- End-to-end (`TestExecuteRunEndToEnd`) drives create-run → dispatch → worker → completed through the **real relay envelope**.
- Epoch-stale writes → 409; run-processor dedup; register/heartbeat/deregister/checkpoint round-trips.

### Integration bug found & fixed mid-build
The run-processor originally parsed a flat `run_id`, but the relay publishes an
envelope (`aggregate_id` = run id, fields nested under `payload`) — every real run
would have been dropped. Per-task tests hid it with hand-crafted flat payloads.
Fixed: run-processor parses the envelope and enriches from the runs table; tests
rewritten to publish the actual envelope shape.

### Spec-first
`endpoint-queries.d2`'s workers block was reconciled (in the spec repo) to the push
dispatch model, run-lifecycle-on-events, and `claim` deferred.

---

## ⚠️ Deferred follow-ups (tracked — NOT blockers for this thin slice)

The counter graph can't error and CI doesn't run `-race`, so none of these block
this slice. They are **required before the noted milestones**:

1. **INF-1 — reliability spine has two unwired legs (gate before any real, error-capable graph):**
   - `max_deliver`→dead-letter→`run.failed` has no dead-letter/advisory consumer.
   - graph-error→`run.failed`→Ack is unwired (`Client.RunFailed` is currently dead code; the counter executor can't error).
   - *Consequence if shipped with a real graph:* a sustained (~25 min) infra outage exhausts redeliveries and leaves a run stuck `in_progress` forever with no terminal event.
2. **Two pre-existing `relay.go` data races** (in already-merged code, not this branch; surface only under `-race`): `Relay.Stop()` vs `listenLoop` `WaitForNotification`, and `Stop()` vs the reconnect-loop `Close`, both on the listener `*pgx.Conn`. Gate a `-race`-clean tag, not this merge.
3. **Shared envelope type** — the relay/consumer/test envelope shape is duplicated three ways with no single source of truth (the exact drift class that caused the integration bug above).
4. **Minor:** `input` is dropped from the dispatched command (harmless for the counter; a real graph needs it); checkpoint is written before `node_completed`, so a crash in that window leaves the node's `execution_history` row absent (observability gap; checkpoint remains source of truth).
