### PR TITLE
feat(controlplane): run reaper — fail runs stuck past the redelivery window (+ eventstore extraction)

### DIFF
--- a/controlplane/docs/superpowers/plans/2026-07-28-run-reaper.md
+++ b/controlplane/docs/superpowers/plans/2026-07-28-run-reaper.md
@@ -1,0 +1,497 @@
+# Run Reaper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a control-plane reaper that fails runs the execution path leaves stuck (`in_progress` past the redelivery window, or `queued` past a dispatch timeout), emitting `run.failed` so no run stays non-terminal forever.
+
+**Architecture:** A background worker (mirroring `nats.CleanupWorker`) ticks on an interval; each tick, in one tenant-DB transaction, selects stuck runs (`FOR UPDATE SKIP LOCKED`), marks them `failed`, and emits `run.failed` through the shared transactional-outbox append. To keep one append implementation (no duplicated append SQL), `Event` + the append are first extracted into a small `controlplane/eventstore` package used by both `endpoints.writeTx` and the reaper.
+
+**Tech Stack:** Go 1.25, pgx v5 (`pgxpool`), testcontainers Postgres.
+
+## Global Constraints
+
+- Design doc: `controlplane/docs/superpowers/specs/2026-07-28-run-reaper-design.md` — the contract; this plan implements it.
+- **Detection is time-since-start, NOT worker-lease.** `in_progress` stale threshold (default 30 min) must exceed the redelivery window (`max_deliver × ack_wait ≈ 25 min`) so the reaper never fails a run JetStream is still recovering. The "fresh in_progress run is NOT reaped" test is the load-bearing guard.
+- The reaper only touches `in_progress` and `queued`. It ignores `requires_action` (HITL, legitimately non-terminal), `completed`, `failed`, `cancelled`.
+- `run.failed` is emitted via the shared outbox append (events + outbox + `pg_notify`) so the relay publishes it — not a silent DB flip.
+- The `eventstore` extraction must be behavior-preserving: the existing `controlplane/endpoints` integration suite must still pass unchanged. `endpoints.Event` becomes a type alias so existing handler literals and generated `*_gen.go` compile without regeneration (never hand-edit `*_gen.go`).
+- Integration tests: testcontainers Postgres, no build tag, standard CI. Never weaken assertions.
+- Never hand-edit go.mod/go.sum. Conventional commits. No PR/push/merge without explicit approval.
+- Run all commands from the worktree root `~/worktrees/duragraph/feat/controlplane-server` (branch `feat/controlplane-run-reaper`).
+
+---
+
+## File Structure
+
+- `controlplane/eventstore/eventstore.go` (new) — `Event` + `Append` + private `jsonOrEmpty`.
+- `controlplane/eventstore/eventstore_integration_test.go` (new) — direct Append test.
+- `controlplane/endpoints/runtime.go` (modify) — drop local `Event`/`appendEvent`; alias `Event`; `writeTx` calls `eventstore.Append`. KEEP the local `jsonOrEmpty` (still used by `workers.go`).
+- `controlplane/reaper/reaper.go` (new) — `Config`, `RunReaper`, `NewRunReaper`, `Start`/`Stop`, `reapOnce`.
+- `controlplane/reaper/reaper_integration_test.go` (new) — reaper tests + a package `TestMain`.
+- `controlplane/server/server.go` (modify) — construct + wire the reaper alongside relay/cleanup/run-processor.
+
+---
+
+## Task 1: Extract `eventstore` (Event + Append), behavior-preserving
+
+**Files:**
+- Create: `controlplane/eventstore/eventstore.go`
+- Create: `controlplane/eventstore/eventstore_integration_test.go`
+- Modify: `controlplane/endpoints/runtime.go`
+
+**Interfaces:**
+- Produces: `eventstore.Event{ AggregateType string; AggregateID uuid.UUID; EventType string; Payload []byte; Metadata []byte }`; `func eventstore.Append(ctx context.Context, tx pgx.Tx, e Event) error` (EnsureStream + INSERT events + INSERT outbox, identical to the current `appendEvent`).
+- Consumes (endpoints): `endpoints.Event` becomes `type Event = eventstore.Event`; `writeTx` calls `eventstore.Append` per event.
+
+- [ ] **Step 1: Write the failing eventstore test**
+
+Create `controlplane/eventstore/eventstore_integration_test.go` (package `eventstore_test`) with a testcontainer `TestMain` (mirror `controlplane/endpoints/assistants_integration_test.go`'s `TestMain` + `applyTenantMigrations` — a Postgres container with the tenant migrations applied, exposing `testPool`). Then:
+
+```go
+func TestAppendWritesEventAndOutbox(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	aggID := uuid.New()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eventstore.Append(ctx, tx, eventstore.Event{
+		AggregateType: "Run", AggregateID: aggID, EventType: "run.failed",
+		Payload: []byte(`{"reason":"test"}`),
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var evCount, obCount int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='run.failed'`, aggID).Scan(&evCount)
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.failed'`, aggID).Scan(&obCount)
+	if evCount != 1 || obCount != 1 {
+		t.Errorf("want 1 event + 1 outbox row, got %d/%d", evCount, obCount)
+	}
+}
+```
+
+- [ ] **Step 2: Run it — fails (package doesn't exist)**
+
+Run: `go test ./controlplane/eventstore/ -run TestAppendWritesEventAndOutbox -v`
+Expected: FAIL — `package controlplane/eventstore` / `undefined: eventstore.Append`.
+
+- [ ] **Step 3: Create the eventstore package**
+
+Create `controlplane/eventstore/eventstore.go` — the `Event` struct + the `appendEvent` body (renamed `Append`) + a private `jsonOrEmpty`, all moved verbatim from `endpoints/runtime.go`:
+
+```go
+// Package eventstore holds the transactional-outbox event append shared by the
+// HTTP write path (endpoints.writeTx) and the run reaper. One append
+// implementation → no duplicated append SQL. Mirrors outbox.sql's EnsureStream +
+// AppendEvent + EnqueueOutbox.
+package eventstore
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Event is one domain event to append within a write transaction. EventID is
+// app-generated so the mirrored outbox row carries the identical id for
+// JetStream dedup.
+type Event struct {
+	AggregateType string
+	AggregateID   uuid.UUID
+	EventType     string
+	Payload       []byte
+	Metadata      []byte
+}
+
+// Append ensures the aggregate's stream, appends the event (advancing version),
+// and mirrors it to the outbox — all on the caller's tx.
+func Append(ctx context.Context, tx pgx.Tx, e Event) error {
+	var streamID uuid.UUID
+	var version int
+	err := tx.QueryRow(ctx, `
+		INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
+		VALUES ($1, $2, $3, 0)
+		ON CONFLICT (aggregate_type, aggregate_id) DO UPDATE SET updated_at = now()
+		RETURNING stream_id, version`,
+		uuid.New(), e.AggregateType, e.AggregateID).Scan(&streamID, &version)
+	if err != nil {
+		return err
+	}
+	eventID := uuid.New()
+	nextVersion := version + 1
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO events (event_id, stream_id, aggregate_type, aggregate_id,
+		                    event_type, event_version, payload, metadata)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		eventID, streamID, e.AggregateType, e.AggregateID,
+		e.EventType, nextVersion, jsonOrEmpty(e.Payload), jsonOrEmpty(e.Metadata)); err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO outbox (event_id, aggregate_type, aggregate_id, event_type, payload, metadata)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (event_id) DO NOTHING`,
+		eventID, e.AggregateType, e.AggregateID, e.EventType,
+		jsonOrEmpty(e.Payload), jsonOrEmpty(e.Metadata))
+	return err
+}
+
+func jsonOrEmpty(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("{}")
+	}
+	return b
+}
+```
+
+- [ ] **Step 4: Point endpoints at eventstore (behavior-preserving)**
+
+In `controlplane/endpoints/runtime.go`:
+- Delete the local `Event` struct definition and the `appendEvent` func.
+- KEEP the local `jsonOrEmpty` (it is still used by `workers.go` lines ~158, ~230 — verify with `grep -n jsonOrEmpty controlplane/endpoints/*.go`).
+- Add `type Event = eventstore.Event` (a type alias, so existing `Event{...}` literals in handlers and generated `*_gen.go` compile unchanged).
+- In `writeTx`, replace `if err := appendEvent(ctx, tx, e); err != nil {` with `if err := eventstore.Append(ctx, tx, e); err != nil {`.
+- Add the import `"github.com/duragraph/duragraph/controlplane/eventstore"`.
+
+- [ ] **Step 5: Build + eventstore test + full endpoints regression**
+
+Run: `go build ./controlplane/...`
+Expected: clean (the `Event` alias keeps all handler + `*_gen.go` references compiling).
+
+Run: `go test ./controlplane/eventstore/ -run TestAppendWritesEventAndOutbox -v`
+Expected: PASS.
+
+Run: `go test ./controlplane/endpoints/ -count=1`
+Expected: PASS — the extraction is behavior-preserving; every existing group (assistants/threads/runs/crons/store/system/workers) still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/eventstore/ controlplane/endpoints/runtime.go
+git commit -m "refactor(controlplane): extract transactional event append into eventstore package"
+```
+
+---
+
+## Task 2: RunReaper + server wiring
+
+**Files:**
+- Create: `controlplane/reaper/reaper.go`
+- Create: `controlplane/reaper/reaper_integration_test.go`
+- Modify: `controlplane/server/server.go`
+
+**Interfaces:**
+- Consumes: `*pgxpool.Pool` (tenant); `eventstore.Append`, `eventstore.Event`.
+- Produces:
+  - `reaper.Config{ Interval, InProgressStaleAfter, QueuedStaleAfter time.Duration }` with a `defaults()` (60s / 30m / 10m).
+  - `reaper.RunReaper` with `func NewRunReaper(pool *pgxpool.Pool, cfg Config) *RunReaper`, `func (r *RunReaper) Start(ctx context.Context) error`, `func (r *RunReaper) Stop()`, `func (r *RunReaper) reapOnce(ctx context.Context) (int, error)`.
+
+- [ ] **Step 1: Write the failing reaper test**
+
+Create `controlplane/reaper/reaper_integration_test.go` (package `reaper` — internal, so it can call `reapOnce`) with a testcontainer `TestMain` (mirror the endpoints harness: Postgres container + `applyTenantMigrations`, exposing `testPool`). Then:
+
+```go
+func seedRun(t *testing.T, ctx context.Context, status string, startedAgo, createdAgo string) string {
+	t.Helper()
+	var aid, rid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	// started_at is NULL for queued; set for in_progress. created_at controls queued staleness.
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO runs (assistant_id, status, created_at, started_at)
+		VALUES ($1, $2, now() - $3::interval,
+		        CASE WHEN $2 = 'in_progress' THEN now() - $4::interval ELSE NULL END)
+		RETURNING id`, aid, status, createdAgo, startedAgo).Scan(&rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rid
+}
+
+func TestReaperFailsStuckRuns(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	staleIP  := seedRun(t, ctx, "in_progress", "40 minutes", "45 minutes") // stale → fail
+	staleQ   := seedRun(t, ctx, "queued",      "0", "20 minutes")          // stale → fail
+	freshIP  := seedRun(t, ctx, "in_progress", "2 minutes", "3 minutes")   // fresh → untouched
+	freshQ   := seedRun(t, ctx, "queued",      "0", "1 minute")            // fresh → untouched
+
+	r := NewRunReaper(testPool, Config{InProgressStaleAfter: 30 * time.Minute, QueuedStaleAfter: 10 * time.Minute})
+	n, err := r.reapOnce(ctx)
+	if err != nil {
+		t.Fatalf("reapOnce: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("reaped count: want 2, got %d", n)
+	}
+	assertStatus(t, ctx, staleIP, "failed")
+	assertStatus(t, ctx, staleQ, "failed")
+	assertStatus(t, ctx, freshIP, "in_progress") // NOT reaped — mid-recovery window
+	assertStatus(t, ctx, freshQ, "queued")
+	// run.failed emitted for the two stuck runs (so the relay publishes them)
+	for _, id := range []string{staleIP, staleQ} {
+		var c int
+		_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.failed'`, id).Scan(&c)
+		if c != 1 {
+			t.Errorf("run %s: want 1 run.failed outbox row, got %d", id, c)
+		}
+	}
+}
+
+func TestReaperIdempotent(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	_ = seedRun(t, ctx, "in_progress", "40 minutes", "45 minutes")
+	r := NewRunReaper(testPool, Config{InProgressStaleAfter: 30 * time.Minute, QueuedStaleAfter: 10 * time.Minute})
+	if _, err := r.reapOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	n, err := r.reapOnce(ctx) // second tick: nothing left non-terminal
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("second tick reaped: want 0, got %d", n)
+	}
+}
+
+func assertStatus(t *testing.T, ctx context.Context, id, want string) {
+	t.Helper()
+	var got string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("run %s status: want %s, got %s", id, want, got)
+	}
+}
+```
+
+- [ ] **Step 2: Run it — fails (package doesn't exist)**
+
+Run: `go test ./controlplane/reaper/ -run TestReaper -v`
+Expected: FAIL — `undefined: NewRunReaper`.
+
+- [ ] **Step 3: Write the reaper**
+
+Create `controlplane/reaper/reaper.go`:
+
+```go
+// Package reaper fails runs the execution path abandoned. A run that a worker
+// leased and then died on (past the redelivery window), or that was queued and
+// never dispatched (command lost), would otherwise sit non-terminal forever.
+// Detection is time-since-start, NOT worker-lease, so the reaper never fails a
+// run JetStream is still redelivering/resuming. Source: the run-reaper design doc.
+package reaper
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Config struct {
+	Interval             time.Duration // tick period; default 60s
+	InProgressStaleAfter time.Duration // default 30m (> max_deliver × ack_wait)
+	QueuedStaleAfter     time.Duration // default 10m
+}
+
+func (c *Config) defaults() {
+	if c.Interval == 0 {
+		c.Interval = 60 * time.Second
+	}
+	if c.InProgressStaleAfter == 0 {
+		c.InProgressStaleAfter = 30 * time.Minute
+	}
+	if c.QueuedStaleAfter == 0 {
+		c.QueuedStaleAfter = 10 * time.Minute
+	}
+}
+
+type RunReaper struct {
+	pool   *pgxpool.Pool
+	cfg    Config
+	stopCh chan struct{}
+}
+
+func NewRunReaper(pool *pgxpool.Pool, cfg Config) *RunReaper {
+	cfg.defaults()
+	return &RunReaper{pool: pool, cfg: cfg, stopCh: make(chan struct{})}
+}
+
+// Start ticks on Interval until ctx is canceled or Stop is called.
+func (r *RunReaper) Start(ctx context.Context) error {
+	ticker := time.NewTicker(r.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-r.stopCh:
+			return nil
+		case <-ticker.C:
+			if n, err := r.reapOnce(ctx); err != nil {
+				slog.Error("reaper: tick failed", "err", err)
+			} else if n > 0 {
+				slog.Info("reaper: failed stuck runs", "count", n)
+			}
+		}
+	}
+}
+
+// Stop signals Start to exit. Idempotent.
+func (r *RunReaper) Stop() {
+	select {
+	case <-r.stopCh:
+	default:
+		close(r.stopCh)
+	}
+}
+
+// reapOnce fails, in one transaction, every run stuck past its threshold, emitting
+// run.failed for each. Returns the number reaped.
+func (r *RunReaper) reapOnce(ctx context.Context) (int, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
+
+	rows, err := tx.Query(ctx, `
+		SELECT id, status FROM runs
+		WHERE (status = 'in_progress' AND started_at < now() - $1::interval)
+		   OR (status = 'queued'      AND created_at < now() - $2::interval)
+		FOR UPDATE SKIP LOCKED`,
+		intervalStr(r.cfg.InProgressStaleAfter), intervalStr(r.cfg.QueuedStaleAfter))
+	if err != nil {
+		return 0, err
+	}
+	type stuck struct {
+		id     uuid.UUID
+		status string
+	}
+	var list []stuck
+	for rows.Next() {
+		var s stuck
+		if err := rows.Scan(&s.id, &s.status); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		list = append(list, s)
+	}
+	rows.Close()
+	if rows.Err() != nil {
+		return 0, rows.Err()
+	}
+
+	for _, s := range list {
+		reason := fmt.Sprintf("reaped: no active worker (stuck %s past threshold)", s.status)
+		if _, err := tx.Exec(ctx,
+			`UPDATE runs SET status='failed', completed_at=now(), error=$2 WHERE id=$1`,
+			s.id, reason); err != nil {
+			return 0, err
+		}
+		if err := eventstore.Append(ctx, tx, eventstore.Event{
+			AggregateType: "Run", AggregateID: s.id, EventType: "run.failed",
+			Payload: []byte(fmt.Sprintf(`{"reason":%q}`, reason)),
+		}); err != nil {
+			return 0, err
+		}
+	}
+	if len(list) > 0 {
+		if _, err := tx.Exec(ctx, `SELECT pg_notify('outbox_new', '')`); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return len(list), nil
+}
+
+// intervalStr renders a duration as a Postgres interval literal (seconds).
+func intervalStr(d time.Duration) string {
+	return fmt.Sprintf("%d seconds", int64(d.Seconds()))
+}
+```
+
+- [ ] **Step 4: Build + run the reaper tests**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/reaper/ -run TestReaper -v -count=1`
+Expected: PASS — `TestReaperFailsStuckRuns` (2 reaped, fresh untouched, run.failed emitted) + `TestReaperIdempotent`.
+
+- [ ] **Step 5: Wire the reaper into the server**
+
+In `controlplane/server/server.go`, mirror the cleanup-worker wiring:
+- Add fields `reaper *reaper.RunReaper` and `reaperDone chan error`; init `reaperDone: make(chan error, 1)` in `New`.
+- In `New`, after the pools are open (the reaper needs only `s.tenant`, not NATS), construct `s.reaper = reaper.NewRunReaper(s.tenant, reaper.Config{})` (defaults). Do this unconditionally when `s.tenant != nil`.
+- In `Run`, gated by `s.cfg.Relays` (consistent with relay/cleanup), launch: `if s.reaper != nil && s.cfg.Relays { go func() { s.reaperDone <- s.reaper.Start(ctx) }() }`.
+- In `Shutdown`, `if s.reaper != nil { s.reaper.Stop() }` and drain `s.reaperDone` (bounded by the drain timeout, like `cleanupDone`).
+- Add the import `"github.com/duragraph/duragraph/controlplane/reaper"`.
+
+- [ ] **Step 6: Build + server regression**
+
+Run: `go build ./... && go vet ./controlplane/...`
+Run: `go test ./controlplane/server/ -count=1`
+Expected: PASS — server still constructs, runs, and shuts down cleanly with the reaper wired.
+
+- [ ] **Step 7: Full regression**
+
+Run: `go test ./controlplane/... -count=1`
+Expected: all PASS (eventstore, endpoints, nats, reaper, server, worker).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add controlplane/reaper/ controlplane/server/server.go
+git commit -m "feat(controlplane): run reaper — fail runs stuck past the redelivery window"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- eventstore extraction (DRY append) → Task 1. ✓
+- Reaper detection (time-since-start; in_progress 30m / queued 10m; disjoint arms via nullable started_at) → Task 2 Step 3. ✓
+- Emit run.failed via shared append → Task 2 (eventstore.Append in reapOnce). ✓
+- Does-not-preempt-recovery guard → `freshIP` stays `in_progress` assertion (Task 2 Step 1). ✓
+- Idempotent → `TestReaperIdempotent`. ✓
+- Ignores requires_action/terminal → the `WHERE status IN ('in_progress','queued')` filter (Task 2 Step 3). ✓
+- Server wiring mirroring cleanup → Task 2 Step 5. ✓
+
+**Placeholder scan:** none. All code is complete. The reaper test's `TestMain` is described as "mirror the endpoints harness" rather than transcribed — that harness (testcontainer Postgres + `applyTenantMigrations`) is an established, copy-adaptable pattern in `assistants_integration_test.go` and `nats_integration_test.go`; the implementer copies it. This is a stated reuse, not a vague requirement.
+
+**Type consistency:** `eventstore.Event`/`eventstore.Append` used identically in Task 1 (def) and Task 2 (reapOnce). `endpoints.Event = eventstore.Event` alias keeps handler + `*_gen.go` literals compiling. `Config`/`RunReaper`/`reapOnce` signatures match between the test (Step 1) and impl (Step 3). Server fields (`reaper`, `reaperDone`) mirror the existing `cleanup`/`cleanupDone` exactly.
+
+**Open risks for the implementer:**
+- Task 1: confirm `jsonOrEmpty` stays in `endpoints` (used by `workers.go`) — do NOT delete it there; only `Event`/`appendEvent` move. Grep before deleting.
+- Task 2: `started_at` is nullable; the `in_progress` arm requires it non-null-and-old (a queued run has NULL started_at, so it can't match the in_progress arm — the arms are disjoint). Confirm the seed helper sets `started_at` only for `in_progress`.
+- Task 2: `reapOnce` must be lowercase and the test in `package reaper` (internal) to call it.
+
+---
+
+## Notes for the implementer
+
+- The 30-min `in_progress` threshold is deliberately > the ~25-min JetStream redelivery window. Do not lower it to a worker-lease timescale — that would fail runs mid-recovery (the design's central constraint).
+- Emit `run.failed` ONLY through `eventstore.Append` (+ the single `pg_notify` per tick) — never a bare `UPDATE runs SET status='failed'` without the event, or observers won't see the failure.
+- Do not push/PR/merge without explicit approval.

--- a/controlplane/docs/superpowers/specs/2026-07-28-run-reaper-design.md
+++ b/controlplane/docs/superpowers/specs/2026-07-28-run-reaper-design.md
@@ -1,0 +1,160 @@
+# Run reaper — fail runs the execution path leaves stuck
+
+**Date:** 2026-07-28
+**Branch:** `feat/controlplane-run-reaper` (off `main`)
+**Status:** approved design, pending implementation plan
+
+## Context
+
+The worker execution path (merged) recovers a crashed worker's run via JetStream
+redelivery + checkpoint resume, and INF-1 escalates a leased-but-failing run to
+`run.failed` when `max_deliver` is exhausted. But two residual cases leave a run
+non-terminal with nothing to finish it (documented limitation in the INF-1
+design):
+
+- **Leased then stranded** — a worker leased the run, then crashed/blipped on its
+  final delivery before it could escalate. JetStream has stopped redelivering; the
+  run sits `in_progress` forever.
+- **Never leased** — the `worker.graph.execute` command was lost or dead-lettered
+  before any worker leased the run. It sits `queued` forever (run-processor only
+  dispatches on `run.created`, so nothing re-dispatches it).
+
+The reaper is a control-plane safety net that finds these stuck runs and marks
+them `failed` (emitting `run.failed` so observers see it). It does **not** recover
+or re-dispatch — that is a deliberate follow-up; this is the minimal "no run stays
+stuck forever" net.
+
+## Correctness constraint — do not preempt JetStream recovery
+
+The reaper must fail **only** runs the execution path has genuinely given up on.
+When a worker dies, JetStream redelivers the un-acked command for up to
+`max_deliver × ack_wait` (`5 × 5m ≈ 25 min`), and a fresh worker resumes from the
+last checkpoint. Therefore stuck-detection is based on **elapsed time since the run
+started/was created**, NOT on a worker's heartbeat lease. A worker-lease trigger
+(≈60 s) would fail runs mid-recovery: the run would flip to `failed`, then the
+redelivered worker's `run.started` would 409 and give up — defeating durable
+resume. The `in_progress` staleness threshold is therefore set **beyond the full
+redelivery window**.
+
+## Design
+
+### RunReaper — a background worker
+
+Mirrors `nats.CleanupWorker` (the outbox-cleanup goroutine): a ticker with
+`Start(ctx) error` / `Stop()` and a `Done chan error`, wired in `server.go`
+alongside relay / cleanup / run-processor (its own `reaperDone` channel, started
+in `Run` when enabled, stopped + drained in `Shutdown`).
+
+Config (all tunable, sensible defaults):
+- `Interval` — how often it ticks. Default **60 s**.
+- `InProgressStaleAfter` — how long an `in_progress` run may sit with no terminal
+  transition before it's presumed dead. Default **30 min** (> the ~25 min
+  redelivery window, with margin).
+- `QueuedStaleAfter` — how long a `queued` run may sit undispatched. Default
+  **10 min** (dispatch is normally near-instant; a long-queued run means its
+  command was lost).
+
+### Per-tick behavior — one transaction
+
+Each tick opens one tenant-DB transaction and, atomically:
+
+1. Selects stuck runs:
+   ```sql
+   SELECT id, lease_epoch FROM runs
+   WHERE (status = 'in_progress' AND started_at < now() - $inProgressStaleAfter)
+      OR (status = 'queued'      AND created_at < now() - $queuedStaleAfter)
+   FOR UPDATE SKIP LOCKED
+   ```
+   (`started_at` is set by `run.started`; a queued run has no `started_at`, so the
+   two arms are disjoint. `SKIP LOCKED` avoids contending with a live write.)
+2. For each stuck run: `UPDATE runs SET status='failed', completed_at=now(),
+   error='reaped: no active worker (stuck <status> past <threshold>)'
+   WHERE id=$id`.
+3. Emits a `run.failed` domain event for each — through the SAME transactional
+   outbox path everything else uses (events + outbox row + `pg_notify`), so the
+   relay publishes it to NATS and SSE/observers see the failure. Not a silent DB
+   flip.
+4. Commits. A failure at any point rolls back the whole tick (no partial reaps).
+
+The reap is intentionally **not** epoch-fenced: the reaper is the authoritative
+system actor for abandoned runs, and its threshold guarantees no live worker owns
+the run. (If a worker somehow reappears after a reap and posts an event, it hits
+the normal terminal-run 409 — the same as any late writer.)
+
+### DRY the event-append (small shared extraction)
+
+`run.failed` must be emitted via the existing reliable append (events + outbox +
+notify), which today lives as the endpoints-private `Event` type + `appendEvent`
+func (used by `endpoints.writeTx`). To avoid duplicating that append SQL in the
+reaper (the exact shape-duplication that caused the run-processor envelope bug),
+extract it into a small shared package:
+
+- New `controlplane/eventstore` package: `type Event` (moved) + `func Append(ctx,
+  tx pgx.Tx, e Event) error` (the current `appendEvent` body).
+- `endpoints`: `writeTx` calls `eventstore.Append`; `endpoints.Event` becomes an
+  alias for / re-uses `eventstore.Event` so the many existing handler references
+  compile unchanged.
+- The reaper opens its tx, updates stuck runs, calls `eventstore.Append(tx,
+  runFailedEvent)` per run, fires `pg_notify('outbox_new','')`, commits.
+
+One append implementation, no drift. This extraction is the only change to
+already-merged endpoint code, and it is behavior-preserving (verified by the
+existing endpoint integration suite still passing).
+
+## Testing
+
+Testcontainers Postgres, no build tag, standard CI.
+
+- **`TestReaperFailsStuckRuns`:** seed four runs on a thread —
+  1. `in_progress` with `started_at = now() - 40m` (stale) → must become `failed`,
+     with a `run.failed` row in `outbox`.
+  2. `queued` with `created_at = now() - 20m` (stale) → must become `failed` +
+     `run.failed` outbox row.
+  3. `in_progress` with `started_at = now() - 2m` (fresh, mid-recovery window) →
+     must stay `in_progress`, **untouched** (proves the reaper doesn't preempt
+     JetStream recovery — the load-bearing assertion).
+  4. `queued` with `created_at = now() - 1m` (fresh) → must stay `queued`.
+  Run one `reapOnce(ctx)` tick; assert all four outcomes + the outbox rows.
+- **`TestReaperIdempotent`:** a second tick over the now-`failed` runs does nothing
+  (they're terminal; the `WHERE status IN ('in_progress','queued')` excludes them)
+  — no duplicate `run.failed` events.
+- **`eventstore` extraction:** the full `controlplane/endpoints` integration suite
+  still passes (behavior-preserving), plus a direct `eventstore.Append` unit/
+  integration test (appends an event + outbox row in a tx).
+- Full `go test ./controlplane/... -count=1` green.
+
+## Files
+
+- `controlplane/eventstore/eventstore.go` (new) — `Event` + `Append`.
+- `controlplane/endpoints/runtime.go` (modify) — `writeTx` uses `eventstore.Append`;
+  `Event` re-uses `eventstore.Event`.
+- `controlplane/reaper/reaper.go` (new) — `RunReaper`, `New…`, `Start`/`Stop`,
+  `reapOnce`.
+- `controlplane/server/server.go` (modify) — construct + wire the reaper (fields,
+  `New`, `Run`, `Shutdown`), gated like the other background workers.
+- Tests: `controlplane/reaper/reaper_integration_test.go`,
+  `controlplane/eventstore/eventstore_test.go`.
+
+## Known limitation — `started_at` threshold vs long-running graphs (recorded)
+
+`in_progress` staleness is measured from `started_at`, which assumes a run
+*completes* within `InProgressStaleAfter` (30 min). That holds for this slice (the
+counter graph is instant) and for anything shorter than the threshold. But a real,
+long-running graph engine (a separate future slice) could legitimately execute
+past 30 min and be **falsely reaped**. When the real executor lands, `in_progress`
+detection must switch from absolute `started_at` to a **liveness signal** — e.g.
+the timestamp of the run's most recent `execution_history` node event, or a
+run-level heartbeat the worker refreshes — so long-but-live runs aren't reaped.
+This is a deliberate follow-up bound to the graph-engine work, called out here so
+the 30-min threshold isn't mistaken for a permanent answer.
+
+## Out of scope (recorded)
+
+- **Recovery / re-dispatch** of stuck runs (requeue + re-publish
+  `worker.graph.execute` to resume from checkpoint, with a bounded attempt count).
+  Chosen against for this slice — the reaper fails; recovery is a deliberate later
+  enhancement.
+- The advisory-consumer backstop for the worker-crashes-on-its-own-last-delivery
+  edge (a different mechanism; still deferred).
+- `requires_action` runs (HITL interrupts) — those are legitimately non-terminal
+  awaiting input, NOT stuck; the reaper ignores them (only `in_progress`/`queued`).

--- a/controlplane/endpoints/runtime.go
+++ b/controlplane/endpoints/runtime.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
 )
 
 // Server holds the control-plane dependencies the handlers need.
@@ -23,16 +25,11 @@ type Server struct {
 	Platform *pgxpool.Pool
 }
 
-// Event is one domain event to append within a write transaction. EventID is
-// app-generated so the mirrored outbox row carries the identical id for
-// JetStream dedup. EventVersion is resolved by appendEvents from the stream.
-type Event struct {
-	AggregateType string
-	AggregateID   uuid.UUID
-	EventType     string
-	Payload       []byte
-	Metadata      []byte
-}
+// Event is one domain event to append within a write transaction. Aliased to
+// eventstore.Event so existing Event{...} literals (handlers + generated
+// *_gen.go) keep compiling unchanged after the append implementation moved to
+// the shared eventstore package.
+type Event = eventstore.Event
 
 // writeTx runs the transactional-outbox write path on pool: it opens a TX,
 // appends each event (advancing the stream version via the
@@ -47,7 +44,7 @@ func (s *Server) writeTx(ctx context.Context, pool *pgxpool.Pool, events []Event
 	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
 
 	for _, e := range events {
-		if err := appendEvent(ctx, tx, e); err != nil {
+		if err := eventstore.Append(ctx, tx, e); err != nil {
 			return err
 		}
 	}
@@ -61,42 +58,6 @@ func (s *Server) writeTx(ctx context.Context, pool *pgxpool.Pool, events []Event
 		return err
 	}
 	return tx.Commit(ctx)
-}
-
-// appendEvent mirrors outbox.sql's EnsureStream + AppendEvent + EnqueueOutbox.
-func appendEvent(ctx context.Context, tx pgx.Tx, e Event) error {
-	var streamID uuid.UUID
-	var version int
-	// EnsureStream: upsert by (aggregate_type, aggregate_id), return its row.
-	err := tx.QueryRow(ctx, `
-		INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
-		VALUES ($1, $2, $3, 0)
-		ON CONFLICT (aggregate_type, aggregate_id) DO UPDATE SET updated_at = now()
-		RETURNING stream_id, version`,
-		uuid.New(), e.AggregateType, e.AggregateID).Scan(&streamID, &version)
-	if err != nil {
-		return err
-	}
-
-	eventID := uuid.New()
-	nextVersion := version + 1
-
-	if _, err := tx.Exec(ctx, `
-		INSERT INTO events (event_id, stream_id, aggregate_type, aggregate_id,
-		                    event_type, event_version, payload, metadata)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		eventID, streamID, e.AggregateType, e.AggregateID,
-		e.EventType, nextVersion, jsonOrEmpty(e.Payload), jsonOrEmpty(e.Metadata)); err != nil {
-		return err
-	}
-
-	_, err = tx.Exec(ctx, `
-		INSERT INTO outbox (event_id, aggregate_type, aggregate_id, event_type, payload, metadata)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (event_id) DO NOTHING`,
-		eventID, e.AggregateType, e.AggregateID, e.EventType,
-		jsonOrEmpty(e.Payload), jsonOrEmpty(e.Metadata))
-	return err
 }
 
 func jsonOrEmpty(b []byte) []byte {

--- a/controlplane/eventstore/eventstore.go
+++ b/controlplane/eventstore/eventstore.go
@@ -1,0 +1,63 @@
+// Package eventstore holds the transactional-outbox event append shared by the
+// HTTP write path (endpoints.writeTx) and the run reaper. One append
+// implementation → no duplicated append SQL. Mirrors outbox.sql's EnsureStream +
+// AppendEvent + EnqueueOutbox.
+package eventstore
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Event is one domain event to append within a write transaction. EventID is
+// app-generated so the mirrored outbox row carries the identical id for
+// JetStream dedup.
+type Event struct {
+	AggregateType string
+	AggregateID   uuid.UUID
+	EventType     string
+	Payload       []byte
+	Metadata      []byte
+}
+
+// Append ensures the aggregate's stream, appends the event (advancing version),
+// and mirrors it to the outbox — all on the caller's tx.
+func Append(ctx context.Context, tx pgx.Tx, e Event) error {
+	var streamID uuid.UUID
+	var version int
+	err := tx.QueryRow(ctx, `
+		INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
+		VALUES ($1, $2, $3, 0)
+		ON CONFLICT (aggregate_type, aggregate_id) DO UPDATE SET updated_at = now()
+		RETURNING stream_id, version`,
+		uuid.New(), e.AggregateType, e.AggregateID).Scan(&streamID, &version)
+	if err != nil {
+		return err
+	}
+	eventID := uuid.New()
+	nextVersion := version + 1
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO events (event_id, stream_id, aggregate_type, aggregate_id,
+		                    event_type, event_version, payload, metadata)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		eventID, streamID, e.AggregateType, e.AggregateID,
+		e.EventType, nextVersion, jsonOrEmpty(e.Payload), jsonOrEmpty(e.Metadata)); err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO outbox (event_id, aggregate_type, aggregate_id, event_type, payload, metadata)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (event_id) DO NOTHING`,
+		eventID, e.AggregateType, e.AggregateID, e.EventType,
+		jsonOrEmpty(e.Payload), jsonOrEmpty(e.Metadata))
+	return err
+}
+
+func jsonOrEmpty(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("{}")
+	}
+	return b
+}

--- a/controlplane/eventstore/eventstore_integration_test.go
+++ b/controlplane/eventstore/eventstore_integration_test.go
@@ -1,0 +1,113 @@
+package eventstore_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+)
+
+// testPool connects to a real Postgres (testcontainers) with the tenant
+// migrations applied. Populated by TestMain.
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	pg, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("tenant"),
+		tcpostgres.WithUsername("t"),
+		tcpostgres.WithPassword("t"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "postgres testcontainer: %v\n", err)
+		os.Exit(1)
+	}
+	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dsn: %v\n", err)
+		os.Exit(1)
+	}
+	testPool, err = pgxpool.New(ctx, dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pool: %v\n", err)
+		os.Exit(1)
+	}
+	if err := applyTenantMigrations(ctx, testPool); err != nil {
+		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	testPool.Close()
+	_ = pg.Terminate(ctx)
+	os.Exit(code)
+}
+
+// applyTenantMigrations runs every tenant *.up.sql in order against the pool.
+func applyTenantMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	dir := filepath.Join("..", "db", "migrations", "tenant")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var ups []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			ups = append(ups, e.Name())
+		}
+	}
+	sort.Strings(ups)
+	for _, name := range ups {
+		sqlBytes, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+		if _, err := pool.Exec(ctx, string(sqlBytes)); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func TestAppendWritesEventAndOutbox(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	aggID := uuid.New()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eventstore.Append(ctx, tx, eventstore.Event{
+		AggregateType: "Run", AggregateID: aggID, EventType: "run.failed",
+		Payload: []byte(`{"reason":"test"}`),
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var evCount, obCount int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='run.failed'`, aggID).Scan(&evCount)
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.failed'`, aggID).Scan(&obCount)
+	if evCount != 1 || obCount != 1 {
+		t.Errorf("want 1 event + 1 outbox row, got %d/%d", evCount, obCount)
+	}
+}

--- a/controlplane/reaper/reaper.go
+++ b/controlplane/reaper/reaper.go
@@ -1,0 +1,141 @@
+// Package reaper fails runs the execution path abandoned. A run that a worker
+// leased and then died on (past the redelivery window), or that was queued and
+// never dispatched (command lost), would otherwise sit non-terminal forever.
+// Detection is time-since-start, NOT worker-lease, so the reaper never fails a
+// run JetStream is still redelivering/resuming. Source: the run-reaper design doc.
+package reaper
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Config struct {
+	Interval             time.Duration // tick period; default 60s
+	InProgressStaleAfter time.Duration // default 30m (> max_deliver × ack_wait)
+	QueuedStaleAfter     time.Duration // default 10m
+}
+
+func (c *Config) defaults() {
+	if c.Interval == 0 {
+		c.Interval = 60 * time.Second
+	}
+	if c.InProgressStaleAfter == 0 {
+		c.InProgressStaleAfter = 30 * time.Minute
+	}
+	if c.QueuedStaleAfter == 0 {
+		c.QueuedStaleAfter = 10 * time.Minute
+	}
+}
+
+type RunReaper struct {
+	pool   *pgxpool.Pool
+	cfg    Config
+	stopCh chan struct{}
+}
+
+func NewRunReaper(pool *pgxpool.Pool, cfg Config) *RunReaper {
+	cfg.defaults()
+	return &RunReaper{pool: pool, cfg: cfg, stopCh: make(chan struct{})}
+}
+
+// Start ticks on Interval until ctx is canceled or Stop is called.
+func (r *RunReaper) Start(ctx context.Context) error {
+	ticker := time.NewTicker(r.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-r.stopCh:
+			return nil
+		case <-ticker.C:
+			if n, err := r.reapOnce(ctx); err != nil {
+				slog.Error("reaper: tick failed", "err", err)
+			} else if n > 0 {
+				slog.Info("reaper: failed stuck runs", "count", n)
+			}
+		}
+	}
+}
+
+// Stop signals Start to exit. Idempotent.
+func (r *RunReaper) Stop() {
+	select {
+	case <-r.stopCh:
+	default:
+		close(r.stopCh)
+	}
+}
+
+// reapOnce fails, in one transaction, every run stuck past its threshold, emitting
+// run.failed for each. Returns the number reaped.
+func (r *RunReaper) reapOnce(ctx context.Context) (int, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
+
+	rows, err := tx.Query(ctx, `
+		SELECT id, status FROM runs
+		WHERE (status = 'in_progress' AND started_at < now() - $1::interval)
+		   OR (status = 'queued'      AND created_at < now() - $2::interval)
+		FOR UPDATE SKIP LOCKED`,
+		intervalStr(r.cfg.InProgressStaleAfter), intervalStr(r.cfg.QueuedStaleAfter))
+	if err != nil {
+		return 0, err
+	}
+	type stuck struct {
+		id     uuid.UUID
+		status string
+	}
+	var list []stuck
+	for rows.Next() {
+		var s stuck
+		if err := rows.Scan(&s.id, &s.status); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		list = append(list, s)
+	}
+	rows.Close()
+	if rows.Err() != nil {
+		return 0, rows.Err()
+	}
+
+	for _, s := range list {
+		reason := fmt.Sprintf("reaped: no active worker (stuck %s past threshold)", s.status)
+		if _, err := tx.Exec(ctx,
+			`UPDATE runs SET status='failed', completed_at=now(), error=$2 WHERE id=$1`,
+			s.id, reason); err != nil {
+			return 0, err
+		}
+		if err := eventstore.Append(ctx, tx, eventstore.Event{
+			AggregateType: "Run", AggregateID: s.id, EventType: "run.failed",
+			Payload: []byte(fmt.Sprintf(`{"reason":%q}`, reason)),
+		}); err != nil {
+			return 0, err
+		}
+	}
+	if len(list) > 0 {
+		if _, err := tx.Exec(ctx, `SELECT pg_notify('outbox_new', '')`); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return len(list), nil
+}
+
+// intervalStr renders a duration as a Postgres interval literal (seconds).
+func intervalStr(d time.Duration) string {
+	return fmt.Sprintf("%d seconds", int64(d.Seconds()))
+}

--- a/controlplane/reaper/reaper_integration_test.go
+++ b/controlplane/reaper/reaper_integration_test.go
@@ -1,0 +1,164 @@
+package reaper
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// testPool connects to a real Postgres (testcontainers) with the tenant
+// migrations applied. Populated by TestMain. package reaper (internal) so
+// the tests here can call the unexported reapOnce.
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	pg, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("tenant"),
+		tcpostgres.WithUsername("t"),
+		tcpostgres.WithPassword("t"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "postgres testcontainer: %v\n", err)
+		os.Exit(1)
+	}
+	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dsn: %v\n", err)
+		os.Exit(1)
+	}
+	testPool, err = pgxpool.New(ctx, dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pool: %v\n", err)
+		os.Exit(1)
+	}
+	if err := applyTenantMigrations(ctx, testPool); err != nil {
+		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	testPool.Close()
+	_ = pg.Terminate(ctx)
+	os.Exit(code)
+}
+
+// applyTenantMigrations runs every tenant *.up.sql in order against the pool.
+func applyTenantMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	dir := filepath.Join("..", "db", "migrations", "tenant")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var ups []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			ups = append(ups, e.Name())
+		}
+	}
+	sort.Strings(ups)
+	for _, name := range ups {
+		sqlBytes, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+		if _, err := pool.Exec(ctx, string(sqlBytes)); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func seedRun(t *testing.T, ctx context.Context, status string, startedAgo, createdAgo string) string {
+	t.Helper()
+	var aid, rid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO assistants (name) VALUES ('a') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	// started_at is NULL for queued; set for in_progress. created_at controls queued staleness.
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO runs (assistant_id, status, created_at, started_at)
+		VALUES ($1, $2::varchar, now() - $3::interval,
+		        CASE WHEN $2::text = 'in_progress' THEN now() - $4::interval ELSE NULL END)
+		RETURNING id`, aid, status, createdAgo, startedAgo).Scan(&rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rid
+}
+
+func TestReaperFailsStuckRuns(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	staleIP := seedRun(t, ctx, "in_progress", "40 minutes", "45 minutes") // stale → fail
+	staleQ := seedRun(t, ctx, "queued", "0", "20 minutes")                // stale → fail
+	freshIP := seedRun(t, ctx, "in_progress", "2 minutes", "3 minutes")   // fresh → untouched
+	freshQ := seedRun(t, ctx, "queued", "0", "1 minute")                  // fresh → untouched
+
+	r := NewRunReaper(testPool, Config{InProgressStaleAfter: 30 * time.Minute, QueuedStaleAfter: 10 * time.Minute})
+	n, err := r.reapOnce(ctx)
+	if err != nil {
+		t.Fatalf("reapOnce: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("reaped count: want 2, got %d", n)
+	}
+	assertStatus(t, ctx, staleIP, "failed")
+	assertStatus(t, ctx, staleQ, "failed")
+	assertStatus(t, ctx, freshIP, "in_progress") // NOT reaped — mid-recovery window
+	assertStatus(t, ctx, freshQ, "queued")
+	// run.failed emitted for the two stuck runs (so the relay publishes them)
+	for _, id := range []string{staleIP, staleQ} {
+		var c int
+		_ = testPool.QueryRow(ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.failed'`, id).Scan(&c)
+		if c != 1 {
+			t.Errorf("run %s: want 1 run.failed outbox row, got %d", id, c)
+		}
+	}
+}
+
+func TestReaperIdempotent(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	_ = seedRun(t, ctx, "in_progress", "40 minutes", "45 minutes")
+	r := NewRunReaper(testPool, Config{InProgressStaleAfter: 30 * time.Minute, QueuedStaleAfter: 10 * time.Minute})
+	if _, err := r.reapOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	n, err := r.reapOnce(ctx) // second tick: nothing left non-terminal
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("second tick reaped: want 0, got %d", n)
+	}
+}
+
+func assertStatus(t *testing.T, ctx context.Context, id, want string) {
+	t.Helper()
+	var got string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("run %s status: want %s, got %s", id, want, got)
+	}
+}

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/duragraph/duragraph/controlplane/endpoints"
 	"github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/reaper"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 )
@@ -104,11 +105,13 @@ type Server struct {
 	relay        *nats.Relay
 	cleanup      *nats.CleanupWorker
 	runProcessor *nats.RunProcessor
+	reaper       *reaper.RunReaper
 	echo         *echo.Echo
 
 	relayDone   chan error
 	cleanupDone chan error
 	rpDone      chan error
+	reaperDone  chan error
 
 	closeOnce sync.Once
 }
@@ -130,6 +133,7 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		relayDone:   make(chan error, 1),
 		cleanupDone: make(chan error, 1),
 		rpDone:      make(chan error, 1),
+		reaperDone:  make(chan error, 1),
 	}
 
 	// --- pgxpools ---
@@ -145,6 +149,11 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 			return nil, fmt.Errorf("server: platform pool: %w", err)
 		}
 		s.plat = platformPool
+	}
+
+	// --- run reaper (needs only the tenant pool, not NATS) ---
+	if s.tenant != nil {
+		s.reaper = reaper.NewRunReaper(s.tenant, reaper.Config{})
 	}
 
 	// --- migrations ---
@@ -249,6 +258,9 @@ func (s *Server) Run(ctx context.Context) error {
 	if s.runProcessor != nil && s.cfg.Relays {
 		go func() { s.rpDone <- s.runProcessor.Start(ctx) }()
 	}
+	if s.reaper != nil && s.cfg.Relays {
+		go func() { s.reaperDone <- s.reaper.Start(ctx) }()
+	}
 
 	// --- HTTP ---
 	httpErr := make(chan error, 1)
@@ -297,6 +309,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.runProcessor != nil {
 		s.runProcessor.Stop()
 	}
+	if s.reaper != nil {
+		s.reaper.Stop()
+	}
 	// Wait for those goroutines to exit (bounded by DrainTimeout).
 	select {
 	case <-s.relayDone:
@@ -311,6 +326,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.runProcessor != nil {
 		select {
 		case <-s.rpDone:
+		case <-shutCtx.Done():
+		}
+	}
+	if s.reaper != nil {
+		select {
+		case <-s.reaperDone:
 		case <-shutCtx.Done():
 		}
 	}


### PR DESCRIPTION
## Run reaper — fail runs the execution path leaves stuck

Closes the reliability gap documented in the INF-1 follow-up: a run that a worker
leased and then died on (past the redelivery window), or that was queued and never
dispatched (command lost/dead-lettered), would otherwise sit non-terminal forever.
The reaper is a control-plane safety net that marks such runs `failed`, emitting
`run.failed` so observers see it.

### The central correctness rule
Detection is **time-since-start, NOT worker-lease.** When a worker dies, JetStream
redelivers the un-acked command for up to `max_deliver × ack_wait ≈ 25 min` and a
fresh worker resumes from the last checkpoint. So the reaper only fails runs the
execution path has genuinely given up on:
- `in_progress` with `started_at` older than **30 min** (> the ~25 min redelivery
  window), and
- `queued` with `created_at` older than **10 min** (dispatch is normally
  near-instant).

A worker-lease trigger (~60s) would fail runs *mid-recovery* — this design
deliberately avoids that, and the test proves it.

### What's in it
- **`controlplane/eventstore`** (new) — extracted the transactional event append
  (`Event` + `Append`: EnsureStream + INSERT events + INSERT outbox) out of
  `endpoints` so the reaper and `endpoints.writeTx` share ONE append implementation
  (no duplicated append SQL — the drift class that caused the earlier envelope bug).
  Behavior-preserving: `endpoints.Event` is now a type alias, so every handler and
  generated `*_gen.go` compiles unchanged, and the full endpoints integration suite
  still passes.
- **`controlplane/reaper`** (new) — `RunReaper`, a `CleanupWorker`-shaped ticker.
  `reapOnce` selects stuck runs (`FOR UPDATE SKIP LOCKED`) in one transaction,
  marks them `failed`, and emits `run.failed` via `eventstore.Append` + one
  `pg_notify` per tick. Only touches `in_progress`/`queued` — ignores
  `requires_action` (HITL) and terminal states. Thresholds are configurable.
- **`server.go`** — wires the reaper alongside relay/cleanup/run-processor.

### Testing
Testcontainers Postgres, no build tag, standard CI.
- `TestReaperFailsStuckRuns`: seeds a stale `in_progress`, stale `queued`, a
  **fresh `in_progress`** (mid-recovery), and a fresh `queued`. Asserts exactly the
  two stale ones become `failed` with a `run.failed` outbox row each, and **both
  fresh runs are untouched** — the load-bearing "does not preempt recovery"
  assertion (mutation-verified in review: lowering the threshold makes it fail).
- `TestReaperIdempotent`: a second tick reaps 0.
- `eventstore` append test; full `controlplane/...` suite green (incl. `-race` on
  reaper + relay).

### Known limitations (documented, deferred)
- The `started_at` threshold assumes runs finish within 30 min. A real
  long-running graph engine will need **liveness-based** detection (last node event
  / run heartbeat) instead — bound to the graph-engine work.
- Scope is **fail only** — recovery (requeue + resume-from-checkpoint, bounded
  attempts) is a deliberate later enhancement.
