### PR TITLE
fix(controlplane): worker reliability — relay shutdown race (INF-2) + dead-letter/graph-error → run.failed (INF-1)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -107,7 +107,7 @@ func run() error {
 	heartbeatDone := make(chan struct{})
 	go heartbeatLoop(ctx, client, heartbeatDone)
 
-	runner := worker.NewRunner(js, client, worker.CounterExecutor{})
+	runner := worker.NewRunner(js, client, worker.CounterExecutor{}, nats.GraphExecutorMaxDeliver)
 	runnerDone := make(chan error, 1)
 	go func() { runnerDone <- runner.Start(ctx) }()
 

--- a/controlplane/docs/superpowers/plans/2026-07-26-worker-reliability-inf1-inf2.md
+++ b/controlplane/docs/superpowers/plans/2026-07-26-worker-reliability-inf1-inf2.md
@@ -1,0 +1,450 @@
+# Worker Reliability Follow-ups (INF-1 + INF-2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the two reliability gaps from PR #217's review — INF-2 (relay shutdown data race) and INF-1 (exhausted-redelivery + graph-error must become `run.failed`, not silent drops).
+
+**Architecture:** INF-2 replaces relay's cross-goroutine listener-conn `Close()` with context cancellation so the conn is only ever touched by its owning goroutine. INF-1 gives the worker executor an error return (behind an `Executor` interface) and makes the runner escalate a poison run or an exhausted redelivery to `run.failed` + Ack, wiring in the previously-dead `Client.RunFailed`.
+
+**Tech Stack:** Go 1.25, pgx v5, NATS JetStream (`nats.go` jetstream + embedded server for tests), Echo, testcontainers Postgres.
+
+## Global Constraints
+
+- Design doc: `controlplane/docs/superpowers/specs/2026-07-26-worker-reliability-inf1-inf2-design.md` — the contract; this plan implements it.
+- Two commits, one PR (branch `feat/controlplane-reliability`, stacked on `feat/controlplane-worker-execution`).
+- Integration tests use testcontainers + embedded NATS, no build tag, run in standard CI. Never weaken an assertion to pass; if behavior is wrong, fix the code.
+- The reliability-critical checks MUST run under `-race` and pass with no data race (INF-2's whole point).
+- `runs` has NO `lease_expires_at`; fencing is `lease_epoch` only. `Client.RunFailed` is epoch-fenced.
+- `execution_history.node_type` ∈ {start,end,llm,tool,conditional}; the counter/stub nodes use `tool`.
+- Never hand-edit `*_gen.go` / go.mod / go.sum. Conventional commits. No PR/push/merge without explicit approval.
+- Run all commands from the worktree root `~/worktrees/duragraph/feat/controlplane-server` (the reliability branch is checked out there).
+
+---
+
+## File Structure
+
+- `controlplane/nats/relay.go` (modify) — context-cancel shutdown; remove listener-conn sharing.
+- `controlplane/nats/consumers.go` (modify) — `GraphExecutorMaxDeliver` const.
+- `controlplane/worker/executor.go` (modify) — `Executor` interface + `Run` error return.
+- `controlplane/worker/runner.go` (modify) — `ex`/`cl` become interfaces, `ProcessOne` returns epoch, `ackDecision` helper, escalation + graph-error wiring, `MaxDeliver` field.
+- `cmd/worker/main.go` (modify) — pass `nats.GraphExecutorMaxDeliver`.
+- Tests: `controlplane/nats/nats_integration_test.go` / `run_processor_test.go` area (relay -race), `controlplane/worker/*_test.go`.
+
+---
+
+## Task 1: INF-2 — relay shutdown without cross-goroutine conn close
+
+**Files:**
+- Modify: `controlplane/nats/relay.go`
+- Test: the relay `-race` tests already exist (`TestRelayStop` in nats package; `TestServer_Relay_Wired` in server package) — this task makes them pass under `-race`.
+
+**Interfaces:**
+- Consumes: existing `Relay` (`Start`, `Stop`, `listenLoop`, `stopCh`, `shouldStop`, `sleepOrStop`).
+- Produces: same public API (`Start(ctx) error`, `Stop()`), race-free. Removes `listener`, `listenerMu`, `setListener`, `clearListener`.
+
+- [ ] **Step 1: Establish the failing (racy) baseline**
+
+Run: `go test ./controlplane/nats/ -run TestRelayStop -race -count=1 2>&1 | tail -20`
+Expected: FAIL with `WARNING: DATA RACE` (Stop's `conn.Close` vs listenLoop's `WaitForNotification` on the same `*pgx.Conn`). Record that this is the baseline the fix must clear. (If your environment somehow doesn't reproduce it in one run, use `-count=10`.)
+
+- [ ] **Step 2: Add a cancel field; drive shutdown by context**
+
+In `controlplane/nats/relay.go`, change the `Relay` struct: remove `listenerMu sync.Mutex` and `listener *pgx.Conn`; add a cancel func guarded for set-once:
+
+```go
+type Relay struct {
+	drain       *OutboxDrain
+	publisher   *Publisher
+	listenerDSN string
+	safetyNet   time.Duration
+	batchSize   int
+	stopCh      chan struct{}
+
+	cancelMu sync.Mutex
+	cancel   context.CancelFunc // set by Start, called by Stop to unblock the wait
+}
+```
+
+(Keep the `sync` import — it's still used by `cancelMu`. Remove `setListener`/`clearListener` methods entirely.)
+
+- [ ] **Step 3: Make `Start` own a cancelable context and close its own conn**
+
+In `Start`, derive a cancelable context once, store its cancel, and use it everywhere `ctx` was used for connect/LISTEN/listenLoop. Replace the `r.setListener(conn)` / `r.clearListener()` calls (they are deleted). The existing `_ = conn.Close(...)` calls in Start stay — they run in Start's own goroutine, which is now the ONLY place the conn is closed.
+
+At the top of `Start`, after the arg checks:
+
+```go
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	r.cancelMu.Lock()
+	r.cancel = cancel
+	r.cancelMu.Unlock()
+```
+
+Then use `runCtx` (not `ctx`) for: `r.shouldStop(runCtx)`, `pgx.Connect(runCtx, ...)`, `conn.Exec(runCtx, "LISTEN ...")`, `r.sleepOrStop(runCtx, ...)`, `r.processOutbox(runCtx)`, and `r.listenLoop(runCtx, conn)`. Delete the `r.setListener(conn)` line and the two `r.clearListener()` lines.
+
+- [ ] **Step 4: `listenLoop` — distinguish Stop-cancel from parent-cancel**
+
+In `listenLoop`, the `WaitForNotification` now unblocks via `runCtx` cancellation. Update the `context.Canceled` case so a Stop (stopCh closed) returns the clean `errStopRequested` while a parent-ctx cancel returns the ctx error:
+
+```go
+		case errors.Is(err, context.Canceled):
+			select {
+			case <-r.stopCh:
+				return errStopRequested // Stop() → clean shutdown (Start returns nil)
+			default:
+				return ctx.Err() // parent ctx canceled
+			}
+```
+
+(The passed `ctx` here is `runCtx`; `ctx.Err()` is `context.Canceled`.)
+
+- [ ] **Step 5: `Stop` cancels instead of closing the conn**
+
+Replace the body of `Stop` so it closes `stopCh` and calls the stored cancel — and never touches the conn:
+
+```go
+// Stop signals Start to exit and cancels the run context so any in-flight
+// WaitForNotification unblocks immediately. The listener conn is closed only by
+// Start's own goroutine, so there is no cross-goroutine use of the conn.
+// Idempotent.
+func (r *Relay) Stop() {
+	select {
+	case <-r.stopCh:
+		return // already stopped
+	default:
+		close(r.stopCh)
+	}
+	r.cancelMu.Lock()
+	cancel := r.cancel
+	r.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+```
+
+- [ ] **Step 6: Build + vet**
+
+Run: `go build ./controlplane/... && go vet ./controlplane/nats/`
+Expected: clean (no unused `listener`/`listenerMu`, imports still satisfied).
+
+- [ ] **Step 7: The race is gone (the whole point)**
+
+Run: `go test ./controlplane/nats/ -run TestRelayStop -race -count=10`
+Expected: PASS, no `WARNING: DATA RACE`.
+
+Run: `go test ./controlplane/server/ -run TestServer_Relay_Wired -race -count=5`
+Expected: PASS, no data race.
+
+- [ ] **Step 8: Shutdown still works + relay still drains**
+
+Run: `go test ./controlplane/nats/ -count=1` and `go test ./controlplane/server/ -count=1`
+Expected: PASS — relay still shuts down promptly on Stop, still drains on NOTIFY, reconnect path intact.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add controlplane/nats/relay.go
+git commit -m "fix(controlplane): relay shutdown cancels context instead of closing listener conn cross-goroutine (fixes -race)"
+```
+
+---
+
+## Task 2: INF-1 — dead-letter escalation + graph-error → run.failed
+
+**Files:**
+- Modify: `controlplane/nats/consumers.go`
+- Modify: `controlplane/worker/executor.go`
+- Modify: `controlplane/worker/runner.go`
+- Modify: `cmd/worker/main.go`
+- Test: `controlplane/worker/runner_ackdecision_test.go` (create), `controlplane/worker/execution_integration_test.go` (extend)
+
+**Interfaces:**
+- Consumes: `Client` (RunStarted/LatestCheckpoint/WriteCheckpoint/NodeCompleted/RunCompleted/RunFailed), `CounterExecutor`, `jetstream.Msg` metadata.
+- Produces:
+  - `nats.GraphExecutorMaxDeliver` (int const, = 5).
+  - `worker.Executor` interface (`Nodes() []string`, `Run(step int, state map[string]int) (map[string]int, error)`); `CounterExecutor` satisfies it.
+  - `worker.runClient` interface (the subset of `*Client` the runner uses); `*Client` satisfies it.
+  - `Runner.MaxDeliver int`; `NewRunner(js, cl, ex, maxDeliver)` OR a `MaxDeliver` field set post-construction (choose one, below).
+  - `Runner.ProcessOne(ctx, cmd) (acked bool, epoch int, err error)`.
+  - `ackDecision(acked bool, epoch, numDelivered, maxDeliver int) decision` (pure).
+
+- [ ] **Step 1: Write the failing `ackDecision` unit test**
+
+Create `controlplane/worker/runner_ackdecision_test.go` (internal `package worker` test so it can see the unexported helper):
+
+```go
+package worker
+
+import "testing"
+
+func TestAckDecision(t *testing.T) {
+	const max = 5
+	cases := []struct {
+		name         string
+		acked        bool
+		epoch        int
+		numDelivered int
+		want         decision
+	}{
+		{"success acks", true, 1, 3, decisionAck},
+		{"transient below max naks", false, 1, 4, decisionNak},
+		{"transient at max with lease escalates", false, 1, 5, decisionEscalate},
+		{"transient past max with lease escalates", false, 2, 6, decisionEscalate},
+		{"transient at max without lease just acks", false, 0, 5, decisionAck},
+		{"acked wins even at max", true, 0, 5, decisionAck},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ackDecision(c.acked, c.epoch, c.numDelivered, max); got != c.want {
+				t.Errorf("ackDecision(%v,%d,%d,%d) = %v, want %v", c.acked, c.epoch, c.numDelivered, max, got, c.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run it — fails (undefined)**
+
+Run: `go test ./controlplane/worker/ -run TestAckDecision -v`
+Expected: FAIL — `undefined: ackDecision` / `decision`.
+
+- [ ] **Step 3: Add the shared max-deliver const**
+
+In `controlplane/nats/consumers.go`, add near the top (package level):
+
+```go
+// GraphExecutorMaxDeliver bounds worker.graph.execute redeliveries. Shared so the
+// consumer config and the worker's dead-letter escalation threshold agree.
+const GraphExecutorMaxDeliver = 5
+```
+
+Change the `graph-executor` spec to use it: `maxDeliver: GraphExecutorMaxDeliver` (replacing the literal `5`).
+
+- [ ] **Step 4: Add the `ackDecision` helper**
+
+In `controlplane/worker/runner.go` add:
+
+```go
+// decision is what Start does with a JetStream message after ProcessOne.
+type decision int
+
+const (
+	decisionAck      decision = iota // Ack (success, terminal, or nothing to fail)
+	decisionNak                      // Nak (transient, redeliver)
+	decisionEscalate                 // RunFailed(epoch) then Ack (final delivery, still failing)
+)
+
+// ackDecision decides the post-ProcessOne action. A successful/terminal outcome
+// acks. A transient failure naks UNTIL the final allowed delivery; on that final
+// delivery it escalates to run.failed when the run was leased (epoch>0), else acks
+// (the run was never leased — nothing to fail; see design doc's known limitation).
+func ackDecision(acked bool, epoch, numDelivered, maxDeliver int) decision {
+	if acked {
+		return decisionAck
+	}
+	if numDelivered >= maxDeliver {
+		if epoch > 0 {
+			return decisionEscalate
+		}
+		return decisionAck
+	}
+	return decisionNak
+}
+```
+
+- [ ] **Step 4b: Run the unit test — passes**
+
+Run: `go test ./controlplane/worker/ -run TestAckDecision -v`
+Expected: PASS (all 6 subcases).
+
+- [ ] **Step 5: `Executor` interface + error return**
+
+In `controlplane/worker/executor.go`:
+
+```go
+// Executor is a graph the runner can execute step by step. Run returns the new
+// state, or a non-nil error for a DETERMINISTIC (poison) failure — the runner
+// turns that into run.failed and does NOT redeliver.
+type Executor interface {
+	Nodes() []string
+	Run(step int, state map[string]int) (map[string]int, error)
+}
+```
+
+Change `CounterExecutor.Run` to return `(map[string]int, error)` (always `nil` error):
+
+```go
+func (CounterExecutor) Run(step int, state map[string]int) (map[string]int, error) {
+	out := map[string]int{}
+	for k, v := range state {
+		out[k] = v
+	}
+	out["count"] = step + 1
+	return out, nil
+}
+```
+
+- [ ] **Step 6: Runner uses interfaces, MaxDeliver, epoch return, graph-error wiring**
+
+In `controlplane/worker/runner.go`:
+
+1. Add the client interface (methods the runner calls; match `*Client`'s signatures exactly — verify against `controlplane/worker/client.go`):
+
+```go
+// runClient is the subset of *Client the runner uses; an interface so tests can
+// inject failures. *Client satisfies it.
+type runClient interface {
+	RunStarted(ctx context.Context, runID uuid.UUID) (int, error)
+	LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (int, []byte, bool, error)
+	WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error
+	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
+	RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error
+	RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error
+}
+```
+
+(If any signature differs from `client.go`, use `client.go`'s actual signature — it is the source of truth.)
+
+2. Change the `Runner` struct: `cl runClient` (was `*Client`), `ex Executor` (was `CounterExecutor`), add `MaxDeliver int`. Update `NewRunner` to accept `ex Executor` and a `maxDeliver int` (keep `StopAfterNode` default -1):
+
+```go
+func NewRunner(js jetstream.JetStream, cl runClient, ex Executor, maxDeliver int) *Runner {
+	return &Runner{js: js, cl: cl, ex: ex, MaxDeliver: maxDeliver, StopAfterNode: -1}
+}
+```
+
+3. `ProcessOne` returns `(acked bool, epoch int, err error)`. Thread the leased `epoch` out (0 when `RunStarted` returned `ErrStaleLease` / never leased). At the graph-run step, handle a deterministic executor error:
+
+```go
+	state, rerr := r.ex.Run(step, state)
+	if rerr != nil {
+		// Poison run — record run.failed and stop; do NOT redeliver.
+		if ferr := r.cl.RunFailed(ctx, cmd.RunID, epoch, rerr.Error()); ferr != nil {
+			if errors.Is(ferr, ErrStaleLease) {
+				return true, epoch, nil // superseded — ack
+			}
+			return false, epoch, ferr // transient failure to record — nak, retry
+		}
+		return true, epoch, nil // failure recorded — ack
+	}
+```
+
+Update every `return` in `ProcessOne` to the 3-value form (add `epoch`; it is 0 before `RunStarted` succeeds, then the leased value).
+
+4. In `Start`, use `ackDecision` + escalation. Replace the ack/nak block:
+
+```go
+	acked, epoch, perr := r.ProcessOne(ctx, cmd)
+	meta, _ := msg.Metadata()
+	nd := 0
+	if meta != nil {
+		nd = int(meta.NumDelivered)
+	}
+	switch ackDecision(acked, epoch, nd, r.MaxDeliver) {
+	case decisionEscalate:
+		reason := "max deliveries exceeded"
+		if perr != nil {
+			reason += ": " + perr.Error()
+		}
+		if ferr := r.cl.RunFailed(ctx, cmd.RunID, epoch, reason); ferr != nil {
+			slog.Warn("runner: escalation RunFailed failed", "run_id", cmd.RunID, "err", ferr)
+		}
+		_ = msg.Ack()
+	case decisionNak:
+		_ = msg.Nak()
+	default: // decisionAck
+		_ = msg.Ack()
+	}
+```
+
+(Keep the existing malformed-command → Ack path and the `msg.InProgress()` call before work.)
+
+- [ ] **Step 7: `cmd/worker` passes the shared const**
+
+In `cmd/worker/main.go`, update the `NewRunner(...)` call to pass `nats.GraphExecutorMaxDeliver` as the new `maxDeliver` arg. (`cmd/worker` already imports the nats package.)
+
+- [ ] **Step 8: Build + the existing worker/nats/server suites still pass**
+
+Run: `go build ./... && go vet ./controlplane/... ./cmd/...`
+Expected: clean. Update ALL `NewRunner` call sites to the new 4-arg signature (verified callers): `cmd/worker/main.go:110` (production — pass `nats.GraphExecutorMaxDeliver`), and `controlplane/worker/execution_integration_test.go` lines **56, 109, 134** (the end-to-end + durable-resume tests — these call `ProcessOne` directly and don't exercise escalation, so any `maxDeliver` is fine; pass `nats.GraphExecutorMaxDeliver` for consistency). Also update any `ProcessOne` result destructuring to the new `(acked, epoch, err)` 3-value form. Fix anything that doesn't compile.
+
+Run: `go test ./controlplane/worker/ -run 'TestExecuteRunEndToEnd|TestDurableResume' -race -count=1 -v`
+Expected: PASS — the durable-resume proof still holds (node A once); the counter path is unaffected by the error return (always nil).
+
+- [ ] **Step 9: Write the graph-error integration test (INF-1b)**
+
+Add to `controlplane/worker/execution_integration_test.go` a `failingExecutor` and a test. Add `"fmt"` to that file's imports (it is not currently imported). The stub errors at node B:
+
+```go
+type failingExecutor struct{}
+
+func (failingExecutor) Nodes() []string { return []string{"A", "B"} }
+func (failingExecutor) Run(step int, state map[string]int) (map[string]int, error) {
+	if step == 1 {
+		return nil, fmt.Errorf("boom at node B")
+	}
+	out := map[string]int{}
+	for k, v := range state {
+		out[k] = v
+	}
+	out["count"] = step + 1
+	return out, nil
+}
+```
+
+Test `TestGraphErrorMarksRunFailed`: seed a queued run on a thread; build a `Runner` with `failingExecutor{}` and the real client; call `ProcessOne` (or drive one command through `Start`) once; assert:
+- returned `acked == true` (poison → ack, no redelivery),
+- run status ends `failed` (`SELECT status FROM runs WHERE id=$rid`),
+- node A ran exactly once (`execution_history` node_id='A' count == 1),
+- a `run.failed` event is in the outbox.
+
+- [ ] **Step 10: Write the escalation integration test (INF-1a)**
+
+Add a stub `runClient` that leases successfully (returns epoch 1) then returns a transient error from `WriteCheckpoint`, plus a `RunFailed` spy. Build a `Runner` with `MaxDeliver: 1` and this stub; drive the escalation path (`ackDecision(acked=false, epoch=1, numDelivered=1, maxDeliver=1)` → escalate) by invoking the same `Start`-branch logic (either through `Start` with an injected message whose `NumDelivered=1`, or by unit-testing the escalation wiring with the stub client). Assert `RunFailed` was called with `epoch=1` and the message was Acked (not Nak'd).
+
+(If driving a real `jetstream.Msg` with `NumDelivered=1` is impractical in-test, assert the wiring at the seam: given `ackDecision` returns `decisionEscalate`, `Start` calls `cl.RunFailed` then Acks. A small test that calls the extracted escalation branch with the stub client + a fake/asserted ack is acceptable — the pure `ackDecision` matrix (Step 1) already covers the decision itself.)
+
+- [ ] **Step 11: Full regression under race for the reliability paths**
+
+Run: `go test ./controlplane/worker/ -race -count=1`
+Run: `go test ./controlplane/... -count=1`
+Expected: all PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add controlplane/nats/consumers.go controlplane/worker/executor.go \
+  controlplane/worker/runner.go cmd/worker/main.go \
+  controlplane/worker/runner_ackdecision_test.go controlplane/worker/execution_integration_test.go
+git commit -m "feat(worker): dead-letter escalation + graph-error → run.failed (wire Client.RunFailed)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- INF-2 context-cancel shutdown + remove listener sharing → Task 1. ✓
+- INF-1b Executor interface + error → run.failed → Task 2 (steps 5,6,9). ✓
+- INF-1a epoch return + ackDecision + escalation + shared const → Task 2 (steps 1,3,4,6,10). ✓
+- runClient interface for testability → Task 2 (step 6). ✓
+- Known limitation (never-leased → ack, not fail) → encoded in `ackDecision` (epoch=0 at max → decisionAck) + tested (Step 1 "without lease just acks"). ✓
+
+**Placeholder scan:** no TBD. The one soft spot is Step 10's escalation integration — the plan gives an explicit fallback (seam test with the stub client) because driving a real `jetstream.Msg` with a forced `NumDelivered` is impractical; the pure `ackDecision` matrix (Step 1) is the primary decision coverage, and the seam test covers the `RunFailed`+Ack wiring. This is a deliberate, stated testing boundary, not a vague requirement.
+
+**Type consistency:** `ackDecision(acked bool, epoch, numDelivered, maxDeliver int) decision` used identically in Step 1 (test), Step 4 (def), Step 6 (Start). `ProcessOne`'s new `(acked, epoch, err)` signature is threaded through all its returns (Step 6.3) and its callers (Step 8). `runClient` method set matches `client.go` (Step 6.1 says verify against source). `NewRunner(js, cl, ex, maxDeliver)` updated at its only production caller (`cmd/worker`, Step 7) and test callers (Step 8).
+
+**Open risks for the implementer:**
+- Task 1: after removing the listener sharing, confirm the reconnect path still closes its conn (the existing `_ = conn.Close(...)` lines in Start stay). Do not remove those.
+- Task 1: `runCtx` must be used for `WaitForNotification`'s parent so Stop's cancel unblocks it; if the wait still derives from the raw `ctx`, Stop won't unblock and the test will hang.
+- Task 2: `msg.Metadata()` returns `(*MessageMetadata, error)`; `NumDelivered` is `uint64` — cast to int. Guard the nil-metadata case (Step 6.4 does).
+
+---
+
+## Notes for the implementer
+
+- Do NOT reintroduce any cross-goroutine use of the relay's listener conn — the whole INF-2 fix is that the conn is closed only by Start's own goroutine.
+- The counter executor never errors; the graph-error path is exercised only by `failingExecutor` in tests. That is expected — the interface exists for the real graph engine (future).
+- Do not push/PR/merge without explicit approval; this branch is stacked on the (open) PR #217 and will be rebased after it merges.

--- a/controlplane/docs/superpowers/specs/2026-07-26-worker-reliability-inf1-inf2-design.md
+++ b/controlplane/docs/superpowers/specs/2026-07-26-worker-reliability-inf1-inf2-design.md
@@ -1,0 +1,179 @@
+# Worker reliability follow-ups — INF-1 (dead-letter + graph-error) and INF-2 (relay race)
+
+**Date:** 2026-07-26
+**Branch:** `feat/controlplane-reliability` (stacked on `feat/controlplane-worker-execution`; rebase onto main after PR #217 merges)
+**Status:** approved design, pending implementation plan
+
+## Context
+
+The worker execution path (PR #217) shipped a thin counter-graph slice. Its final
+review flagged two reliability gaps the user prioritized:
+
+- **INF-1** — two legs of the stated reliability spine are unwired: (a) exhausting
+  `max_deliver` silently drops the run (no `run.failed`); (b) a deterministic graph
+  error has no `run.failed`→Ack path (`Client.RunFailed` is dead code; the counter
+  executor can't error).
+- **INF-2** — two pre-existing `relay.go` data races (only under `-race`; CI does
+  not run `-race`). Root cause: `Relay.Stop()` closes the listener `pgx.Conn` from
+  a different goroutine to unblock an in-flight `WaitForNotification`, but a
+  `pgx.Conn` is not safe for concurrent `Close`+`Wait`. The existing `listenerMu`
+  guards only the pointer, not the conn's internals.
+
+Both are independent (different files/packages) and land as two commits on one
+branch / one PR.
+
+## INF-2 — relay shutdown without a cross-goroutine conn close
+
+**File:** `controlplane/nats/relay.go`
+
+Current shutdown (racy): `Start` records the listener conn via `setListener`;
+`Stop()` reads it under `listenerMu` and calls `conn.Close()` from the caller's
+goroutine while `listenLoop` is inside `conn.WaitForNotification` on the same conn.
+The mutex protects the `r.listener` pointer but not the concurrent use of the conn
+itself — hence the `-race` failures in `TestRelayStop` and `TestServer_Relay_Wired`.
+
+**Fix:** unblock the wait via **context cancellation**, so the conn is only ever
+touched by its owning goroutine.
+
+- `Start(ctx)` derives `runCtx, cancel := context.WithCancel(ctx)` and stores
+  `cancel` on the Relay (guarded or set-once before the goroutine can call Stop).
+- `listenLoop` uses `runCtx` for `WaitForNotification` (keeping the existing
+  per-iteration wait timeout as a child of `runCtx`). pgx returns from
+  `WaitForNotification` when its context is canceled.
+- `Stop()` closes `stopCh` (unchanged, idempotent) **and calls `cancel()`** —
+  it no longer touches the conn at all.
+- The **listener goroutine** (inside `Start`) closes its own conn on loop exit
+  (the existing reconnect-loop close path + a final close when `runCtx` is done).
+- Remove `setListener`, `clearListener`, `r.listener`, `listenerMu` — the conn
+  never escapes its owning goroutine, so no shared-conn state remains.
+
+**Done-criteria:** `go test ./controlplane/nats/ -run TestRelayStop -race -count=1`
+and `go test ./controlplane/server/ -run TestServer_Relay_Wired -race -count=1`
+pass with no data race; the relay still shuts down promptly (Stop unblocks the
+wait within the loop's timeout, ideally immediately via cancel) and still drains
+on notify during normal operation.
+
+## INF-1 — dead-letter escalation + graph-error → run.failed
+
+**Files:** `controlplane/worker/executor.go`, `controlplane/worker/runner.go`,
+`controlplane/nats/consumers.go`.
+
+### Shared max-deliver constant
+
+`maxDeliver: 5` currently lives only on the `graph-executor` `consumerSpec`. Expose
+it as a package const so the consumer config and the runner's escalation threshold
+share one source of truth:
+
+- `controlplane/nats/consumers.go`: `const GraphExecutorMaxDeliver = 5`, and the
+  `graph-executor` spec uses `maxDeliver: GraphExecutorMaxDeliver`.
+- The runner takes a `MaxDeliver int`; `cmd/worker` passes
+  `nats.GraphExecutorMaxDeliver`; tests may set a small value.
+
+### 1b — graph error → run.failed (Executor interface)
+
+- `executor.go`: define
+  ```go
+  type Executor interface {
+      Nodes() []string
+      Run(step int, state map[string]int) (map[string]int, error)
+  }
+  ```
+  `CounterExecutor.Run` returns `(…, nil)` (never errors). This is the seam a
+  failing test stub plugs into.
+- `runner.go`: `Runner.ex` becomes `Executor` (interface); `NewRunner(js, cl,
+  ex Executor)`.
+- `runner.go`: `Runner.cl` becomes a minimal `runClient` interface (the exact
+  subset of `*Client` methods the runner calls: `RunStarted`, `LatestCheckpoint`,
+  `WriteCheckpoint`, `NodeCompleted`, `RunCompleted`, `RunFailed`). The real
+  `*Client` satisfies it; tests inject a stub that returns a transient error after
+  a successful lease, so the 1a escalation path is deterministically testable.
+  This mirrors `ex` becoming an interface and adds no production behavior change.
+- In `ProcessOne`, `state, rerr := r.ex.Run(step, state)`. On `rerr != nil` (a
+  deterministic graph error — a poison run, not transient): post
+  `r.cl.RunFailed(ctx, cmd.RunID, epoch, rerr.Error())`, then return `acked=true`
+  (do NOT redeliver a poison graph). If `RunFailed` itself returns `ErrStaleLease`
+  (superseded) → `acked=true`; if it returns a transient error → `acked=false`
+  (Nak — the failure record didn't persist, retry).
+
+### 1a — max-deliver escalation → run.failed
+
+- `ProcessOne` returns the **leased epoch** so `Start` can mark the run failed on
+  the last delivery. New signature:
+  `func (r *Runner) ProcessOne(ctx, cmd) (acked bool, epoch int, err error)`.
+  `epoch` is the value from `RunStarted` (0 when the run was never leased — e.g.
+  `RunStarted` returned `ErrStaleLease`, meaning the run is already terminal/gone).
+- Extract the terminal decision into a **pure, unit-testable helper**:
+  ```go
+  // ackDecision decides what to do with a JetStream message after ProcessOne.
+  //   acked            → ProcessOne's acked return
+  //   epoch            → leased epoch (0 = never leased)
+  //   numDelivered     → msg.Metadata().NumDelivered
+  //   maxDeliver       → the consumer's max_deliver
+  // returns one of: ackOnly | nak | escalateFail (RunFailed then Ack)
+  func ackDecision(acked bool, epoch, numDelivered, maxDeliver int) decision
+  ```
+  Rules: `acked` → `ackOnly`. Else (transient) if `numDelivered >= maxDeliver` →
+  `escalateFail` when `epoch > 0`, else `ackOnly` (nothing to fail — run gone).
+  Else → `nak`.
+- `Start`'s consume handler applies it: on `escalateFail`, best-effort
+  `r.cl.RunFailed(ctx, runID, epoch, "max deliveries exceeded: "+err)` then
+  `msg.Ack()`; on `nak`, `msg.Nak()`; on `ackOnly`, `msg.Ack()`.
+- `Client.RunFailed` is now called from both the 1a and 1b paths (was dead code).
+
+## Testing
+
+Testcontainers Postgres + embedded NATS (no build tag; standard CI). No assertion
+weakening.
+
+- **INF-2:** `TestRelayStop` (nats) and `TestServer_Relay_Wired` (server) pass
+  under `-race -count=1`. Add a focused assertion that `Stop()` returns promptly
+  and a subsequent `Start` still works (no leaked/closed-twice conn).
+- **INF-1b:** a `failingExecutor` stub whose `Run` errors at node B. Drive a real
+  run through the runner; assert: run status ends `failed`, node A's
+  `execution_history` row exists (A ran), the message is **acked** (no infinite
+  redelivery), and `run.failed` is in the outbox.
+- **INF-1a:** unit-test `ackDecision` across the matrix:
+  `(acked=true,*)→ackOnly`; `(acked=false, epoch>0, numDelivered>=max)→escalateFail`;
+  `(acked=false, epoch=0, numDelivered>=max)→ackOnly`;
+  `(acked=false, numDelivered<max)→nak`. Plus one integration check that the
+  escalation path actually calls `RunFailed` + acks (e.g. a runner with
+  `MaxDeliver=1` and an injected transient failure after lease → run ends `failed`
+  via escalation on the first/last delivery).
+- Full `go test ./controlplane/... -count=1` green.
+
+## Files touched
+
+- `controlplane/nats/relay.go` — context-cancel shutdown; drop listener-conn sharing.
+- `controlplane/nats/consumers.go` — `GraphExecutorMaxDeliver` const.
+- `controlplane/worker/executor.go` — `Executor` interface + error return.
+- `controlplane/worker/runner.go` — interface field, epoch return, `ackDecision`
+  helper, escalation + graph-error wiring, `MaxDeliver` field.
+- `cmd/worker/main.go` — pass `nats.GraphExecutorMaxDeliver` to the runner.
+- Tests: `controlplane/nats/*relay*_test.go` (or existing), `controlplane/worker/*_test.go`.
+
+## Known limitation of worker-side escalation (recorded, not hidden)
+
+Escalation to `run.failed` requires a **leased epoch**. Two exhaustion cases are
+therefore NOT covered by this design, and both are acceptable-but-noted:
+
+1. **Run never leased.** If `RunStarted` transient-fails on every delivery to
+   exhaustion (e.g. the DB is down the entire time), `epoch=0`, so escalation
+   cannot call the epoch-fenced `RunFailed`. The message is Acked and the run stays
+   `queued` — NOT marked failed, and nothing re-dispatches it (run-processor only
+   dispatches on `run.created`). This is strictly better than today (which silently
+   drops every exhausted run) but leaves a stuck-`queued` run in this narrow case.
+   A lease-free "fail a stuck queued run" path (admin retry, or a queued-run reaper)
+   is a deliberate follow-up, not part of this slice.
+2. **Worker crashes on its own last delivery**, before it can post `run.failed`.
+   Same outcome as JetStream dropping the message. The advisory-consumer backstop
+   (below) would close this; deferred.
+
+## Out of scope (recorded)
+
+- The advisory-consumer reaper backstop for the worker-crashes-on-its-last-delivery
+  edge (chosen against: worker-side escalation covers the common case; the crash-on-
+  last-delivery gap is an edge-of-edge, deferred).
+- `input` seeding into the command; the checkpoint-before-node_completed
+  observability gap (separate follow-ups from PR #217's review).
+- A real graph engine (the `Executor` interface is added now, but the only
+  implementation remains the counter + a test stub).

--- a/controlplane/docs/superpowers/specs/2026-07-26-worker-reliability-inf1-inf2-design.md
+++ b/controlplane/docs/superpowers/specs/2026-07-26-worker-reliability-inf1-inf2-design.md
@@ -156,14 +156,18 @@ weakening.
 Escalation to `run.failed` requires a **leased epoch**. Two exhaustion cases are
 therefore NOT covered by this design, and both are acceptable-but-noted:
 
-1. **Run never leased.** If `RunStarted` transient-fails on every delivery to
-   exhaustion (e.g. the DB is down the entire time), `epoch=0`, so escalation
-   cannot call the epoch-fenced `RunFailed`. The message is Acked and the run stays
-   `queued` — NOT marked failed, and nothing re-dispatches it (run-processor only
-   dispatches on `run.created`). This is strictly better than today (which silently
-   drops every exhausted run) but leaves a stuck-`queued` run in this narrow case.
-   A lease-free "fail a stuck queued run" path (admin retry, or a queued-run reaper)
-   is a deliberate follow-up, not part of this slice.
+1. **Run not leased on the final delivery.** Escalation reads the epoch from the
+   *current* delivery's `RunStarted`; if that call transient-fails on the final
+   delivery, `epoch=0`, so escalation cannot call the epoch-fenced `RunFailed`. The
+   message is Acked and the run is NOT marked failed. Two sub-cases:
+   - **Never leased at all** (e.g. DB down the entire time): the run stays `queued`.
+   - **Leased on an earlier delivery, then fails to re-lease on the final one**
+     (e.g. a transient blip only on the last attempt): the run stays `in_progress`.
+   Either way nothing re-dispatches it (run-processor only dispatches on
+   `run.created`). This is strictly better than today (which silently drops every
+   exhausted run) but leaves a stuck run in this narrow case. A lease-free "fail a
+   stuck run" path (admin retry, or a queued/in_progress reaper) is a deliberate
+   follow-up, not part of this slice.
 2. **Worker crashes on its own last delivery**, before it can post `run.failed`.
    Same outcome as JetStream dropping the message. The advisory-consumer backstop
    (below) would close this; deferred.

--- a/controlplane/nats/consumers.go
+++ b/controlplane/nats/consumers.go
@@ -9,6 +9,10 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
+// GraphExecutorMaxDeliver bounds worker.graph.execute redeliveries. Shared so the
+// consumer config and the worker's dead-letter escalation threshold agree.
+const GraphExecutorMaxDeliver = 5
+
 // consumerSpec is one of the seven durable JetStream consumers from
 // nats.d2 (consumers shape). Each binds to a stream with a filter
 // subject (when the stream carries more than one subject family) and
@@ -26,7 +30,7 @@ type consumerSpec struct {
 // WORKER_COMMANDS by the command family they handle.
 var tenantConsumers = []consumerSpec{
 	{name: "run-processor", stream: "RUNS", ackWait: 30 * time.Second},
-	{name: "graph-executor", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.graph.execute", ackWait: 5 * time.Minute, maxDeliver: 5},
+	{name: "graph-executor", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.graph.execute", ackWait: 5 * time.Minute, maxDeliver: GraphExecutorMaxDeliver},
 	{name: "llm-worker", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.llm.invoke", ackWait: 2 * time.Minute},
 	{name: "tool-worker", stream: "WORKER_COMMANDS", filter: "duragraph.worker_commands.worker.tool.execute", ackWait: 1 * time.Minute},
 }

--- a/controlplane/nats/relay.go
+++ b/controlplane/nats/relay.go
@@ -48,10 +48,12 @@ const (
 // that a pooler would drop between TXs) and uses the main pgxpool for
 // the drain itself. A Stop signal or ctx cancel cleanly ends both.
 //
-// Stop closes the listener conn from a separate goroutine so any
-// in-flight WaitForNotification unblocks immediately — without this the
-// relay would wait up to safetyNet (default 30s) before noticing the
-// stop signal.
+// Stop cancels the run context so any in-flight WaitForNotification
+// unblocks immediately — without this the relay would wait up to
+// safetyNet (default 30s) before noticing the stop signal. The listener
+// conn itself is only ever touched by Start's own goroutine (pgx.Conn is
+// not safe for concurrent Close + Wait), so shutdown is driven entirely
+// by context cancellation rather than a cross-goroutine conn.Close.
 type Relay struct {
 	drain       *OutboxDrain
 	publisher   *Publisher
@@ -60,8 +62,8 @@ type Relay struct {
 	batchSize   int
 	stopCh      chan struct{}
 
-	listenerMu sync.Mutex
-	listener   *pgx.Conn
+	cancelMu sync.Mutex
+	cancel   context.CancelFunc // set by Start, called by Stop to unblock the wait
 }
 
 // NewRelay constructs the relay.
@@ -112,28 +114,32 @@ func (r *Relay) Start(ctx context.Context) error {
 		return errors.New("relay: drain and publisher are required")
 	}
 
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	r.cancelMu.Lock()
+	r.cancel = cancel
+	r.cancelMu.Unlock()
+
 	backoff := initialReconnectBackoff
 	for {
-		if err := r.shouldStop(ctx); err != nil {
+		if err := r.shouldStop(runCtx); err != nil {
 			return err
 		}
 
-		conn, err := pgx.Connect(ctx, r.listenerDSN)
+		conn, err := pgx.Connect(runCtx, r.listenerDSN)
 		if err != nil {
 			slog.Error("relay: listener connect failed", "err", err, "retry_in", backoff)
-			if waitErr := r.sleepOrStop(ctx, backoff); waitErr != nil {
+			if waitErr := r.sleepOrStop(runCtx, backoff); waitErr != nil {
 				return waitErr
 			}
 			backoff = nextBackoff(backoff)
 			continue
 		}
-		r.setListener(conn)
 
-		if _, err := conn.Exec(ctx, "LISTEN "+outboxNotifyChannel); err != nil {
+		if _, err := conn.Exec(runCtx, "LISTEN "+outboxNotifyChannel); err != nil {
 			slog.Error("relay: LISTEN failed", "err", err, "retry_in", backoff)
 			_ = conn.Close(context.Background())
-			r.clearListener()
-			if waitErr := r.sleepOrStop(ctx, backoff); waitErr != nil {
+			if waitErr := r.sleepOrStop(runCtx, backoff); waitErr != nil {
 				return waitErr
 			}
 			backoff = nextBackoff(backoff)
@@ -147,13 +153,12 @@ func (r *Relay) Start(ctx context.Context) error {
 
 		// Step 5: startup backlog drain — rows may have been written
 		// while we were down. Process before entering the wait loop.
-		if err := r.processOutbox(ctx); err != nil {
+		if err := r.processOutbox(runCtx); err != nil {
 			slog.Error("relay: initial drain failed", "err", err)
 		}
 
-		loopErr := r.listenLoop(ctx, conn)
+		loopErr := r.listenLoop(runCtx, conn)
 		_ = conn.Close(context.Background())
-		r.clearListener()
 
 		if errors.Is(loopErr, context.Canceled) || errors.Is(loopErr, context.DeadlineExceeded) {
 			return loopErr
@@ -191,7 +196,12 @@ func (r *Relay) listenLoop(ctx context.Context, conn *pgx.Conn) error {
 		case errors.Is(err, context.DeadlineExceeded):
 			// Safety-net interval elapsed — drain anyway.
 		case errors.Is(err, context.Canceled):
-			return ctx.Err()
+			select {
+			case <-r.stopCh:
+				return errStopRequested // Stop() → clean shutdown (Start returns nil)
+			default:
+				return ctx.Err() // parent ctx canceled
+			}
 		default:
 			return fmt.Errorf("wait for notification: %w", err)
 		}
@@ -202,8 +212,10 @@ func (r *Relay) listenLoop(ctx context.Context, conn *pgx.Conn) error {
 	}
 }
 
-// Stop signals Start to exit and closes the listener connection so
-// any in-flight WaitForNotification unblocks immediately. Idempotent.
+// Stop signals Start to exit and cancels the run context so any in-flight
+// WaitForNotification unblocks immediately. The listener conn is closed only
+// by Start's own goroutine, so there is no cross-goroutine use of the conn.
+// Idempotent.
 func (r *Relay) Stop() {
 	select {
 	case <-r.stopCh:
@@ -211,31 +223,12 @@ func (r *Relay) Stop() {
 	default:
 		close(r.stopCh)
 	}
-	// Close the listener conn from this goroutine to unblock a
-	// WaitForNotification in listenLoop. Closing after Start has
-	// released the conn is a no-op (clearListener set it to nil).
-	r.listenerMu.Lock()
-	conn := r.listener
-	r.listener = nil
-	r.listenerMu.Unlock()
-	if conn != nil {
-		_ = conn.Close(context.Background())
+	r.cancelMu.Lock()
+	cancel := r.cancel
+	r.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
-}
-
-// setListener records the current listener conn so Stop can close it.
-func (r *Relay) setListener(conn *pgx.Conn) {
-	r.listenerMu.Lock()
-	r.listener = conn
-	r.listenerMu.Unlock()
-}
-
-// clearListener drops the listener conn reference. Called after Start
-// itself closes the conn (normal reconnect-loop cycle and shutdown).
-func (r *Relay) clearListener() {
-	r.listenerMu.Lock()
-	r.listener = nil
-	r.listenerMu.Unlock()
 }
 
 func (r *Relay) shouldStop(ctx context.Context) error {

--- a/controlplane/worker/client_test.go
+++ b/controlplane/worker/client_test.go
@@ -55,11 +55,17 @@ func TestCounterExecutor(t *testing.T) {
 	if got := ex.Nodes(); len(got) != 2 || got[0] != "A" || got[1] != "B" {
 		t.Fatalf("nodes: %v", got)
 	}
-	st := ex.Run(0, map[string]int{})
+	st, err := ex.Run(0, map[string]int{})
+	if err != nil {
+		t.Fatalf("A: unexpected error: %v", err)
+	}
 	if st["count"] != 1 {
 		t.Errorf("A: want count=1, got %d", st["count"])
 	}
-	st = ex.Run(1, st)
+	st, err = ex.Run(1, st)
+	if err != nil {
+		t.Fatalf("B: unexpected error: %v", err)
+	}
 	if st["count"] != 2 {
 		t.Errorf("B: want count=2, got %d", st["count"])
 	}

--- a/controlplane/worker/execution_integration_test.go
+++ b/controlplane/worker/execution_integration_test.go
@@ -3,6 +3,7 @@ package worker_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -53,7 +54,7 @@ func TestExecuteRunEndToEnd(t *testing.T) {
 	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
 		t.Fatalf("register: %v", err)
 	}
-	runner := worker.NewRunner(js, cl, worker.CounterExecutor{})
+	runner := worker.NewRunner(js, cl, worker.CounterExecutor{}, dnats.GraphExecutorMaxDeliver)
 	go func() { _ = runner.Start(ctx) }()
 
 	// Publish the REAL relay envelope for run.created onto RUNS — the run id
@@ -106,10 +107,10 @@ func TestDurableResume(t *testing.T) {
 	if err := cl1.Register(ctx, []string{"counter"}, 1); err != nil {
 		t.Fatalf("register worker1: %v", err)
 	}
-	r1 := worker.NewRunner(nil, cl1, worker.CounterExecutor{})
+	r1 := worker.NewRunner(nil, cl1, worker.CounterExecutor{}, dnats.GraphExecutorMaxDeliver)
 	r1.StopAfterNode = 0 // simulate death before starting node index 1 (B)
 
-	acked1, err1 := r1.ProcessOne(ctx, cmd)
+	acked1, _, err1 := r1.ProcessOne(ctx, cmd)
 	if err1 != nil {
 		t.Fatalf("first ProcessOne: unexpected error: %v", err1)
 	}
@@ -131,9 +132,9 @@ func TestDurableResume(t *testing.T) {
 	if err := cl2.Register(ctx, []string{"counter"}, 1); err != nil {
 		t.Fatalf("register worker2: %v", err)
 	}
-	r2 := worker.NewRunner(nil, cl2, worker.CounterExecutor{})
+	r2 := worker.NewRunner(nil, cl2, worker.CounterExecutor{}, dnats.GraphExecutorMaxDeliver)
 
-	acked2, err2 := r2.ProcessOne(ctx, cmd)
+	acked2, _, err2 := r2.ProcessOne(ctx, cmd)
 	if err2 != nil {
 		t.Fatalf("second ProcessOne: unexpected error: %v", err2)
 	}
@@ -152,6 +153,69 @@ func TestDurableResume(t *testing.T) {
 	// lease is now epoch 2, so its event is fenced off as stale.
 	if err := cl1.NodeCompleted(ctx, rid, 1, "B", "tool"); !errors.Is(err, worker.ErrStaleLease) {
 		t.Errorf("dead worker's replayed write: want ErrStaleLease, got %v", err)
+	}
+}
+
+// failingExecutor is a 2-step graph (A, B) whose node B is deterministically
+// poison: it always errors instead of returning a new state. Used to prove
+// the graph-error → run.failed path (INF-1b) without touching the real graph
+// engine (a later cycle).
+type failingExecutor struct{}
+
+func (failingExecutor) Nodes() []string { return []string{"A", "B"} }
+func (failingExecutor) Run(step int, state map[string]int) (map[string]int, error) {
+	if step == 1 {
+		return nil, fmt.Errorf("boom at node B")
+	}
+	out := map[string]int{}
+	for k, v := range state {
+		out[k] = v
+	}
+	out["count"] = step + 1
+	return out, nil
+}
+
+// TestGraphErrorMarksRunFailed proves a deterministic graph error becomes
+// run.failed instead of a silent drop or an infinite redelivery loop
+// (INF-1b): node A completes and checkpoints normally, node B's executor
+// error is recorded via RunFailed and the message is Acked (not Nak'd) so
+// JetStream never redelivers a poison command.
+func TestGraphErrorMarksRunFailed(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter"}
+
+	wid := uuid.New()
+	cl := worker.NewClient(serverURL, wid, nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(nil, cl, failingExecutor{}, dnats.GraphExecutorMaxDeliver)
+
+	acked, epoch, err := runner.ProcessOne(ctx, cmd)
+	if err != nil {
+		t.Fatalf("ProcessOne: unexpected error: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (poison run recorded, no redelivery), got false")
+	}
+	if epoch != 1 {
+		t.Errorf("ProcessOne: want epoch=1 (leased), got %d", epoch)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "failed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	var nOutbox int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.failed'`, rid).Scan(&nOutbox); err != nil {
+		t.Fatalf("select outbox run.failed: %v", err)
+	}
+	if nOutbox != 1 {
+		t.Errorf("outbox[run.failed]: want 1 row, got %d", nOutbox)
 	}
 }
 

--- a/controlplane/worker/executor.go
+++ b/controlplane/worker/executor.go
@@ -4,18 +4,26 @@
 // real graph engine is a later cycle.
 package worker
 
+// Executor is a graph the runner can execute step by step. Run returns the new
+// state, or a non-nil error for a DETERMINISTIC (poison) failure — the runner
+// turns that into run.failed and does NOT redeliver.
+type Executor interface {
+	Nodes() []string
+	Run(step int, state map[string]int) (map[string]int, error)
+}
+
 type CounterExecutor struct{}
 
 // Nodes returns the ordered node ids.
 func (CounterExecutor) Nodes() []string { return []string{"A", "B"} }
 
 // Run applies node[step] to state and returns the new state. Node A → count=1,
-// node B → count=2 (idempotent given step).
-func (CounterExecutor) Run(step int, state map[string]int) map[string]int {
+// node B → count=2 (idempotent given step). Never errors.
+func (CounterExecutor) Run(step int, state map[string]int) (map[string]int, error) {
 	out := map[string]int{}
 	for k, v := range state {
 		out[k] = v
 	}
 	out["count"] = step + 1
-	return out
+	return out, nil
 }

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -32,12 +32,55 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
+// decision is what Start does with a JetStream message after ProcessOne.
+type decision int
+
+const (
+	decisionAck      decision = iota // Ack (success, terminal, or nothing to fail)
+	decisionNak                      // Nak (transient, redeliver)
+	decisionEscalate                 // RunFailed(epoch) then Ack (final delivery, still failing)
+)
+
+// ackDecision decides the post-ProcessOne action. A successful/terminal outcome
+// acks. A transient failure naks UNTIL the final allowed delivery; on that final
+// delivery it escalates to run.failed when the run was leased (epoch>0), else acks
+// (the run was never leased — nothing to fail; see design doc's known limitation).
+func ackDecision(acked bool, epoch, numDelivered, maxDeliver int) decision {
+	if acked {
+		return decisionAck
+	}
+	if numDelivered >= maxDeliver {
+		if epoch > 0 {
+			return decisionEscalate
+		}
+		return decisionAck
+	}
+	return decisionNak
+}
+
+// runClient is the subset of *Client the runner uses; an interface so tests can
+// inject failures. *Client satisfies it.
+type runClient interface {
+	RunStarted(ctx context.Context, runID uuid.UUID) (int, error)
+	LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (int, []byte, bool, error)
+	WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error
+	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
+	RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error
+	RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error
+}
+
 // Runner consumes worker.graph.execute commands and executes them against
-// CounterExecutor.
+// an Executor.
 type Runner struct {
 	js jetstream.JetStream
-	cl *Client
-	ex CounterExecutor
+	cl runClient
+	ex Executor
+
+	// MaxDeliver is the graph-executor consumer's configured MaxDeliver
+	// (nats.GraphExecutorMaxDeliver in production). Used by ackDecision to
+	// decide when a transient failure has exhausted its redeliveries and
+	// must escalate to run.failed instead of Nak'ing forever.
+	MaxDeliver int
 
 	// StopAfterNode is a test hook that simulates a worker crash: when >= 0,
 	// ProcessOne returns (acked=false, nil) — without acking, without
@@ -49,10 +92,12 @@ type Runner struct {
 	StopAfterNode int
 }
 
-// NewRunner builds a Runner bound to js, cl, and ex. StopAfterNode defaults
-// to -1 (disabled).
-func NewRunner(js jetstream.JetStream, cl *Client, ex CounterExecutor) *Runner {
-	return &Runner{js: js, cl: cl, ex: ex, StopAfterNode: -1}
+// NewRunner builds a Runner bound to js, cl, and ex, with maxDeliver as the
+// dead-letter escalation threshold (nats.GraphExecutorMaxDeliver in
+// production — must match the graph-executor consumer's MaxDeliver).
+// StopAfterNode defaults to -1 (disabled).
+func NewRunner(js jetstream.JetStream, cl runClient, ex Executor, maxDeliver int) *Runner {
+	return &Runner{js: js, cl: cl, ex: ex, MaxDeliver: maxDeliver, StopAfterNode: -1}
 }
 
 // GraphCommand is the worker.graph.execute payload shape, matching what
@@ -70,8 +115,9 @@ type GraphCommand struct {
 // Start binds the graph-executor durable consumer (WORKER_COMMANDS,
 // filter worker.graph.execute) and processes messages until ctx is
 // cancelled. Each message: InProgress() (so JetStream doesn't consider it
-// stalled while we work), decode, ProcessOne, then Ack on success/terminal
-// or Nak to let JetStream redeliver.
+// stalled while we work), decode, ProcessOne, then ackDecision picks Ack,
+// Nak (transient, redeliver), or Escalate (final delivery still failing —
+// record run.failed via RunFailed, then Ack so it doesn't redeliver forever).
 func (r *Runner) Start(ctx context.Context) error {
 	cons, err := r.js.Consumer(ctx, "WORKER_COMMANDS", "graph-executor")
 	if err != nil {
@@ -87,14 +133,23 @@ func (r *Runner) Start(ctx context.Context) error {
 			_ = msg.Ack() // malformed: nothing to retry, ack so it doesn't jam the consumer
 			return
 		}
-		acked, perr := r.ProcessOne(ctx, cmd)
+		acked, epoch, perr := r.ProcessOne(ctx, cmd)
 		if perr != nil {
 			slog.Warn("runner: processOne error", "run_id", cmd.RunID, "acked", acked, "err", perr)
 		}
-		if acked {
+		meta, _ := msg.Metadata()
+		nd := 0
+		if meta != nil {
+			nd = int(meta.NumDelivered)
+		}
+		switch ackDecision(acked, epoch, nd, r.MaxDeliver) {
+		case decisionEscalate:
+			r.escalate(ctx, cmd.RunID, epoch, perr)
 			_ = msg.Ack()
-		} else {
+		case decisionNak:
 			_ = msg.Nak()
+		default: // decisionAck
+			_ = msg.Ack()
 		}
 	})
 	if err != nil {
@@ -105,12 +160,32 @@ func (r *Runner) Start(ctx context.Context) error {
 	return nil
 }
 
-// ProcessOne executes cmd's run against CounterExecutor with checkpoint
-// resume, following the control flow documented on Runner and in the task
-// brief. Returns acked=true when the message should be Acked (success,
-// terminal/stale-lease outcomes with nothing left to do) and acked=false
-// when it should be Nak'd for redelivery (transient errors, or the
-// StopAfterNode test hook simulating a crash).
+// escalate records a run as failed after its worker.graph.execute command has
+// exhausted every allowed redelivery (ackDecision returned decisionEscalate).
+// It is the dead-letter path: without it, a command that keeps failing
+// transiently would either redeliver forever or, once JetStream gives up,
+// silently vanish with the run stuck in_progress. Extracted from Start so
+// the escalation wiring itself (not just the ackDecision matrix) is
+// independently testable.
+func (r *Runner) escalate(ctx context.Context, runID uuid.UUID, epoch int, perr error) {
+	reason := "max deliveries exceeded"
+	if perr != nil {
+		reason += ": " + perr.Error()
+	}
+	if ferr := r.cl.RunFailed(ctx, runID, epoch, reason); ferr != nil {
+		slog.Warn("runner: escalation RunFailed failed", "run_id", runID, "err", ferr)
+	}
+}
+
+// ProcessOne executes cmd's run against r.ex with checkpoint resume,
+// following the control flow documented on Runner and in the task brief.
+// Returns acked=true when the message should be Acked (success,
+// terminal/stale-lease outcomes with nothing left to do, or a poison
+// deterministic executor error recorded as run.failed) and acked=false when
+// it should be Nak'd for redelivery (transient errors, or the StopAfterNode
+// test hook simulating a crash). epoch is the lease epoch obtained from
+// RunStarted — 0 if the run was never leased (RunStarted failed before
+// returning one).
 //
 // Exported (not the brief's literal lowercase "processOne") because the
 // integration tests live in the external worker_test package alongside
@@ -119,22 +194,22 @@ func (r *Runner) Start(ctx context.Context) error {
 // call an unexported method but could not reach that harness, since Go
 // external test packages are not importable from internal ones. Behavior
 // matches the brief's processOne exactly; only the exported name differs.
-func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, err error) {
-	epoch, err := r.cl.RunStarted(ctx, cmd.RunID)
+func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, epoch int, err error) {
+	epoch, err = r.cl.RunStarted(ctx, cmd.RunID)
 	if err != nil {
 		if errors.Is(err, ErrStaleLease) {
 			// Run is already terminal (or was claimed and finished by
 			// someone else) — nothing to do. Ack.
-			return true, nil
+			return true, 0, nil
 		}
-		return false, err // transient — Nak, redeliver
+		return false, 0, err // transient — Nak, redeliver
 	}
 
 	resumeFrom := 0
 	var state map[string]int
 	v, raw, found, lerr := r.cl.LatestCheckpoint(ctx, cmd.ThreadID, cmd.RunID)
 	if lerr != nil {
-		return false, lerr // transient — Nak, redeliver
+		return false, epoch, lerr // transient — Nak, redeliver
 	}
 	if found {
 		// version v = count of completed nodes (1-based), so resume at
@@ -142,7 +217,7 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		resumeFrom = v
 		if len(raw) > 0 {
 			if uerr := json.Unmarshal(raw, &state); uerr != nil {
-				return false, fmt.Errorf("runner: decode checkpoint state: %w", uerr)
+				return false, epoch, fmt.Errorf("runner: decode checkpoint state: %w", uerr)
 			}
 		}
 	}
@@ -157,34 +232,45 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 			// checkpointed, before starting the next node. No ack — the
 			// command must be redelivered (to a fresh Runner in the resume
 			// test) for the run to actually finish.
-			return false, nil
+			return false, epoch, nil
 		}
 
-		state = r.ex.Run(step, state)
+		var rerr error
+		state, rerr = r.ex.Run(step, state)
+		if rerr != nil {
+			// Poison run — record run.failed and stop; do NOT redeliver.
+			if ferr := r.cl.RunFailed(ctx, cmd.RunID, epoch, rerr.Error()); ferr != nil {
+				if errors.Is(ferr, ErrStaleLease) {
+					return true, epoch, nil // superseded — ack
+				}
+				return false, epoch, ferr // transient failure to record — nak, retry
+			}
+			return true, epoch, nil // failure recorded — ack
+		}
 
 		stateJSON, merr := json.Marshal(state)
 		if merr != nil {
-			return false, fmt.Errorf("runner: encode state: %w", merr)
+			return false, epoch, fmt.Errorf("runner: encode state: %w", merr)
 		}
 		if werr := r.cl.WriteCheckpoint(ctx, cmd.ThreadID, cmd.RunID, epoch, step+1, stateJSON); werr != nil {
 			if errors.Is(werr, ErrStaleLease) {
-				return true, nil // superseded by a newer lease — stop, ack
+				return true, epoch, nil // superseded by a newer lease — stop, ack
 			}
-			return false, werr // transient — Nak, redeliver
+			return false, epoch, werr // transient — Nak, redeliver
 		}
 		if nerr := r.cl.NodeCompleted(ctx, cmd.RunID, epoch, nodes[step], "tool"); nerr != nil {
 			if errors.Is(nerr, ErrStaleLease) {
-				return true, nil
+				return true, epoch, nil
 			}
-			return false, nerr
+			return false, epoch, nerr
 		}
 	}
 
 	if cerr := r.cl.RunCompleted(ctx, cmd.RunID, epoch); cerr != nil {
 		if errors.Is(cerr, ErrStaleLease) {
-			return true, nil
+			return true, epoch, nil
 		}
-		return false, cerr
+		return false, epoch, cerr
 	}
-	return true, nil
+	return true, epoch, nil
 }

--- a/controlplane/worker/runner_ackdecision_test.go
+++ b/controlplane/worker/runner_ackdecision_test.go
@@ -1,0 +1,28 @@
+package worker
+
+import "testing"
+
+func TestAckDecision(t *testing.T) {
+	const max = 5
+	cases := []struct {
+		name         string
+		acked        bool
+		epoch        int
+		numDelivered int
+		want         decision
+	}{
+		{"success acks", true, 1, 3, decisionAck},
+		{"transient below max naks", false, 1, 4, decisionNak},
+		{"transient at max with lease escalates", false, 1, 5, decisionEscalate},
+		{"transient past max with lease escalates", false, 2, 6, decisionEscalate},
+		{"transient at max without lease just acks", false, 0, 5, decisionAck},
+		{"acked wins even at max", true, 0, 5, decisionAck},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ackDecision(c.acked, c.epoch, c.numDelivered, max); got != c.want {
+				t.Errorf("ackDecision(%v,%d,%d,%d) = %v, want %v", c.acked, c.epoch, c.numDelivered, max, got, c.want)
+			}
+		})
+	}
+}

--- a/controlplane/worker/runner_escalation_test.go
+++ b/controlplane/worker/runner_escalation_test.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// stubEscalationClient is a runClient stub for TestEscalationWiring (INF-1a):
+// it leases successfully (epoch 1, matching a real RunStarted), then fails
+// transiently on WriteCheckpoint on every attempt, and records whether
+// RunFailed was called and with what epoch. Internal (package worker) so it
+// can implement the unexported runClient interface directly.
+type stubEscalationClient struct {
+	failedEpoch int
+	failedCalls int
+}
+
+func (c *stubEscalationClient) RunStarted(ctx context.Context, runID uuid.UUID) (int, error) {
+	return 1, nil
+}
+
+func (c *stubEscalationClient) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (int, []byte, bool, error) {
+	return 0, nil, false, nil
+}
+
+func (c *stubEscalationClient) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error {
+	return errors.New("transient: write checkpoint boom")
+}
+
+func (c *stubEscalationClient) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
+	return nil
+}
+
+func (c *stubEscalationClient) RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error {
+	return nil
+}
+
+func (c *stubEscalationClient) RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error {
+	c.failedEpoch = epoch
+	c.failedCalls++
+	return nil
+}
+
+// TestEscalationWiring proves the dead-letter escalation wiring (INF-1a): a
+// run that leases (epoch 1) but then fails transiently on every attempt
+// escalates to run.failed via RunFailed on the final allowed delivery,
+// instead of Nak'ing forever. It exercises the exact sequence Start's
+// Consume callback runs — ProcessOne, then ackDecision(acked, epoch,
+// numDelivered, MaxDeliver), then on decisionEscalate calling the SAME
+// r.escalate method Start calls (not a re-implementation of it) — using a
+// stub runClient so it doesn't need a real jetstream.Msg with a forced
+// NumDelivered (impractical in-test per the task brief; the pure
+// ackDecision matrix in runner_ackdecision_test.go already covers the
+// decision table itself).
+func TestEscalationWiring(t *testing.T) {
+	ctx := context.Background()
+	cl := &stubEscalationClient{}
+	runner := NewRunner(nil, cl, CounterExecutor{}, 1)
+	runner.MaxDeliver = 1
+
+	cmd := GraphCommand{RunID: uuid.New(), ThreadID: uuid.New()}
+	acked, epoch, perr := runner.ProcessOne(ctx, cmd)
+	if acked {
+		t.Fatal("ProcessOne: want acked=false (transient WriteCheckpoint failure), got true")
+	}
+	if epoch != 1 {
+		t.Fatalf("ProcessOne: want epoch=1 (leased), got %d", epoch)
+	}
+	if perr == nil {
+		t.Fatal("ProcessOne: want non-nil transient error")
+	}
+
+	// Mirror Start's post-ProcessOne wiring: numDelivered at MaxDeliver (the
+	// final allowed delivery) with a leased epoch must escalate.
+	const numDelivered = 1
+	got := ackDecision(acked, epoch, numDelivered, runner.MaxDeliver)
+	if got != decisionEscalate {
+		t.Fatalf("ackDecision(%v,%d,%d,%d) = %v, want decisionEscalate", acked, epoch, numDelivered, runner.MaxDeliver, got)
+	}
+
+	// Call the ACTUAL method Start invokes on decisionEscalate (not a copy
+	// of its body) — this is what makes the spy assertion below meaningful:
+	// a regression that made Start skip escalate(), or call it with the
+	// wrong epoch, would be caught by testing this exact method.
+	runner.escalate(ctx, cmd.RunID, epoch, perr)
+
+	if cl.failedCalls != 1 {
+		t.Fatalf("RunFailed: want 1 call, got %d", cl.failedCalls)
+	}
+	if cl.failedEpoch != 1 {
+		t.Errorf("RunFailed: want epoch=1, got %d", cl.failedEpoch)
+	}
+}


### PR DESCRIPTION
## Worker reliability follow-ups — INF-1 (dead-letter + graph-error) and INF-2 (relay race)

Closes the two reliability gaps flagged in PR #217's final review. Two independent
fixes, one per commit.

### INF-2 — relay shutdown data race (`controlplane/nats/relay.go`)
`Relay.Stop()` used to close the listener `pgx.Conn` from a different goroutine to
unblock an in-flight `WaitForNotification` — but `pgx.Conn` isn't safe for
concurrent `Close`+`Wait`, so `-race` flagged it (`TestRelayStop`,
`TestServer_Relay_Wired`). The pre-existing `listenerMu` guarded only the pointer,
not the conn's internals.

**Fix:** shutdown is driven by **context cancellation**. `Start` owns a cancelable
context; `Stop()` cancels it (and closes `stopCh`) — it never touches the conn.
`WaitForNotification` unblocks via cancellation, and the conn is closed only inside
`Start`'s own goroutine. `listenLoop` distinguishes a Stop (`stopCh` closed → clean
`nil` return) from a parent-ctx cancel. The `listener`/`listenerMu`/`setListener`/
`clearListener` sharing is removed entirely.

Verified `-race` clean: `TestRelayStop -race -count=10`, `TestServer_Relay_Wired
-race -count=5` — no data race.

### INF-1 — exhausted redelivery + graph error → run.failed (`controlplane/worker/`)
Previously, exhausting `max_deliver` silently dropped the run, and a deterministic
graph error had no terminal path (`Client.RunFailed` was dead code).

- **Graph error (1b):** the executor is now an `Executor` interface whose `Run`
  returns an error. A deterministic error → `RunFailed(runID, epoch, reason)` + Ack
  (poison run, no redelivery).
- **Dead-letter escalation (1a):** on the final allowed delivery
  (`NumDelivered >= GraphExecutorMaxDeliver`) that's still failing transiently, the
  runner escalates to `run.failed` (epoch-fenced) + Ack instead of a pointless Nak.
  A pure `ackDecision(acked, epoch, numDelivered, maxDeliver)` helper encodes the
  choice; `GraphExecutorMaxDeliver` is a single const shared by the consumer config
  and the runner. `runClient`/`Executor` interfaces make both paths testable.
- `Client.RunFailed` is now wired in from both paths.

### Testing
Testcontainers Postgres + embedded NATS (no build tag; standard CI). Both
behaviors mutation-tested (breaking the graph-error path or the escalation boundary
makes the tests fail):
- `ackDecision` unit matrix (incl. the never-leased→ack limitation).
- `TestGraphErrorMarksRunFailed`: run ends `failed`, node A ran once, message acked
  (no redelivery loop), one `run.failed` outbox row.
- Escalation wiring test (drives the real `escalate` method + `ackDecision`).
- Durable-resume proof re-verified under `-race` (node A runs exactly once across
  crash+resume) — no regression from the interface refactor.

### Known limitation (documented, deferred)
Escalation needs a leased epoch. A run that fails to (re)lease on its **final**
delivery (`epoch=0`) can't be marked failed via the epoch-fenced `RunFailed`, so it
stays stuck (`queued` if never leased, `in_progress` if leased earlier then
blipped). This is strictly better than the old silent-drop-of-everything, but the
complete fix is a **lease-free reaper** for stuck runs (+ an advisory-consumer
backstop for the worker-crashes-on-its-own-last-delivery edge) — a tracked
follow-up, not part of this slice.
