### PR TITLE
feat(controlplane): runs streaming (SSE) + wait — observe and await runs

### DIFF
--- a/controlplane/docs/superpowers/plans/2026-07-31-runs-streaming-wait.md
+++ b/controlplane/docs/superpowers/plans/2026-07-31-runs-streaming-wait.md
@@ -1,0 +1,436 @@
+# Pass D — Runs Streaming (SSE) + Wait Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a client observe and await a run — SSE streams of a run's events and blocking wait-until-terminal — by wiring the existing `nats.Subscriber` into the endpoints and filling the `sse`/`wait` stubs with a lossless catch-up-then-live handler.
+
+**Architecture:** `endpoints.Server` gains a `nats.Subscriber` (built in `server.go` from the relay's NATS conn). SSE handlers subscribe-first to `duragraph.runs.>`/`duragraph.executions.>`, replay the run's persisted events from the `events` table (catch-up), then stream live NATS messages filtered by `aggregate_id==run_id` and deduped by `event_id`, closing on the run's terminal event or client disconnect. Frames are thin passthrough (`event: <type>\ndata: <payload>`). Wait endpoints use the same subscribe-first discipline and return the final run as JSON.
+
+**Tech Stack:** Go 1.25, Echo v4 (streaming + flush), pgx v5, NATS core subscription (`nats.Subscriber`), testcontainers Postgres + embedded NATS.
+
+## Global Constraints
+
+- Design doc: `controlplane/docs/superpowers/specs/2026-07-31-runs-streaming-wait-design.md` — the contract.
+- **Lossless is the central property:** subscribe BEFORE the catch-up DB read; dedup live vs catch-up by `event_id`; a client connecting to an already-finished run must still receive its events (catch-up). The test that seeds catch-up events + publishes live + terminal is the guard.
+- Frame format is thin passthrough: `event: <event_type>\ndata: <payload-json>\n\n`, flushed. NOT LangGraph stream-mode format.
+- SSE endpoints require NATS: when `s.Subscriber == nil` → 503.
+- Generated `*_gen.go` never hand-edited; the `custom` flag emits routes-only, bodies hand-written. Marking `sse`/`wait` endpoints `custom` must leave the impl runs endpoints (create/get/cancel) byte-identical after regen.
+- **SSE tests MUST use `httptest.NewServer` (a real server), NOT `httptest.NewRecorder`** — the recorder buffers and doesn't support incremental flush/streaming.
+- Integration tests: testcontainers Postgres + embedded in-process NATS, no build tag, standard CI. Never weaken assertions.
+- Never hand-edit go.mod/go.sum. Conventional commits. No PR/push/merge without explicit approval.
+- Run from the worktree root `~/worktrees/duragraph/feat/controlplane-server` (branch `feat/controlplane-runs-streaming`).
+
+## File Structure
+
+- `controlplane/endpoints/runtime.go` (modify) — add `Subscriber *nats.Subscriber` to `Server`.
+- `controlplane/gen/endpoints.yaml` (modify) — mark the 6 runs `sse`/`wait` endpoints `custom`.
+- `controlplane/endpoints/runs_gen.go` (regenerate) — routes-only for the 6.
+- `controlplane/endpoints/runs_stream.go` (new) — SSE + wait handlers + shared helpers (`streamRun`, `catchUp`, `writeSSEFrame`, `isTerminalEvent`, `createRun`).
+- `controlplane/server/server.go` (modify) — construct `nats.NewSubscriberFromConn` and set `ep.Subscriber`.
+- Tests: `controlplane/endpoints/runs_stream_integration_test.go`.
+
+---
+
+## Task 1: Subscriber wiring + shared SSE plumbing + `stream_per_run`
+
+**Files:**
+- Modify: `controlplane/endpoints/runtime.go`, `controlplane/gen/endpoints.yaml`, `controlplane/server/server.go`
+- Regenerate: `controlplane/endpoints/runs_gen.go`
+- Create: `controlplane/endpoints/runs_stream.go`, `controlplane/endpoints/runs_stream_integration_test.go`
+
+**Interfaces:**
+- Produces: `Server.Subscriber *nats.Subscriber`; helpers `streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTerminal bool) error`, `catchUp(ctx, aggIDs []uuid.UUID) ([]frame, error)`, `writeSSEFrame(c echo.Context, eventType string, payload []byte) error`, `isTerminalEvent(t string) bool`; handler `RunsStreamPerRun`.
+- Consumes: `nats.Subscriber.Subscribe`, `nats.SubscriptionMsg`, the relay envelope (`{event_id, aggregate_id, event_type, payload}`).
+
+- [ ] **Step 1: Write the failing tests (SSE read harness + stream_per_run)**
+
+Create `controlplane/endpoints/runs_stream_integration_test.go`. It needs the shared `testPool` + an embedded NATS server. Add an embedded NATS to the endpoints package test setup if not present (mirror `controlplane/nats/nats_integration_test.go`'s embedded server; expose a package `testNATS *nats.Conn`). Then a real-server SSE read helper + the test:
+
+```go
+// readSSE connects to url, reads Server-Sent frames until `until` frames arrive or
+// the deadline passes, and returns them. Uses a real HTTP client (streaming).
+func readSSE(t *testing.T, url string, want int, deadline time.Duration) []sseFrame {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("sse connect: %v", err)
+	}
+	frames := make(chan sseFrame, 32)
+	go func() {
+		defer resp.Body.Close()
+		sc := bufio.NewScanner(resp.Body)
+		var ev, data string
+		for sc.Scan() {
+			line := sc.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				ev = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if ev != "" {
+					frames <- sseFrame{Event: ev, Data: data}
+					ev, data = "", ""
+				}
+			}
+		}
+	}()
+	var got []sseFrame
+	timeout := time.After(deadline)
+	for len(got) < want {
+		select {
+		case f := <-frames:
+			got = append(got, f)
+		case <-timeout:
+			return got
+		}
+	}
+	return got
+}
+
+type sseFrame struct{ Event, Data string }
+```
+
+And the test (uses an `httptest.NewServer` around an Echo with the runs streaming routes, the shared `testPool`, and `testNATS` for the Subscriber):
+
+```go
+func TestStreamPerRunCatchUpAndLive(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	// seed a run + two catch-up events (as if already emitted)
+	rid := seedRunWithStream(t, ctx) // helper: assistant + run + event_stream, returns run uuid
+	insertEvent(t, ctx, rid, 1, "run.started", `{"n":1}`)
+	insertEvent(t, ctx, rid, 2, "execution.node_completed", `{"node":"A"}`)
+
+	e := echo.New()
+	s := &Server{Tenant: testPool, Subscriber: nats.NewSubscriberFromConn(testNATS)}
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/stream"
+	// Read in a goroutine; publish live + terminal after the stream is up.
+	done := make(chan []sseFrame, 1)
+	go func() { done <- readSSE(t, url, 4, 5*time.Second) }()
+	time.Sleep(300 * time.Millisecond) // let subscribe+catchup run
+	pub := nats.NewPublisher(mustJS(t)) // JetStream publisher on testNATS
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("execution.node_completed"), uuid.NewString(), envelopeFor(rid, "execution.node_completed", `{"node":"B"}`))
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("run.completed"), uuid.NewString(), envelopeFor(rid, "run.completed", `{}`))
+
+	frames := <-done
+	// Expect 4: 2 catch-up (run.started, node_completed A) + 2 live (node_completed B, run.completed)
+	if len(frames) != 4 {
+		t.Fatalf("want 4 frames, got %d: %+v", len(frames), frames)
+	}
+	if frames[0].Event != "run.started" || frames[3].Event != "run.completed" {
+		t.Errorf("frame order wrong: %+v", frames)
+	}
+}
+```
+
+(Helpers `seedRunWithStream`, `insertEvent`, `envelopeFor`, `mustJS` are small; write them in the test file. `envelopeFor(rid, type, payload)` returns the relay envelope map `{event_id, aggregate_type:"Run", aggregate_id:rid, event_type, payload}`. The catch-up read keys on the `events` table, so `insertEvent` inserts into `events` with the given `event_version`.)
+
+Also `TestStreamRequiresNATS`: a `Server{Tenant: testPool}` (nil Subscriber) → GET stream → 503. And `TestStreamDedup`: an event whose `event_id` is in BOTH the catch-up `events` row and the published live envelope is emitted once (assert frame count).
+
+- [ ] **Step 2: Run — fails (handlers are stubs / no Subscriber field)**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestStreamPerRun|TestStreamRequiresNATS|TestStreamDedup' -v`
+Expected: FAIL (compile: `Server` has no `Subscriber`; `RunsStreamPerRun` returns the sse stub `501`).
+
+- [ ] **Step 3: Add the Subscriber field**
+
+In `controlplane/endpoints/runtime.go`, add to `Server`:
+```go
+	// Subscriber tails NATS for SSE/wait endpoints. Nil when NATS is disabled
+	// (those endpoints then return 503). Set by the server composition root.
+	Subscriber *nats.Subscriber
+```
+Add the import `"github.com/duragraph/duragraph/controlplane/nats"`.
+
+- [ ] **Step 4: Mark the 6 endpoints custom + regenerate**
+
+In `controlplane/gen/endpoints.yaml`, add `custom: true` to the runs endpoints `join`, `stream_per_run`, `stream_thread`, `create_and_stream`, `stateless_stream`, `stateless_wait`. Run `go run ./controlplane/gen`. Confirm: `git diff --stat controlplane/endpoints/assistants_gen.go controlplane/endpoints/store_gen.go` empty (other groups untouched); `runs_gen.go` now routes `RunsJoin`/`RunsStreamPerRun`/`RunsStreamThread`/`RunsCreateAndStream`/`RunsStatelessStream`/`RunsStatelessWait` with no bodies, and the impl handlers (create/get/cancel) keep their bodies.
+
+- [ ] **Step 5: Write the shared SSE plumbing + `stream_per_run`**
+
+Create `controlplane/endpoints/runs_stream.go`:
+
+```go
+// Hand-written SSE + wait handlers for the runs group (routes generated into
+// runs_gen.go via custom: true). Lossless: subscribe-first, replay persisted
+// events (catch-up), then stream live NATS events deduped by event_id, closing on
+// the run's terminal event or client disconnect. Thin passthrough frames.
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// relayEnvelope is the body the relay publishes (see nats/relay.go envelope()).
+type relayEnvelope struct {
+	EventID     string          `json:"event_id"`
+	AggregateID string          `json:"aggregate_id"`
+	EventType   string          `json:"event_type"`
+	Payload     json.RawMessage `json:"payload"`
+}
+
+func isTerminalEvent(t string) bool {
+	return t == "run.completed" || t == "run.failed" || t == "run.cancelled"
+}
+
+// RunsStreamPerRun streams one run's events. GET /threads/{id}/runs/{rid}/stream.
+func (s *Server) RunsStreamPerRun(c echo.Context) error {
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "streaming requires NATS")
+	}
+	rid, err := uuid.Parse(c.Param("rid"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid rid")
+	}
+	// validate the run exists
+	var exists bool
+	if err := s.Tenant.QueryRow(c.Request().Context(),
+		`SELECT true FROM runs WHERE id=$1`, rid).Scan(&exists); err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "run not found")
+	}
+	return s.streamRun(c, map[uuid.UUID]bool{rid: true}, true /*closeOnTerminal*/)
+}
+
+// streamRun runs the lossless catch-up-then-live loop for the given run id set.
+// closeOnTerminal ends the stream when a terminal run.* event for a watched run
+// arrives (per-run streams); false keeps it open until disconnect (thread feed).
+func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTerminal bool) error {
+	ctx := c.Request().Context()
+
+	// 1. Subscribe FIRST (before catch-up) so nothing is missed in the gap.
+	runsCh, err := s.Subscriber.Subscribe(ctx, "duragraph.runs.>")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	execCh, err := s.Subscriber.Subscribe(ctx, "duragraph.executions.>")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// SSE headers.
+	h := c.Response().Header()
+	h.Set(echo.HeaderContentType, "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	c.Response().WriteHeader(http.StatusOK)
+	c.Response().Flush()
+
+	seen := map[string]bool{} // event_id → emitted (dedup)
+
+	// 2. Catch-up: replay persisted events for the watched runs, in order.
+	ids := make([]uuid.UUID, 0, len(runIDs))
+	for id := range runIDs {
+		ids = append(ids, id)
+	}
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT event_id::text, event_type, payload FROM events
+		WHERE aggregate_id = ANY($1) ORDER BY event_version`, ids)
+	if err == nil {
+		for rows.Next() {
+			var eid, etype string
+			var payload []byte
+			if rows.Scan(&eid, &etype, &payload) == nil {
+				seen[eid] = true
+				if werr := writeSSEFrame(c, etype, payload); werr != nil {
+					rows.Close()
+					return nil // client gone
+				}
+				if closeOnTerminal && isTerminalEvent(etype) {
+					rows.Close()
+					return nil // run already finished — all events replayed
+				}
+			}
+		}
+		rows.Close()
+	}
+
+	// 3. Live: stream new events for the watched runs, deduped.
+	for {
+		var msg *nats.SubscriptionMsg
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg = <-runsCh:
+		case msg = <-execCh:
+		}
+		if msg == nil { // channel closed (ctx canceled)
+			return nil
+		}
+		var env relayEnvelope
+		if json.Unmarshal(msg.Payload, &env) != nil {
+			continue
+		}
+		aid, err := uuid.Parse(env.AggregateID)
+		if err != nil || !runIDs[aid] || seen[env.EventID] {
+			continue
+		}
+		seen[env.EventID] = true
+		if writeSSEFrame(c, env.EventType, env.Payload) != nil {
+			return nil
+		}
+		if closeOnTerminal && isTerminalEvent(env.EventType) {
+			return nil
+		}
+	}
+}
+
+func writeSSEFrame(c echo.Context, eventType string, payload []byte) error {
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	if _, err := c.Response().Write([]byte("event: " + eventType + "\ndata: ")); err != nil {
+		return err
+	}
+	if _, err := c.Response().Write(payload); err != nil {
+		return err
+	}
+	if _, err := c.Response().Write([]byte("\n\n")); err != nil {
+		return err
+	}
+	c.Response().Flush()
+	return nil
+}
+
+var _ = context.Background // retained if unused after edits
+```
+
+- [ ] **Step 6: Wire the Subscriber in the server**
+
+In `controlplane/server/server.go`, in the `cfg.NATSURL != ""` block where `nc, js` are obtained, after building the endpoints `ep`, set `ep.Subscriber = nats.NewSubscriberFromConn(nc)`. (The `ep` construction may be before the NATS block — if so, move the `ep.Subscriber` assignment to after `nc` exists, or set it when mounting. Ensure `ep.Subscriber` is nil when NATS is disabled.) The subscriber shares the relay's `nc`; it's drained on shutdown with the rest.
+
+- [ ] **Step 7: Build + run the tests**
+
+Run: `go build ./controlplane/...`
+Run: `go test ./controlplane/endpoints/ -run 'TestStreamPerRun|TestStreamRequiresNATS|TestStreamDedup' -v -count=1`
+Expected: PASS — catch-up (2) + live (2) frames, dedup, 503 without NATS.
+
+Run: `go test ./controlplane/endpoints/ -count=1` (regression — the impl runs endpoints + all groups still green).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add controlplane/endpoints/runtime.go controlplane/gen/endpoints.yaml \
+  controlplane/endpoints/runs_gen.go controlplane/endpoints/runs_stream.go \
+  controlplane/server/server.go controlplane/endpoints/runs_stream_integration_test.go
+git commit -m "feat(controlplane): SSE stream_per_run + subscriber wiring + lossless catch-up/live plumbing"
+```
+
+---
+
+## Task 2: `stream_thread` + `create_and_stream` + `stateless_stream`
+
+**Files:**
+- Modify: `controlplane/endpoints/runs_stream.go` (add handlers + `createRun` helper)
+- Modify: `controlplane/endpoints/runs_stream_integration_test.go` (add tests)
+
+**Interfaces:**
+- Consumes: `streamRun`, `writeSSEFrame` (Task 1); `writeTx`, `mustJSON`, `asUUID` (existing runtime helpers); the runs projection SQL (mirrors `RunsCreateOnThread`/`RunsCreateStateless`).
+- Produces: `RunsStreamThread`, `RunsCreateAndStream`, `RunsStatelessStream`; `createRun(ctx, threadID *uuid.UUID, req RunCreate…) (uuid.UUID, error)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `TestStreamThread` (seed a thread + 2 runs; catch-up replays both runs' events; `closeOnTerminal=false` — the stream stays open until the client disconnects; assert frames for both runs' seeded events arrive, then cancel the client) and `TestCreateAndStream` (`POST /threads/{id}/runs/stream` with a body → assert a `runs` row + `run.created` outbox row created, and the SSE stream opens; publish the run's events → frames arrive).
+
+- [ ] **Step 2: Run — fails**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestStreamThread|TestCreateAndStream' -v`
+Expected: FAIL (stub bodies).
+
+- [ ] **Step 3: Add the handlers + createRun**
+
+Append to `controlplane/endpoints/runs_stream.go`:
+- `RunsStreamThread(c)`: parse `id` (thread), `SELECT id FROM runs WHERE thread_id=$1` → build the `runIDs` set (may be empty), `streamRun(c, ids, false /*stay open*/)`. (Catch-up over `aggregate_id = ANY(ids)` handles the union; an empty set streams live-only until a run appears.)
+- `createRun(ctx, threadID *uuid.UUID, assistantID uuid.UUID, input, metadata []byte) (uuid.UUID, error)`: mirror `RunsCreateOnThread`'s create — `aggID := uuid.New()`; `writeTx(ctx, s.Tenant, []Event{{AggregateType:"Run", AggregateID: aggID, EventType:"run.created", Payload: …}}, projection)` where the projection does the `INSERT INTO runs (...)` (thread-scoped when `threadID != nil`, else stateless). Return `aggID`.
+- `RunsCreateAndStream(c)`: bind the create request; `rid, err := s.createRun(ctx, &threadID, …)`; then `streamRun(c, map[uuid.UUID]bool{rid: true}, true)`.
+- `RunsStatelessStream(c)`: same but `threadID = nil`.
+
+(The generated `RunsCreateOnThread`/`RunsCreateStateless` keep their own inline create — `createRun` is shared only by the two custom stream-create handlers here, to avoid a generator change. Small, acceptable.)
+
+- [ ] **Step 4: Build + tests + regression**
+
+Run: `go build ./controlplane/... && go test ./controlplane/endpoints/ -run 'TestStreamThread|TestCreateAndStream' -v -count=1` → PASS.
+Run: `go test ./controlplane/endpoints/ -count=1` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add controlplane/endpoints/runs_stream.go controlplane/endpoints/runs_stream_integration_test.go
+git commit -m "feat(controlplane): SSE stream_thread + create_and_stream + stateless_stream"
+```
+
+---
+
+## Task 3: `join` + `stateless_wait` + end-to-end
+
+**Files:**
+- Modify: `controlplane/endpoints/runs_stream.go` (add wait handlers)
+- Modify: `controlplane/endpoints/runs_stream_integration_test.go` (add tests + e2e)
+
+**Interfaces:**
+- Consumes: `Subscriber.Subscribe`, `relayEnvelope`, `isTerminalEvent`, `runRow.toAPI()`, `createRun`.
+- Produces: `RunsJoin`, `RunsStatelessWait`; `waitForRun(c, rid) (runRow, error)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`TestJoinReturnsOnTerminal`: seed an `in_progress` run; start `join` (GET) in a goroutine; after 300ms publish `run.completed` for the run; assert the handler returns 200 with the run whose status maps to a terminal API status. `TestJoinAlreadyTerminal`: seed a `completed` run → `join` returns immediately. `TestWaitRequiresNATS`: nil Subscriber → 503.
+
+Plus **`TestStreamEndToEnd`** (the integration proof, reusing the worker harness pattern): stand up the worker endpoints + run-processor + an in-process worker + the SSE endpoints against shared testcontainers; `POST /threads/{id}/runs/stream`; assert the SSE client receives `run.started` → `execution.node_completed`×2 → `run.completed` as the counter graph executes. (If wiring the full worker harness into the endpoints test package is too heavy, place this test in `controlplane/worker` alongside the existing e2e harness and drive the SSE client there — note which package it lands in.)
+
+- [ ] **Step 2: Run — fails**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestJoin|TestWait' -v` → FAIL.
+
+- [ ] **Step 3: Add the wait handlers**
+
+Append to `runs_stream.go`:
+- `waitForRun(c echo.Context, rid uuid.UUID) error`: if `s.Subscriber == nil` → 503. Subscribe FIRST to `duragraph.runs.>`. `SELECT status FROM runs WHERE id=$1` — 404 if missing; if terminal, skip waiting. Else loop `select { <-ctx.Done(): return current run; case msg := <-ch: parse envelope; if aggregate_id==rid && isTerminalEvent(type) break }`. Then `SELECT *` the run into `runRow`, `return c.JSON(200, row.toAPI())`.
+- `RunsJoin(c)`: parse `rid` → `waitForRun(c, rid)`.
+- `RunsStatelessWait(c)`: bind create request → `rid, _ := createRun(ctx, nil, …)` → `waitForRun(c, rid)`.
+
+- [ ] **Step 4: Build + tests + full regression (incl -race on the stream path)**
+
+Run: `go build ./... && go test ./controlplane/endpoints/ -run 'TestJoin|TestWait|TestStream' -race -count=1 -v` → PASS.
+Run: `go test ./controlplane/... -count=1` → whole rebuild green (incl. the e2e wherever it landed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add controlplane/endpoints/runs_stream.go controlplane/endpoints/runs_stream_integration_test.go
+git commit -m "feat(controlplane): runs join + wait (block-until-terminal) + streaming e2e"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** stream_per_run → T1; stream_thread/create_and_stream/stateless_stream → T2; join/stateless_wait → T3; subscriber wiring → T1 Step 6; lossless catch-up+live+dedup → `streamRun` (T1); thin passthrough frames → `writeSSEFrame`; 503-without-NATS → each handler; e2e → T3. ✓
+
+**Placeholder scan:** the `var _ = context.Background` line in T1 Step 5 is a guard against an unused import during incremental edits — remove it if `context` ends up used (it is, via `ctx`); the implementer deletes it. T2/T3 handler bodies are specified by contract + reference the shared `streamRun`/`createRun`/`waitForRun` with exact SQL described — the non-obvious code (`streamRun`, `writeSSEFrame`, the SSE read harness) is given in full in T1; the reuse handlers are thin wrappers, appropriate to specify by contract.
+
+**Type consistency:** `streamRun(c, map[uuid.UUID]bool, bool)`, `writeSSEFrame(c, string, []byte)`, `relayEnvelope{EventID,AggregateID,EventType,Payload}`, `isTerminalEvent(string) bool` used identically across tasks. Handler names match `pascal(runs)+pascal(name)`: `RunsStreamPerRun`/`RunsStreamThread`/`RunsCreateAndStream`/`RunsStatelessStream`/`RunsJoin`/`RunsStatelessWait`. `createRun` signature shared by T2/T3.
+
+**Open risks for the implementer:**
+- SSE tests MUST use `httptest.NewServer` (real server + flush), never `httptest.NewRecorder`. Stated in Global Constraints.
+- The endpoints test package needs an embedded NATS conn (`testNATS`) — add it to the package's test setup (mirror the nats package) if absent; the relay-published envelope shape must match `relayEnvelope` (verify against `nats/relay.go` `envelope()`).
+- Subscribe-first ordering is load-bearing: the two `Subscribe` calls MUST precede the catch-up DB read, or a fast event between read and subscribe is lost. Do not reorder.
+- `create_and_stream` writes headers (200) then streams; a create error must be returned as a normal HTTP error BEFORE any SSE header is written (validate/create first, stream second).
+
+## Notes for the implementer
+
+- Thin passthrough only: emit the real event types/payloads; do not synthesize LangGraph stream modes.
+- `stream_thread` uses `closeOnTerminal=false` (stays open until disconnect); the per-run/create variants use `true`.
+- Do not push/PR/merge without explicit approval.

--- a/controlplane/docs/superpowers/specs/2026-07-31-runs-streaming-wait-design.md
+++ b/controlplane/docs/superpowers/specs/2026-07-31-runs-streaming-wait-design.md
@@ -1,0 +1,161 @@
+# Pass D — runs streaming (SSE) + wait
+
+**Date:** 2026-07-31
+**Branch:** `feat/controlplane-runs-streaming` (off `main`)
+**Status:** approved design, pending implementation plan
+
+## Context
+
+Runs execute end-to-end (worker path + reaper merged), but a client can't yet
+**observe** or **await** a run. This slice adds the streaming/observability
+endpoints: SSE streams of a run's events and blocking wait-until-terminal. The
+hard NATS plumbing already exists — the relay publishes `run.*`/`execution.*` to
+JetStream, and `nats.Subscriber` (core-NATS ephemeral tail: `Subscribe(ctx,
+subject) → <-chan *SubscriptionMsg`) is built. This slice wires that subscriber
+into the endpoints and gives the `sse`/`wait` stubs bespoke handler bodies.
+
+Source of truth: `endpoint-queries.d2` (runs `stream_*`/`join`/`wait` blocks),
+`nats.d2` (RUNS/EXECUTION subjects), `duragraph-latest.yaml` (content types).
+
+### Scope
+
+**In (6 endpoints, all `custom` — SSE/wait can't be generator-fillable):**
+- SSE (`text/event-stream`): `stream_per_run` (`GET /threads/{id}/runs/{rid}/stream`),
+  `stream_thread` (`GET /threads/{id}/stream`), `create_and_stream`
+  (`POST /threads/{id}/runs/stream`), `stateless_stream` (`POST /runs/stream`).
+- wait (`application/json`, block-to-terminal): `join`
+  (`GET /threads/{id}/runs/{rid}/join`), `wait` (`POST /runs/wait`).
+
+**Out (separate passes):** `cancel`, `resume` (HITL), `batch` (event-sourced
+writes, no SSE); LangGraph SDK stream-mode format (see below).
+
+### Frame format: thin passthrough (not LangGraph stream modes)
+
+Frames carry the real events we emit — `run.started`, `execution.node_*`,
+`run.completed`/`failed`/`cancelled` — as `event: <event_type>\ndata:
+<payload>\n\n`. This proves the full pipe (worker → outbox → relay → NATS → SSE →
+client) with real data. It is **not** the LangGraph SDK stream-mode format
+(`values`/`updates`/`messages`) — those require real graph-state deltas the counter
+executor can't produce; that mapping is a refinement bound to the real graph
+engine.
+
+## Architecture
+
+### Wiring the subscriber into endpoints
+
+`endpoints.Server` gains a `Subscriber *nats.Subscriber` field (nil when NATS is
+disabled). `server.go` constructs it from the same `*nats.Conn` used for the relay
+(`nats.NewSubscriberFromConn(nc)`) and sets it on the `endpoints.Server`. SSE/wait
+handlers require it: when `s.Subscriber == nil`, they return `503` (streaming needs
+NATS).
+
+The relay's published subjects are `duragraph.runs.>` and `duragraph.executions.>`
+(envelope body: `{event_id, aggregate_type, aggregate_id, event_type, payload,
+metadata}` — `aggregate_id` is the run id). A per-run handler subscribes to both
+and filters received messages by `aggregate_id == run_id`.
+
+### SSE handler pattern — lossless (the central correctness design)
+
+Core-NATS subscription is live-only (no replay), and counter runs finish in
+milliseconds, so a naive "subscribe and stream" shows an existing run nothing. The
+handler is therefore **subscribe-first, then catch up, then go live, deduping**:
+
+1. **Subscribe first** to `duragraph.runs.>` + `duragraph.executions.>` (start
+   buffering live events *before* the DB read, so nothing slips through the gap
+   between read and subscribe).
+2. **Catch up** — `SELECT event_id, event_type, payload FROM events WHERE
+   aggregate_id = $run_id ORDER BY event_version` — emit each as a frame, recording
+   the set of emitted `event_id`s.
+3. **Go live** — for each buffered/incoming NATS message: parse the envelope, skip
+   unless `aggregate_id == run_id`, skip if `event_id` already emitted (dedup),
+   else emit.
+4. **Close** on the run's terminal event (`event_type ∈ {run.completed,
+   run.failed, run.cancelled}`) or client disconnect
+   (`<-c.Request().Context().Done()`). This per-run terminal close applies to
+   `stream_per_run`, `create_and_stream`, `stateless_stream`. **`stream_thread`
+   closes on client disconnect only** — a thread is a live feed that can have many
+   runs (and new ones start over time), so no single run's terminal ends it.
+
+Frame write (Echo): set headers `Content-Type: text/event-stream`, `Cache-Control:
+no-cache`, `Connection: keep-alive`; write `event: <type>\ndata: <json>\n\n`; then
+`c.Response().Flush()`. The subscription's `ctx` is `c.Request().Context()`, so a
+disconnect cancels it and `Subscriber` unsubscribes + closes the channel.
+
+- **`stream_thread`** resolves the thread's run ids first (`SELECT id FROM runs
+  WHERE thread_id=$tid`) and filters by `aggregate_id ∈` that set (catch-up unions
+  each run's events; a thread with no runs yet just streams live as runs appear).
+- **`create_and_stream` / `stateless_stream`** first create the run (reusing the
+  existing `run.created` write — `writeTx` + the runs projection), then run the SSE
+  pattern on the new run id. (Catch-up is near-empty since the run was just created;
+  events arrive live as the worker executes.)
+
+### wait / join — block until terminal
+
+Same subscribe-first discipline so the terminal event isn't missed in the gap:
+
+1. Subscribe first to `duragraph.runs.>` filtered to the run.
+2. `SELECT status FROM runs WHERE id=$rid` — if already terminal
+   (`completed`/`failed`/`cancelled`), skip waiting.
+3. Otherwise block on the subscription until a terminal `run.*` event for the run
+   (or a request-context/timeout deadline).
+4. `SELECT *` the final run and return it as JSON (the `runRow.toAPI()` shape).
+
+`wait` (`POST /runs/wait`) creates a stateless run first, then waits.
+
+## Error handling
+
+- `s.Subscriber == nil` (NATS off) → 503.
+- Run/thread not found → 404 (validate with a `SELECT` before streaming/waiting).
+- Bind failure on create-variants → 400.
+- SSE: on subscribe error → 500 before headers; after headers are sent, a mid-stream
+  error is logged and the stream closes (can't change the status code).
+- wait: request-context cancel/timeout → return whatever the run's current state is,
+  or 504 on an explicit deadline (design: return current run state on ctx done).
+
+## Testing
+
+Testcontainers Postgres + embedded in-process NATS, no build tag, standard CI.
+
+- **`TestStreamPerRunCatchUpAndLive`:** seed a run + insert two events (catch-up)
+  into `events`; start the SSE handler against an `httptest` server; read the SSE
+  response; assert the two catch-up frames arrive; then publish a live
+  `execution.node_completed` + a terminal `run.completed` to NATS; assert both
+  arrive (live, deduped — the terminal closes the stream). Confirms catch-up + live
+  + dedup + terminal-close.
+- **`TestStreamDedup`:** an event present in BOTH the catch-up read and the live
+  feed (same `event_id`) is emitted once.
+- **`TestJoinReturnsOnTerminal`:** seed an `in_progress` run; in a goroutine publish
+  `run.completed` after a short delay; assert `join` blocks then returns the run
+  with terminal status. And: an already-terminal run returns immediately.
+- **`TestCreateAndStream`:** `POST /threads/{id}/runs/stream` creates the run
+  (assert a `runs` row + `run.created` in outbox) and opens an SSE stream; publish
+  the run's events; assert frames arrive.
+- **`TestStreamRequiresNATS`:** `Subscriber == nil` → 503.
+- One lighter **end-to-end** reusing the worker harness: create-and-stream a run,
+  let the in-process worker execute the counter graph, assert the SSE client
+  receives `run.started` → `node_completed`×2 → `run.completed`.
+- Full `go test ./controlplane/... -count=1` green.
+
+## Files
+
+- `controlplane/endpoints/runtime.go` (modify) — add `Subscriber *nats.Subscriber`
+  to `Server`. (Import `controlplane/nats`.)
+- `controlplane/gen/endpoints.yaml` (modify) — mark the 6 runs streaming/wait
+  endpoints `custom`.
+- `controlplane/endpoints/runs_gen.go` (regenerate) — routes-only for those 6.
+- `controlplane/endpoints/runs_stream.go` (new) — the SSE + wait handlers + a shared
+  `streamRun`/`catchUp`/`isTerminal` helper set.
+- `controlplane/server/server.go` (modify) — construct `nats.NewSubscriberFromConn`
+  and set `ep.Subscriber`; ensure the subscriber's conn drains on shutdown.
+- Tests: `controlplane/endpoints/runs_stream_integration_test.go`.
+
+## Out of scope (recorded)
+
+- **LangGraph SDK stream-mode format** (`values`/`updates`/`messages`/`events`) —
+  needs the real graph engine's state semantics; thin passthrough now.
+- **`cancel` / `resume` / `batch`** — separate runs-writes pass.
+- **Reconnect / Last-Event-ID resume** of a dropped SSE connection — clients
+  reconnect and catch-up replays from the `events` table, but a formal
+  `Last-Event-ID` cursor is not implemented this slice.
+- **JetStream durable consumer** for SSE — core-NATS ephemeral is correct for a
+  live client; durability isn't needed (catch-up covers the persisted history).

--- a/controlplane/endpoints/assistants_integration_test.go
+++ b/controlplane/endpoints/assistants_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,19 +14,83 @@ import (
 	"testing"
 	"time"
 
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
+	"github.com/nats-io/nats-server/v2/server"
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // testPool connects to a real Postgres (testcontainers) with the tenant
-// migrations applied. Populated by TestMain.
-var testPool *pgxpool.Pool
+// migrations applied. testNATS is a core-NATS connection to an embedded,
+// in-process NATS+JetStream server (mirrors controlplane/nats's test setup).
+// Both are populated by TestMain and shared across every test in this
+// package.
+var (
+	testPool *pgxpool.Pool
+	testNATS *natsgo.Conn
+)
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
+
+	// --- embedded NATS server ---
+	natsPort, err := freeTCPPort()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "free-port: %v\n", err)
+		os.Exit(1)
+	}
+	natsDataDir, err := os.MkdirTemp("", "duragraph-endpoints-nats-test-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mkdtemp: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(natsDataDir)
+
+	natsSrv, err := server.NewServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      natsPort,
+		JetStream: true,
+		StoreDir:  filepath.Join(natsDataDir, "js"),
+		NoSigs:    true,
+		NoLog:     true, // quiet
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nats new: %v\n", err)
+		os.Exit(1)
+	}
+	go natsSrv.Start()
+	if !natsSrv.ReadyForConnections(10 * time.Second) {
+		fmt.Fprintln(os.Stderr, "nats: did not become ready")
+		os.Exit(1)
+	}
+	defer natsSrv.Shutdown()
+
+	natsURL := fmt.Sprintf("nats://127.0.0.1:%d", natsPort)
+	testNATS, err = natsgo.Connect(natsURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nats connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer testNATS.Drain()
+
+	// Declare the streams so tests can publish via JetStream (Publisher.
+	// PublishMsg requires the subject's stream to already exist).
+	testJS, err := jetstream.New(testNATS)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nats jetstream: %v\n", err)
+		os.Exit(1)
+	}
+	if err := dnats.EnsureStreams(ctx, testJS); err != nil {
+		fmt.Fprintf(os.Stderr, "nats ensure streams: %v\n", err)
+		os.Exit(1)
+	}
+
+	// --- Postgres testcontainer with tenant migrations applied ---
 	pg, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("tenant"),
@@ -58,6 +123,17 @@ func TestMain(m *testing.M) {
 	testPool.Close()
 	_ = pg.Terminate(ctx)
 	os.Exit(code)
+}
+
+// freeTCPPort returns an ephemeral port free at the moment of the call (best
+// effort — used only to hand the embedded NATS server a port to bind).
+func freeTCPPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // applyTenantMigrations runs every tenant *.up.sql in order against the pool.

--- a/controlplane/endpoints/runs_gen.go
+++ b/controlplane/endpoints/runs_gen.go
@@ -194,93 +194,17 @@ RETURNING id, thread_id, assistant_id, status, input, output, error, metadata, k
 	return c.JSON(http.StatusOK, row.toAPI())
 }
 
-// RunsJoin — POST /threads/{id}/runs/{rid}/join  (kind: wait)
-//   - SELECT status FROM runs WHERE id = :rid
-//   - IF not terminal: subscribe NATS run.completed/run.failed for run_id, block
-func (s *Server) RunsJoin(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// WAIT: create/read then block on a terminal NATS event. Bespoke — fill in.
-	//   SELECT status FROM runs WHERE id = :rid
-	//   IF not terminal: subscribe NATS run.completed/run.failed for run_id, block
-	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
-}
+// RunsJoin — POST /threads/{id}/runs/{rid}/join  (kind: wait) — hand-written in runs.go
 
-// RunsStreamPerRun — GET /threads/{id}/runs/{rid}/stream  (kind: sse)
-//   - SELECT status FROM runs WHERE id = :rid (validate exists)
-//   - Subscribe NATS JetStream consumer filtered to run_id subjects
-//   - Loop: receive → SSE data frame → flush
-//   - Cleanup: unsubscribe on client disconnect
-func (s *Server) RunsStreamPerRun(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SSE: subscribe to NATS, stream frames to client. Bespoke — fill in.
-	//   SELECT status FROM runs WHERE id = :rid (validate exists)
-	//   Subscribe NATS JetStream consumer filtered to run_id subjects
-	//   Loop: receive → SSE data frame → flush
-	//   Cleanup: unsubscribe on client disconnect
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
-}
+// RunsStreamPerRun — GET /threads/{id}/runs/{rid}/stream  (kind: sse) — hand-written in runs.go
 
-// RunsStreamThread — GET /threads/{id}/stream  (kind: sse)
-//   - SELECT id FROM runs WHERE thread_id = :id AND status IN ('queued','in_progress')
-//   - Subscribe NATS for all active runs on thread
-//   - Loop: receive → SSE → flush
-func (s *Server) RunsStreamThread(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SSE: subscribe to NATS, stream frames to client. Bespoke — fill in.
-	//   SELECT id FROM runs WHERE thread_id = :id AND status IN ('queued','in_progress')
-	//   Subscribe NATS for all active runs on thread
-	//   Loop: receive → SSE → flush
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
-}
+// RunsStreamThread — GET /threads/{id}/stream  (kind: sse) — hand-written in runs.go
 
-// RunsCreateAndStream — POST /threads/{id}/runs/stream  (kind: sse)
-//   - CREATE RUN (same as POST /threads/{id}/runs)
-//   - Subscribe NATS immediately to new run's subjects
-//   - Loop: SSE stream until terminal
-func (s *Server) RunsCreateAndStream(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SSE: subscribe to NATS, stream frames to client. Bespoke — fill in.
-	//   CREATE RUN (same as POST /threads/{id}/runs)
-	//   Subscribe NATS immediately to new run's subjects
-	//   Loop: SSE stream until terminal
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
-}
+// RunsCreateAndStream — POST /threads/{id}/runs/stream  (kind: sse) — hand-written in runs.go
 
-// RunsStatelessStream — POST /runs/stream  (kind: sse)
-//   - CREATE RUN (same as POST /runs)
-//   - Subscribe NATS immediately to new run's subjects
-//   - Loop: SSE stream until terminal
-func (s *Server) RunsStatelessStream(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SSE: subscribe to NATS, stream frames to client. Bespoke — fill in.
-	//   CREATE RUN (same as POST /runs)
-	//   Subscribe NATS immediately to new run's subjects
-	//   Loop: SSE stream until terminal
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
-}
+// RunsStatelessStream — POST /runs/stream  (kind: sse) — hand-written in runs.go
 
-// RunsStatelessWait — POST /runs/wait  (kind: wait)
-//   - CREATE RUN (same as POST /runs)
-//   - Subscribe NATS, wait for run.completed or run.failed
-//   - Return final run state as JSON
-func (s *Server) RunsStatelessWait(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// WAIT: create/read then block on a terminal NATS event. Bespoke — fill in.
-	//   CREATE RUN (same as POST /runs)
-	//   Subscribe NATS, wait for run.completed or run.failed
-	//   Return final run state as JSON
-	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
-}
+// RunsStatelessWait — POST /runs/wait  (kind: wait) — hand-written in runs.go
 
 // RunsCancelStateless — POST /runs/cancel  (kind: write)
 //   - same as POST /threads/{id}/runs/{rid}/cancel

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -3,21 +3,22 @@
 // events (catch-up), then stream live NATS events deduped by event_id, closing on
 // the run's terminal event or client disconnect. Thin passthrough frames.
 //
-// Task 1 (this file, initial cut) implements the shared plumbing (streamRun,
-// writeSSEFrame, isTerminalEvent, relayEnvelope) and RunsStreamPerRun in full.
-// RunsJoin, RunsStreamThread, RunsCreateAndStream, RunsStatelessStream, and
-// RunsStatelessWait are stubbed here with the same NotImplemented behavior the
-// generator previously produced — Tasks 2 and 3 replace the stubs with real
-// bodies built on streamRun (see
+// Task 1 implemented the shared plumbing (streamRun, writeSSEFrame,
+// isTerminalEvent, relayEnvelope) and RunsStreamPerRun in full. Task 2 (this
+// pass) adds RunsStreamThread, RunsCreateAndStream, RunsStatelessStream, and
+// the shared createRun helper, all built on streamRun. RunsJoin and
+// RunsStatelessWait remain stubbed pending Task 3 (see
 // controlplane/docs/superpowers/plans/2026-07-31-runs-streaming-wait.md).
 package endpoints
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	"github.com/duragraph/duragraph/controlplane/nats"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
 
@@ -31,6 +32,47 @@ type relayEnvelope struct {
 
 func isTerminalEvent(t string) bool {
 	return t == "run.completed" || t == "run.failed" || t == "run.cancelled"
+}
+
+// seenCap bounds the memory a single streamRun connection's dedup set can use.
+// Per-run streams (closeOnTerminal=true) close quickly and never approach
+// this; the thread feed (closeOnTerminal=false) can run indefinitely, so
+// without a bound its dedup set would grow forever. Evicting the oldest seen
+// event_id once the cap is exceeded trades perfect dedup for very old events
+// (rare — a duplicate that old would surface as a harmless repeat frame, never
+// a missed one) for a fixed memory ceiling.
+const seenCap = 4096
+
+// boundedSeen is a fixed-capacity, O(1) set of event_id strings backed by a
+// ring buffer: once full, each Add overwrites (and evicts from the map) the
+// oldest entry.
+type boundedSeen struct {
+	set  map[string]bool
+	ring []string
+	pos  int
+	full bool
+}
+
+func newBoundedSeen(cap int) *boundedSeen {
+	return &boundedSeen{set: make(map[string]bool, cap), ring: make([]string, cap)}
+}
+
+func (b *boundedSeen) Has(id string) bool { return b.set[id] }
+
+func (b *boundedSeen) Add(id string) {
+	if b.set[id] {
+		return
+	}
+	if b.full {
+		delete(b.set, b.ring[b.pos])
+	}
+	b.ring[b.pos] = id
+	b.set[id] = true
+	b.pos++
+	if b.pos == len(b.ring) {
+		b.pos = 0
+		b.full = true
+	}
 }
 
 // RunsStreamPerRun streams one run's events. GET /threads/{id}/runs/{rid}/stream.
@@ -75,22 +117,30 @@ func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTer
 	c.Response().WriteHeader(http.StatusOK)
 	c.Response().Flush()
 
-	seen := map[string]bool{} // event_id → emitted (dedup)
+	seen := newBoundedSeen(seenCap) // event_id → emitted (dedup, bounded)
 
 	// 2. Catch-up: replay persisted events for the watched runs, in order.
+	// Ordered by occurred_at first (event_version alone only orders events
+	// WITHIN one run's own stream; for a multi-run watch set — e.g. the
+	// thread feed, which unions every run on a thread — sorting by version
+	// alone interleaves each run's independently-numbered version sequence
+	// wrongly, since a low version number on one run has no relationship to
+	// a low version number on another. occurred_at gives a single, real
+	// chronological order across runs; event_version stays as the tiebreak
+	// for same-instant events, so single-run ordering is unchanged.
 	ids := make([]uuid.UUID, 0, len(runIDs))
 	for id := range runIDs {
 		ids = append(ids, id)
 	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT event_id::text, event_type, payload FROM events
-		WHERE aggregate_id = ANY($1) ORDER BY event_version`, ids)
+		WHERE aggregate_id = ANY($1) ORDER BY occurred_at, event_version`, ids)
 	if err == nil {
 		for rows.Next() {
 			var eid, etype string
 			var payload []byte
 			if rows.Scan(&eid, &etype, &payload) == nil {
-				seen[eid] = true
+				seen.Add(eid)
 				if werr := writeSSEFrame(c, etype, payload); werr != nil {
 					rows.Close()
 					return nil // client gone
@@ -121,10 +171,10 @@ func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTer
 			continue
 		}
 		aid, err := uuid.Parse(env.AggregateID)
-		if err != nil || !runIDs[aid] || seen[env.EventID] {
+		if err != nil || !runIDs[aid] || seen.Has(env.EventID) {
 			continue
 		}
-		seen[env.EventID] = true
+		seen.Add(env.EventID)
 		if writeSSEFrame(c, env.EventType, env.Payload) != nil {
 			return nil
 		}
@@ -151,11 +201,123 @@ func writeSSEFrame(c echo.Context, eventType string, payload []byte) error {
 	return nil
 }
 
-// --- Stubs below: Task 1 marks these endpoints custom (so Task 2/3 can build
-// on streamRun without another generator/regen round), but only implements
-// RunsStreamPerRun. The stubs reproduce the exact NotImplemented behavior the
-// generator previously emitted for these (kind: sse / kind: wait, no impl),
-// so this is a no-behavior-change placeholder pending Tasks 2 and 3.
+// RunsStreamThread — GET /threads/{id}/stream  (kind: sse)
+// Streams every run currently on the thread, unioned. The feed stays open
+// until the client disconnects (closeOnTerminal=false): a thread outlives any
+// single run, so a terminal event on one run must not end the whole feed. An
+// empty run set (a brand-new thread with no runs yet) is valid — nothing to
+// catch up on, and the live loop simply drops every envelope until a watched
+// aggregate_id shows up. Known limitation: runIDs is a snapshot taken once at
+// request time, so a run created on this thread AFTER the stream opens is not
+// added to the watch set (its events are silently ignored, not missed-then-
+// caught-up) — reconnecting picks it up. Fine for now; a future pass could
+// re-query periodically or subscribe to run.created for the thread.
+func (s *Server) RunsStreamThread(c echo.Context) error {
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "streaming requires NATS")
+	}
+	ctx := c.Request().Context()
+	threadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	ids := map[uuid.UUID]bool{}
+	rows, err := s.Tenant.Query(ctx, `SELECT id FROM runs WHERE thread_id = $1`, threadID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	for rows.Next() {
+		var id uuid.UUID
+		if scanErr := rows.Scan(&id); scanErr == nil {
+			ids[id] = true
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return s.streamRun(c, ids, false /*stay open — thread feed*/)
+}
+
+// createRun is the shared create path for the two stream-and-create
+// endpoints below. It mirrors RunsCreateOnThread/RunsCreateStateless's write
+// (event_streams + events + outbox + runs projection, all in one TX via
+// writeTx) but is parameterized on threadID so both variants can share it —
+// the generated handlers keep their own inline copy so this stays a small,
+// additive helper rather than a generator change. Returns the new run's id.
+func (s *Server) createRun(ctx context.Context, threadID *uuid.UUID, assistantID uuid.UUID, input, metadata []byte) (uuid.UUID, error) {
+	aggID := uuid.New()
+	payload := mustJSON(struct {
+		AssistantID uuid.UUID       `json:"assistant_id"`
+		Input       json.RawMessage `json:"input,omitempty"`
+		Metadata    json.RawMessage `json:"metadata,omitempty"`
+	}{AssistantID: assistantID, Input: input, Metadata: metadata})
+	events := []Event{
+		{AggregateType: "Run", AggregateID: aggID, EventType: "run.created", Payload: payload},
+	}
+	err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
+		var execErr error
+		if threadID != nil {
+			_, execErr = tx.Exec(ctx, `INSERT INTO runs (id, thread_id, assistant_id, status, input, metadata)
+VALUES ($1, $2, $3, 'queued', $4, $5)`, aggID, *threadID, assistantID, input, metadata)
+		} else {
+			_, execErr = tx.Exec(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata)
+VALUES ($1, $2, 'queued', $3, $4)`, aggID, assistantID, input, metadata)
+		}
+		return execErr
+	})
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return aggID, nil
+}
+
+// RunsCreateAndStream — POST /threads/{id}/runs/stream  (kind: sse)
+// Creates the run first (a normal HTTP error on a bad request/DB failure,
+// with no SSE header written yet), then streams that one run until terminal.
+func (s *Server) RunsCreateAndStream(c echo.Context) error {
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "streaming requires NATS")
+	}
+	ctx := c.Request().Context()
+	threadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req RunCreateStateful
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	rid, err := s.createRun(ctx, &threadID, asUUID(req.AssistantId), mustJSON(req.Input), mustJSON(req.Metadata))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return s.streamRun(c, map[uuid.UUID]bool{rid: true}, true /*closeOnTerminal*/)
+}
+
+// RunsStatelessStream — POST /runs/stream  (kind: sse)
+// Same as RunsCreateAndStream but for a stateless run (no thread).
+func (s *Server) RunsStatelessStream(c echo.Context) error {
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "streaming requires NATS")
+	}
+	ctx := c.Request().Context()
+	var req RunCreateStateless
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	rid, err := s.createRun(ctx, nil, asUUID(req.AssistantId), mustJSON(req.Input), mustJSON(req.Metadata))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return s.streamRun(c, map[uuid.UUID]bool{rid: true}, true /*closeOnTerminal*/)
+}
+
+// --- Stub below: Task 1 marks this endpoint custom (so Task 3 can build on
+// streamRun without another generator/regen round). The stub reproduces the
+// exact NotImplemented behavior the generator previously emitted for it
+// (kind: wait, no impl), so this is a no-behavior-change placeholder pending
+// Task 3.
 
 // RunsJoin — POST /threads/{id}/runs/{rid}/join  (kind: wait)
 //   - SELECT status FROM runs WHERE id = :rid
@@ -164,39 +326,6 @@ func writeSSEFrame(c echo.Context, eventType string, payload []byte) error {
 // TODO(Task 3): implement via waitForRun (see the streaming-wait plan).
 func (s *Server) RunsJoin(c echo.Context) error {
 	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
-}
-
-// RunsStreamThread — GET /threads/{id}/stream  (kind: sse)
-//   - SELECT id FROM runs WHERE thread_id = :id AND status IN ('queued','in_progress')
-//   - Subscribe NATS for all active runs on thread
-//   - Loop: receive → SSE → flush
-//
-// TODO(Task 2): implement via streamRun(c, ids, false).
-func (s *Server) RunsStreamThread(c echo.Context) error {
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
-}
-
-// RunsCreateAndStream — POST /threads/{id}/runs/stream  (kind: sse)
-//   - CREATE RUN (same as POST /threads/{id}/runs)
-//   - Subscribe NATS immediately to new run's subjects
-//   - Loop: SSE stream until terminal
-//
-// TODO(Task 2): implement via createRun + streamRun(c, {rid}, true).
-func (s *Server) RunsCreateAndStream(c echo.Context) error {
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
-}
-
-// RunsStatelessStream — POST /runs/stream  (kind: sse)
-//   - CREATE RUN (same as POST /runs)
-//   - Subscribe NATS immediately to new run's subjects
-//   - Loop: SSE stream until terminal
-//
-// TODO(Task 2): implement via createRun(nil, ...) + streamRun(c, {rid}, true).
-func (s *Server) RunsStatelessStream(c echo.Context) error {
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
 }
 
 // RunsStatelessWait — POST /runs/wait  (kind: wait)

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -4,16 +4,17 @@
 // the run's terminal event or client disconnect. Thin passthrough frames.
 //
 // Task 1 implemented the shared plumbing (streamRun, writeSSEFrame,
-// isTerminalEvent, relayEnvelope) and RunsStreamPerRun in full. Task 2 (this
-// pass) adds RunsStreamThread, RunsCreateAndStream, RunsStatelessStream, and
-// the shared createRun helper, all built on streamRun. RunsJoin and
-// RunsStatelessWait remain stubbed pending Task 3 (see
-// controlplane/docs/superpowers/plans/2026-07-31-runs-streaming-wait.md).
+// isTerminalEvent, relayEnvelope) and RunsStreamPerRun in full. Task 2 added
+// RunsStreamThread, RunsCreateAndStream, RunsStatelessStream, and the shared
+// createRun helper, all built on streamRun. Task 3 (this pass) adds
+// waitForRun (block-until-terminal, subscribe-first) plus RunsJoin and
+// RunsStatelessWait, built on it.
 package endpoints
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/duragraph/duragraph/controlplane/nats"
@@ -313,27 +314,111 @@ func (s *Server) RunsStatelessStream(c echo.Context) error {
 	return s.streamRun(c, map[uuid.UUID]bool{rid: true}, true /*closeOnTerminal*/)
 }
 
-// --- Stub below: Task 1 marks this endpoint custom (so Task 3 can build on
-// streamRun without another generator/regen round). The stub reproduces the
-// exact NotImplemented behavior the generator previously emitted for it
-// (kind: wait, no impl), so this is a no-behavior-change placeholder pending
-// Task 3.
+// waitForRun blocks until run rid reaches a terminal status (completed,
+// failed, cancelled), then responds 200 with the run's current API
+// representation. Subscribe-first (before the DB status read) is load-bearing:
+// it guarantees a terminal event fired in the gap between the read and the
+// subscribe can never be missed — the same lossless ordering streamRun uses.
+//
+//   - 503 if NATS is disabled (no Subscriber).
+//   - 404 if the run doesn't exist.
+//   - If the run is already terminal, returns immediately without waiting.
+//   - Otherwise blocks on the live feed until a terminal run.* event for rid
+//     arrives, or the request context is canceled (client disconnect/timeout),
+//     in which case it returns the run's state as of the cancellation.
+func (s *Server) waitForRun(c echo.Context, rid uuid.UUID) error {
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "wait requires NATS")
+	}
+	ctx := c.Request().Context()
+
+	// 1. Subscribe FIRST (before the status read) so nothing is missed in the gap.
+	runsCh, err := s.Subscriber.Subscribe(ctx, "duragraph.runs.>")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// 2. Check current status; skip waiting if already terminal.
+	var status string
+	if err := s.Tenant.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&status); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "run not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	if !isTerminalStatus(status) {
+		// 3. Block until a terminal run.* event for rid arrives, or disconnect.
+	waitLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				break waitLoop
+			case msg := <-runsCh:
+				if msg == nil { // channel closed (ctx canceled)
+					break waitLoop
+				}
+				var env relayEnvelope
+				if json.Unmarshal(msg.Payload, &env) != nil {
+					continue
+				}
+				aid, err := uuid.Parse(env.AggregateID)
+				if err != nil || aid != rid || !isTerminalEvent(env.EventType) {
+					continue
+				}
+				break waitLoop
+			}
+		}
+	}
+
+	// 4. Return the run's current state (fresh SELECT — whatever it is at this
+	// point, terminal or not, e.g. if the wait ended via client disconnect).
+	rows, err := s.Tenant.Query(ctx, `SELECT id, thread_id, assistant_id, status, input, output, error, metadata, kwargs, multitask_strategy, version, lease_epoch, worker_id, priority, graph_id, created_at, started_at, completed_at, updated_at
+FROM runs WHERE id = $1`, rid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[runRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "run not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toAPI())
+}
+
+// isTerminalStatus reports whether a DB runs.status value is terminal
+// (mirrors isTerminalEvent's event-type check, for the DB-status side).
+func isTerminalStatus(status string) bool {
+	return status == "completed" || status == "failed" || status == "cancelled"
+}
 
 // RunsJoin — POST /threads/{id}/runs/{rid}/join  (kind: wait)
-//   - SELECT status FROM runs WHERE id = :rid
-//   - IF not terminal: subscribe NATS run.completed/run.failed for run_id, block
-//
-// TODO(Task 3): implement via waitForRun (see the streaming-wait plan).
+// Blocks until the run reaches a terminal status, then returns it as JSON.
 func (s *Server) RunsJoin(c echo.Context) error {
-	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
+	rid, err := uuid.Parse(c.Param("rid"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid rid")
+	}
+	return s.waitForRun(c, rid)
 }
 
 // RunsStatelessWait — POST /runs/wait  (kind: wait)
-//   - CREATE RUN (same as POST /runs)
-//   - Subscribe NATS, wait for run.completed or run.failed
-//   - Return final run state as JSON
-//
-// TODO(Task 3): implement via createRun(nil, ...) + waitForRun.
+// Creates a stateless run, then blocks until it reaches a terminal status and
+// returns it as JSON.
 func (s *Server) RunsStatelessWait(c echo.Context) error {
-	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "wait requires NATS")
+	}
+	ctx := c.Request().Context()
+	var req RunCreateStateless
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	rid, err := s.createRun(ctx, nil, asUUID(req.AssistantId), mustJSON(req.Input), mustJSON(req.Metadata))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return s.waitForRun(c, rid)
 }

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -1,0 +1,210 @@
+// Hand-written SSE + wait handlers for the runs group (routes generated into
+// runs_gen.go via custom: true). Lossless: subscribe-first, replay persisted
+// events (catch-up), then stream live NATS events deduped by event_id, closing on
+// the run's terminal event or client disconnect. Thin passthrough frames.
+//
+// Task 1 (this file, initial cut) implements the shared plumbing (streamRun,
+// writeSSEFrame, isTerminalEvent, relayEnvelope) and RunsStreamPerRun in full.
+// RunsJoin, RunsStreamThread, RunsCreateAndStream, RunsStatelessStream, and
+// RunsStatelessWait are stubbed here with the same NotImplemented behavior the
+// generator previously produced — Tasks 2 and 3 replace the stubs with real
+// bodies built on streamRun (see
+// controlplane/docs/superpowers/plans/2026-07-31-runs-streaming-wait.md).
+package endpoints
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// relayEnvelope is the body the relay publishes (see nats/relay.go envelope()).
+type relayEnvelope struct {
+	EventID     string          `json:"event_id"`
+	AggregateID string          `json:"aggregate_id"`
+	EventType   string          `json:"event_type"`
+	Payload     json.RawMessage `json:"payload"`
+}
+
+func isTerminalEvent(t string) bool {
+	return t == "run.completed" || t == "run.failed" || t == "run.cancelled"
+}
+
+// RunsStreamPerRun streams one run's events. GET /threads/{id}/runs/{rid}/stream.
+func (s *Server) RunsStreamPerRun(c echo.Context) error {
+	if s.Subscriber == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "streaming requires NATS")
+	}
+	rid, err := uuid.Parse(c.Param("rid"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid rid")
+	}
+	// validate the run exists
+	var exists bool
+	if err := s.Tenant.QueryRow(c.Request().Context(),
+		`SELECT true FROM runs WHERE id=$1`, rid).Scan(&exists); err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "run not found")
+	}
+	return s.streamRun(c, map[uuid.UUID]bool{rid: true}, true /*closeOnTerminal*/)
+}
+
+// streamRun runs the lossless catch-up-then-live loop for the given run id set.
+// closeOnTerminal ends the stream when a terminal run.* event for a watched run
+// arrives (per-run streams); false keeps it open until disconnect (thread feed).
+func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTerminal bool) error {
+	ctx := c.Request().Context()
+
+	// 1. Subscribe FIRST (before catch-up) so nothing is missed in the gap.
+	runsCh, err := s.Subscriber.Subscribe(ctx, "duragraph.runs.>")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	execCh, err := s.Subscriber.Subscribe(ctx, "duragraph.executions.>")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// SSE headers.
+	h := c.Response().Header()
+	h.Set(echo.HeaderContentType, "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	c.Response().WriteHeader(http.StatusOK)
+	c.Response().Flush()
+
+	seen := map[string]bool{} // event_id → emitted (dedup)
+
+	// 2. Catch-up: replay persisted events for the watched runs, in order.
+	ids := make([]uuid.UUID, 0, len(runIDs))
+	for id := range runIDs {
+		ids = append(ids, id)
+	}
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT event_id::text, event_type, payload FROM events
+		WHERE aggregate_id = ANY($1) ORDER BY event_version`, ids)
+	if err == nil {
+		for rows.Next() {
+			var eid, etype string
+			var payload []byte
+			if rows.Scan(&eid, &etype, &payload) == nil {
+				seen[eid] = true
+				if werr := writeSSEFrame(c, etype, payload); werr != nil {
+					rows.Close()
+					return nil // client gone
+				}
+				if closeOnTerminal && isTerminalEvent(etype) {
+					rows.Close()
+					return nil // run already finished — all events replayed
+				}
+			}
+		}
+		rows.Close()
+	}
+
+	// 3. Live: stream new events for the watched runs, deduped.
+	for {
+		var msg *nats.SubscriptionMsg
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg = <-runsCh:
+		case msg = <-execCh:
+		}
+		if msg == nil { // channel closed (ctx canceled)
+			return nil
+		}
+		var env relayEnvelope
+		if json.Unmarshal(msg.Payload, &env) != nil {
+			continue
+		}
+		aid, err := uuid.Parse(env.AggregateID)
+		if err != nil || !runIDs[aid] || seen[env.EventID] {
+			continue
+		}
+		seen[env.EventID] = true
+		if writeSSEFrame(c, env.EventType, env.Payload) != nil {
+			return nil
+		}
+		if closeOnTerminal && isTerminalEvent(env.EventType) {
+			return nil
+		}
+	}
+}
+
+func writeSSEFrame(c echo.Context, eventType string, payload []byte) error {
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	if _, err := c.Response().Write([]byte("event: " + eventType + "\ndata: ")); err != nil {
+		return err
+	}
+	if _, err := c.Response().Write(payload); err != nil {
+		return err
+	}
+	if _, err := c.Response().Write([]byte("\n\n")); err != nil {
+		return err
+	}
+	c.Response().Flush()
+	return nil
+}
+
+// --- Stubs below: Task 1 marks these endpoints custom (so Task 2/3 can build
+// on streamRun without another generator/regen round), but only implements
+// RunsStreamPerRun. The stubs reproduce the exact NotImplemented behavior the
+// generator previously emitted for these (kind: sse / kind: wait, no impl),
+// so this is a no-behavior-change placeholder pending Tasks 2 and 3.
+
+// RunsJoin — POST /threads/{id}/runs/{rid}/join  (kind: wait)
+//   - SELECT status FROM runs WHERE id = :rid
+//   - IF not terminal: subscribe NATS run.completed/run.failed for run_id, block
+//
+// TODO(Task 3): implement via waitForRun (see the streaming-wait plan).
+func (s *Server) RunsJoin(c echo.Context) error {
+	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
+}
+
+// RunsStreamThread — GET /threads/{id}/stream  (kind: sse)
+//   - SELECT id FROM runs WHERE thread_id = :id AND status IN ('queued','in_progress')
+//   - Subscribe NATS for all active runs on thread
+//   - Loop: receive → SSE → flush
+//
+// TODO(Task 2): implement via streamRun(c, ids, false).
+func (s *Server) RunsStreamThread(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
+	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
+}
+
+// RunsCreateAndStream — POST /threads/{id}/runs/stream  (kind: sse)
+//   - CREATE RUN (same as POST /threads/{id}/runs)
+//   - Subscribe NATS immediately to new run's subjects
+//   - Loop: SSE stream until terminal
+//
+// TODO(Task 2): implement via createRun + streamRun(c, {rid}, true).
+func (s *Server) RunsCreateAndStream(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
+	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
+}
+
+// RunsStatelessStream — POST /runs/stream  (kind: sse)
+//   - CREATE RUN (same as POST /runs)
+//   - Subscribe NATS immediately to new run's subjects
+//   - Loop: SSE stream until terminal
+//
+// TODO(Task 2): implement via createRun(nil, ...) + streamRun(c, {rid}, true).
+func (s *Server) RunsStatelessStream(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
+	return echo.NewHTTPError(http.StatusNotImplemented, "sse handler not implemented")
+}
+
+// RunsStatelessWait — POST /runs/wait  (kind: wait)
+//   - CREATE RUN (same as POST /runs)
+//   - Subscribe NATS, wait for run.completed or run.failed
+//   - Return final run state as JSON
+//
+// TODO(Task 3): implement via createRun(nil, ...) + waitForRun.
+func (s *Server) RunsStatelessWait(c echo.Context) error {
+	return echo.NewHTTPError(http.StatusNotImplemented, "wait handler not implemented")
+}

--- a/controlplane/endpoints/runs_stream_integration_test.go
+++ b/controlplane/endpoints/runs_stream_integration_test.go
@@ -1,0 +1,248 @@
+package endpoints
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// sseFrame is one decoded Server-Sent Event (event + data lines).
+type sseFrame struct{ Event, Data string }
+
+// readSSE connects to url, reads Server-Sent frames until `want` frames arrive
+// or the deadline passes, and returns whatever was collected. Uses a real HTTP
+// client (streaming) — httptest.NewRecorder buffers and can't do this.
+func readSSE(t *testing.T, url string, want int, deadline time.Duration) []sseFrame {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("sse connect: %v", err)
+	}
+	frames := make(chan sseFrame, 32)
+	go func() {
+		defer resp.Body.Close()
+		sc := bufio.NewScanner(resp.Body)
+		var ev, data string
+		for sc.Scan() {
+			line := sc.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				ev = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if ev != "" {
+					frames <- sseFrame{Event: ev, Data: data}
+					ev, data = "", ""
+				}
+			}
+		}
+	}()
+	var got []sseFrame
+	timeout := time.After(deadline)
+	for len(got) < want {
+		select {
+		case f := <-frames:
+			got = append(got, f)
+		case <-timeout:
+			return got
+		}
+	}
+	return got
+}
+
+// seedRunWithStream creates an assistant, a stateless run, and the run's
+// event_streams row (aggregate_type='Run', aggregate_id=<run id>) so
+// insertEvent can append catch-up events against it. Returns the run's uuid.
+func seedRunWithStream(t *testing.T, ctx context.Context) uuid.UUID {
+	t.Helper()
+	var assistantID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (graph_id, name) VALUES ('hello_world', 'stream-test') RETURNING id`,
+	).Scan(&assistantID); err != nil {
+		t.Fatalf("seed assistant: %v", err)
+	}
+	var runID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (assistant_id, status) VALUES ($1, 'in_progress') RETURNING id`, assistantID,
+	).Scan(&runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO event_streams (aggregate_type, aggregate_id, version) VALUES ('Run', $1, 0)`, runID,
+	); err != nil {
+		t.Fatalf("seed event_stream: %v", err)
+	}
+	return runID
+}
+
+// insertEvent appends one row directly to the events table (as if already
+// relayed/emitted), for a run seeded by seedRunWithStream. Returns the
+// generated event_id so callers (e.g. the dedup test) can republish it live.
+func insertEvent(t *testing.T, ctx context.Context, runID uuid.UUID, version int, eventType, payload string) uuid.UUID {
+	t.Helper()
+	var streamID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`SELECT stream_id FROM event_streams WHERE aggregate_type='Run' AND aggregate_id=$1`, runID,
+	).Scan(&streamID); err != nil {
+		t.Fatalf("insertEvent: lookup stream: %v", err)
+	}
+	eventID := uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO events (event_id, stream_id, aggregate_type, aggregate_id, event_type, event_version, payload)
+		VALUES ($1, $2, 'Run', $3, $4, $5, $6)`,
+		eventID, streamID, runID, eventType, version, payload,
+	); err != nil {
+		t.Fatalf("insertEvent: %v", err)
+	}
+	return eventID
+}
+
+// envelopeFor builds the relay envelope shape (nats/relay.go envelope()) for
+// a live publish in tests, with a fresh event_id.
+func envelopeFor(rid uuid.UUID, eventType, payload string) map[string]any {
+	var p any
+	_ = json.Unmarshal([]byte(payload), &p)
+	return map[string]any{
+		"event_id":       uuid.NewString(),
+		"aggregate_type": "Run",
+		"aggregate_id":   rid.String(),
+		"event_type":     eventType,
+		"payload":        p,
+	}
+}
+
+// mustJS returns a JetStream context over the shared embedded testNATS
+// connection, for tests that publish live events via nats.Publisher.
+func mustJS(t *testing.T) jetstream.JetStream {
+	t.Helper()
+	js, err := jetstream.New(testNATS)
+	if err != nil {
+		t.Fatalf("mustJS: %v", err)
+	}
+	return js
+}
+
+// newStreamTestServer mounts the runs group with a live Subscriber over the
+// shared embedded testNATS connection.
+func newStreamTestServer() *Server {
+	return &Server{Tenant: testPool, Subscriber: nats.NewSubscriberFromConn(testNATS)}
+}
+
+// TestStreamPerRunCatchUpAndLive proves the central lossless property:
+// subscribe-first, then catch-up (persisted events), then live (deduped by
+// event_id), closing on the run's terminal event.
+func TestStreamPerRunCatchUpAndLive(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	// seed a run + two catch-up events (as if already emitted)
+	rid := seedRunWithStream(t, ctx) // helper: assistant + run + event_stream, returns run uuid
+	insertEvent(t, ctx, rid, 1, "run.started", `{"n":1}`)
+	insertEvent(t, ctx, rid, 2, "execution.node_completed", `{"node":"A"}`)
+
+	e := echo.New()
+	s := newStreamTestServer()
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/stream"
+	// Read in a goroutine; publish live + terminal after the stream is up.
+	done := make(chan []sseFrame, 1)
+	go func() { done <- readSSE(t, url, 4, 5*time.Second) }()
+	time.Sleep(300 * time.Millisecond)  // let subscribe+catchup run
+	pub := nats.NewPublisher(mustJS(t)) // JetStream publisher on testNATS
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("execution.node_completed"), uuid.NewString(), envelopeFor(rid, "execution.node_completed", `{"node":"B"}`))
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("run.completed"), uuid.NewString(), envelopeFor(rid, "run.completed", `{}`))
+
+	frames := <-done
+	// Expect 4: 2 catch-up (run.started, node_completed A) + 2 live (node_completed B, run.completed)
+	if len(frames) != 4 {
+		t.Fatalf("want 4 frames, got %d: %+v", len(frames), frames)
+	}
+	if frames[0].Event != "run.started" || frames[3].Event != "run.completed" {
+		t.Errorf("frame order wrong: %+v", frames)
+	}
+}
+
+// TestStreamRequiresNATS proves the SSE endpoint 503s immediately when the
+// server has no Subscriber (NATS disabled) — no DB round-trip, no streaming.
+func TestStreamRequiresNATS(t *testing.T) {
+	e := echo.New()
+	s := &Server{Tenant: testPool}
+	s.RegisterRuns(e.Group("/api/v1"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/threads/"+uuid.Nil.String()+"/runs/"+uuid.New().String()+"/stream", nil)
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestStreamDedup proves an event whose event_id is present in BOTH the
+// catch-up events row and a subsequently-published live envelope is emitted
+// only once — the seen-by-event_id dedup guard.
+func TestStreamDedup(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	rid := seedRunWithStream(t, ctx)
+	dupID := insertEvent(t, ctx, rid, 1, "run.started", `{"n":1}`)
+
+	e := echo.New()
+	s := newStreamTestServer()
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/stream"
+	// Only 2 frames are ever legitimate here: the catch-up run.started, and
+	// the live run.completed. If dedup is broken, the duplicated run.started
+	// would arrive as a THIRD frame before run.completed, and frames[1] would
+	// be the dup (not run.completed) — readSSE stops at `want` frames, so a
+	// dedup failure surfaces as a wrong frames[1].Event below.
+	done := make(chan []sseFrame, 1)
+	go func() { done <- readSSE(t, url, 2, 5*time.Second) }()
+	time.Sleep(300 * time.Millisecond)
+
+	pub := nats.NewPublisher(mustJS(t))
+	// Republish the SAME event_id as the catch-up row — must be deduped.
+	dupEnvelope := map[string]any{
+		"event_id":       dupID.String(),
+		"aggregate_type": "Run",
+		"aggregate_id":   rid.String(),
+		"event_type":     "run.started",
+		"payload":        map[string]any{"n": 1},
+	}
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("run.started"), uuid.NewString(), dupEnvelope)
+	// A genuine new terminal event, with its own event_id.
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("run.completed"), uuid.NewString(), envelopeFor(rid, "run.completed", `{}`))
+
+	frames := <-done
+	if len(frames) != 2 {
+		t.Fatalf("want 2 frames (catch-up run.started + live run.completed; dup dropped), got %d: %+v", len(frames), frames)
+	}
+	if frames[0].Event != "run.started" {
+		t.Errorf("frame 0: want run.started (catch-up), got %+v", frames[0])
+	}
+	if frames[1].Event != "run.completed" {
+		t.Errorf("frame 1: want run.completed (live terminal, dup dropped), got %+v", frames[1])
+	}
+}

--- a/controlplane/endpoints/runs_stream_integration_test.go
+++ b/controlplane/endpoints/runs_stream_integration_test.go
@@ -123,6 +123,27 @@ func envelopeFor(rid uuid.UUID, eventType, payload string) map[string]any {
 	}
 }
 
+// seedRunOnThreadWithStream creates a run scoped to threadID (using the given
+// assistant) plus its event_streams row — the thread-scoped sibling of
+// seedRunWithStream, for tests that need multiple runs on one thread (e.g.
+// TestStreamThread's multi-run catch-up ordering).
+func seedRunOnThreadWithStream(t *testing.T, ctx context.Context, threadID, assistantID uuid.UUID) uuid.UUID {
+	t.Helper()
+	var runID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1, $2, 'in_progress') RETURNING id`,
+		threadID, assistantID,
+	).Scan(&runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO event_streams (aggregate_type, aggregate_id, version) VALUES ('Run', $1, 0)`, runID,
+	); err != nil {
+		t.Fatalf("seed event_stream: %v", err)
+	}
+	return runID
+}
+
 // mustJS returns a JetStream context over the shared embedded testNATS
 // connection, for tests that publish live events via nats.Publisher.
 func mustJS(t *testing.T) jetstream.JetStream {
@@ -244,5 +265,197 @@ func TestStreamDedup(t *testing.T) {
 	}
 	if frames[1].Event != "run.completed" {
 		t.Errorf("frame 1: want run.completed (live terminal, dup dropped), got %+v", frames[1])
+	}
+}
+
+// readSSEViaRequest is readSSE but takes a caller-built *http.Request (so the
+// test can attach a cancelable context) instead of building one from a URL.
+func readSSEViaRequest(t *testing.T, req *http.Request, want int, deadline time.Duration) []sseFrame {
+	t.Helper()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// A canceled request surfaces here as an error too; treat as "no frames".
+		return nil
+	}
+	defer resp.Body.Close()
+	frames := make(chan sseFrame, 32)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		var ev, data string
+		for sc.Scan() {
+			line := sc.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				ev = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if ev != "" {
+					frames <- sseFrame{Event: ev, Data: data}
+					ev, data = "", ""
+				}
+			}
+		}
+	}()
+	var got []sseFrame
+	timeout := time.After(deadline)
+	for len(got) < want {
+		select {
+		case f := <-frames:
+			got = append(got, f)
+		case <-timeout:
+			return got
+		}
+	}
+	return got
+}
+
+// TestStreamThread proves the thread feed (GET /threads/{id}/stream) unions
+// catch-up events across ALL of a thread's runs and orders them
+// chronologically rather than by each run's own event_version — the Task 1
+// review Minor: sorting purely by event_version interleaves multiple runs'
+// independent version sequences wrongly. Here run1 gets three events
+// (started, node_completed, completed) strictly before run2's single
+// started event is inserted; a naive `ORDER BY event_version` would sort
+// run2's version-1 event ahead of run1's version-2/3 events (tied at
+// version 1 with run1's own started event), which is chronologically wrong.
+// It also proves closeOnTerminal=false: run1's run.completed (a terminal
+// event) arrives mid-catch-up but the thread feed stays open and still
+// delivers run2's later events (both catch-up and live).
+func TestStreamThread(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants, threads CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	var assistantID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (graph_id, name) VALUES ('hello_world', 'thread-stream-test') RETURNING id`,
+	).Scan(&assistantID); err != nil {
+		t.Fatalf("seed assistant: %v", err)
+	}
+	var threadID uuid.UUID
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatalf("seed thread: %v", err)
+	}
+	run1 := seedRunOnThreadWithStream(t, ctx, threadID, assistantID)
+	run2 := seedRunOnThreadWithStream(t, ctx, threadID, assistantID)
+
+	insertEvent(t, ctx, run1, 1, "run.started", `{}`)
+	time.Sleep(5 * time.Millisecond)
+	insertEvent(t, ctx, run1, 2, "execution.node_completed", `{"node":"A"}`)
+	time.Sleep(5 * time.Millisecond)
+	insertEvent(t, ctx, run1, 3, "run.completed", `{}`)
+	time.Sleep(5 * time.Millisecond)
+	insertEvent(t, ctx, run2, 1, "run.started", `{}`)
+
+	e := echo.New()
+	s := newStreamTestServer()
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + threadID.String() + "/stream"
+	reqCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+
+	done := make(chan []sseFrame, 1)
+	go func() { done <- readSSEViaRequest(t, req, 5, 5*time.Second) }()
+	time.Sleep(300 * time.Millisecond) // let subscribe+catchup run
+
+	pub := nats.NewPublisher(mustJS(t))
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("execution.node_completed"), uuid.NewString(),
+		envelopeFor(run2, "execution.node_completed", `{"node":"B"}`))
+
+	frames := <-done
+	cancel() // end the still-open thread feed now that we have what we need
+
+	want := []string{"run.started", "execution.node_completed", "run.completed", "run.started", "execution.node_completed"}
+	if len(frames) != len(want) {
+		t.Fatalf("want %d frames, got %d: %+v", len(want), len(frames), frames)
+	}
+	for i, w := range want {
+		if frames[i].Event != w {
+			t.Errorf("frame %d: want %s, got %s (full: %+v)", i, w, frames[i].Event, frames)
+		}
+	}
+}
+
+// TestCreateAndStream proves POST /threads/{id}/runs/stream creates the run
+// (runs row + run.created event/outbox row) BEFORE any SSE bytes are written,
+// then streams that run's events — catch-up replays run.created itself, then
+// a live-published event arrives.
+func TestCreateAndStream(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants, threads CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	var assistantID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (graph_id, name) VALUES ('hello_world', 'create-stream-test') RETURNING id`,
+	).Scan(&assistantID); err != nil {
+		t.Fatalf("seed assistant: %v", err)
+	}
+	var threadID uuid.UUID
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatalf("seed thread: %v", err)
+	}
+
+	e := echo.New()
+	s := newStreamTestServer()
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + threadID.String() + "/runs/stream"
+	body := `{"assistant_id":"` + assistantID.String() + `"}`
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodPost, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	done := make(chan []sseFrame, 1)
+	go func() { done <- readSSEViaRequest(t, req, 2, 5*time.Second) }()
+
+	// Poll for the run row the POST creates, then assert its run.created
+	// event + outbox row landed BEFORE publishing a second, live event.
+	var runID uuid.UUID
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := testPool.QueryRow(ctx, `SELECT id FROM runs WHERE thread_id=$1`, threadID).Scan(&runID); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if runID == uuid.Nil {
+		t.Fatalf("runs row was not created by POST")
+	}
+	var eventCount, outboxCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='run.created'`, runID,
+	).Scan(&eventCount); err != nil || eventCount != 1 {
+		t.Fatalf("run.created event missing: count=%d err=%v", eventCount, err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.created'`, runID,
+	).Scan(&outboxCount); err != nil || outboxCount != 1 {
+		t.Fatalf("run.created outbox row missing: count=%d err=%v", outboxCount, err)
+	}
+
+	pub := nats.NewPublisher(mustJS(t))
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("run.started"), uuid.NewString(), envelopeFor(runID, "run.started", `{}`))
+
+	frames := <-done
+	cancel()
+
+	if len(frames) != 2 {
+		t.Fatalf("want 2 frames (run.created catch-up + run.started live), got %d: %+v", len(frames), frames)
+	}
+	if frames[0].Event != "run.created" {
+		t.Errorf("frame 0: want run.created, got %+v", frames[0])
+	}
+	if frames[1].Event != "run.started" {
+		t.Errorf("frame 1: want run.started, got %+v", frames[1])
 	}
 }

--- a/controlplane/endpoints/runs_stream_integration_test.go
+++ b/controlplane/endpoints/runs_stream_integration_test.go
@@ -459,3 +459,121 @@ func TestCreateAndStream(t *testing.T) {
 		t.Errorf("frame 1: want run.started, got %+v", frames[1])
 	}
 }
+
+// joinResult is a join/wait POST's decoded outcome, handed back over a
+// channel from the goroutine driving the (possibly blocking) request.
+type joinResult struct {
+	status int
+	body   map[string]any
+}
+
+// postJoin POSTs url (join or wait) and sends the decoded result on done. A
+// request error is reported via t.Errorf and an empty result is still sent so
+// callers waiting on done never block forever.
+func postJoin(t *testing.T, url string, done chan<- joinResult) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		t.Errorf("join/wait POST: %v", err)
+		done <- joinResult{}
+		return
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	done <- joinResult{status: resp.StatusCode, body: body}
+}
+
+// TestJoinReturnsOnTerminal proves POST /threads/{id}/runs/{rid}/join blocks
+// on an in_progress run until a terminal run.* event arrives, then returns
+// the run's terminal state as JSON.
+func TestJoinReturnsOnTerminal(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	rid := seedRunWithStream(t, ctx) // in_progress run
+
+	e := echo.New()
+	s := newStreamTestServer()
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/join"
+
+	done := make(chan joinResult, 1)
+	go postJoin(t, url, done)
+
+	time.Sleep(300 * time.Millisecond) // let subscribe + status read run
+	if _, err := testPool.Exec(ctx, `UPDATE runs SET status='completed' WHERE id=$1`, rid); err != nil {
+		t.Fatal(err)
+	}
+	pub := nats.NewPublisher(mustJS(t))
+	_ = pub.PublishWithID(ctx, nats.SubjectFor("run.completed"), uuid.NewString(), envelopeFor(rid, "run.completed", `{}`))
+
+	select {
+	case res := <-done:
+		if res.status != http.StatusOK {
+			t.Fatalf("want 200, got %d: %+v", res.status, res.body)
+		}
+		if res.body["status"] != "success" {
+			t.Errorf("want terminal status \"success\", got %+v", res.body["status"])
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("join did not return within 5s")
+	}
+}
+
+// TestJoinAlreadyTerminal proves join returns immediately (no wait) when the
+// run is already terminal at request time.
+func TestJoinAlreadyTerminal(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE runs, events, outbox, event_streams, assistants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	rid := seedRunWithStream(t, ctx)
+	if _, err := testPool.Exec(ctx, `UPDATE runs SET status='completed' WHERE id=$1`, rid); err != nil {
+		t.Fatal(err)
+	}
+
+	e := echo.New()
+	s := newStreamTestServer()
+	s.RegisterRuns(e.Group("/api/v1"))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	url := srv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/join"
+
+	done := make(chan joinResult, 1)
+	go postJoin(t, url, done)
+
+	select {
+	case res := <-done:
+		if res.status != http.StatusOK {
+			t.Fatalf("want 200, got %d: %+v", res.status, res.body)
+		}
+		if res.body["status"] != "success" {
+			t.Errorf("want terminal status \"success\", got %+v", res.body["status"])
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("join (already terminal) did not return immediately within 1s")
+	}
+}
+
+// TestWaitRequiresNATS proves POST /runs/wait 503s immediately when the
+// server has no Subscriber (NATS disabled) — no DB round-trip, no wait.
+func TestWaitRequiresNATS(t *testing.T) {
+	e := echo.New()
+	s := &Server{Tenant: testPool}
+	s.RegisterRuns(e.Group("/api/v1"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/wait", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/controlplane/endpoints/runtime.go
+++ b/controlplane/endpoints/runtime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/duragraph/duragraph/controlplane/eventstore"
+	"github.com/duragraph/duragraph/controlplane/nats"
 )
 
 // Server holds the control-plane dependencies the handlers need.
@@ -23,6 +24,10 @@ import (
 type Server struct {
 	Tenant   *pgxpool.Pool
 	Platform *pgxpool.Pool
+
+	// Subscriber tails NATS for SSE/wait endpoints. Nil when NATS is disabled
+	// (those endpoints then return 503). Set by the server composition root.
+	Subscriber *nats.Subscriber
 }
 
 // Event is one domain event to append within a write transaction. Aliased to

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -428,6 +428,7 @@ groups:
         path: /threads/{id}/runs/{rid}/join
         kind: wait
         outbox: false
+        custom: true
         steps:
           - "SELECT status FROM runs WHERE id = :rid"
           - "IF not terminal: subscribe NATS run.completed/run.failed for run_id, block"
@@ -436,6 +437,7 @@ groups:
         path: /threads/{id}/runs/{rid}/stream
         kind: sse
         outbox: false
+        custom: true
         nats: {subscribe: "run.* + execution.* for this run"}
         steps:
           - "SELECT status FROM runs WHERE id = :rid (validate exists)"
@@ -447,6 +449,7 @@ groups:
         path: /threads/{id}/stream
         kind: sse
         outbox: false
+        custom: true
         nats: {subscribe: "all active runs on thread"}
         steps:
           - "SELECT id FROM runs WHERE thread_id = :id AND status IN ('queued','in_progress')"
@@ -457,6 +460,7 @@ groups:
         path: /threads/{id}/runs/stream
         kind: sse
         outbox: true
+        custom: true
         events: [run.created]
         nats: {subject: run.created, stream: RUNS, subscribe: "run.* + execution.* for new run"}
         steps:
@@ -468,6 +472,7 @@ groups:
         path: /runs/stream
         kind: sse
         outbox: true
+        custom: true
         events: [run.created]
         nats: {subject: run.created, stream: RUNS, subscribe: "run.* + execution.* for new run"}
         steps:
@@ -479,6 +484,7 @@ groups:
         path: /runs/wait
         kind: wait
         outbox: true
+        custom: true
         events: [run.created]
         nats: {subject: run.created, stream: RUNS, subscribe: "blocks until terminal"}
         steps:

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -173,6 +173,7 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 	}
 
 	// --- NATS relay + cleanup worker (optional) ---
+	var subscriber *nats.Subscriber
 	if cfg.NATSURL != "" {
 		nc, js, err := nats.Connect(ctx, cfg.NATSURL)
 		if err != nil {
@@ -209,9 +210,10 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		// controlplane/nats/run_processor.go.
 		s.runProcessor = nats.NewRunProcessor(js, publisher, s.tenant)
 		// nc lives for the relay's lifetime; closed on Shutdown via
-		// the relay's Stop → publisher Drain. For the SSE subscriber,
-		// there's a separate NewSubscriberFromConn path (TODO when
-		// SSE handlers land).
+		// the relay's Stop → publisher Drain. The SSE/wait endpoints
+		// share the same conn via a Subscriber (core-NATS, no
+		// separate connection or durable state).
+		subscriber = nats.NewSubscriberFromConn(nc)
 	}
 
 	// --- Echo router with all 10 endpoint groups mounted ---
@@ -225,8 +227,9 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 	s.echo = e
 
 	ep := &endpoints.Server{
-		Tenant:   s.tenant,
-		Platform: s.plat,
+		Tenant:     s.tenant,
+		Platform:   s.plat,
+		Subscriber: subscriber,
 	}
 	g := e.Group("/api/v1")
 	ep.RegisterAssistants(g)

--- a/controlplane/worker/stream_e2e_test.go
+++ b/controlplane/worker/stream_e2e_test.go
@@ -1,0 +1,203 @@
+package worker_test
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// sseFrame is one decoded Server-Sent Event (event + data lines). Mirrors the
+// endpoints package's own (unexported there) helper of the same name —
+// duplicated at the small size actually needed here rather than exporting it
+// across packages for one test.
+type sseFrame struct{ Event, Data string }
+
+// readSSE connects to url, reads Server-Sent frames until `want` frames
+// arrive or the deadline passes, and returns whatever was collected. Uses a
+// real HTTP client (streaming) — httptest.NewRecorder buffers and can't do
+// this.
+func readSSE(t *testing.T, url string, want int, deadline time.Duration) []sseFrame {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("sse connect: %v", err)
+	}
+	frames := make(chan sseFrame, 32)
+	go func() {
+		defer resp.Body.Close()
+		sc := bufio.NewScanner(resp.Body)
+		var ev, data string
+		for sc.Scan() {
+			line := sc.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				ev = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if ev != "" {
+					frames <- sseFrame{Event: ev, Data: data}
+					ev, data = "", ""
+				}
+			}
+		}
+	}()
+	var got []sseFrame
+	timeout := time.After(deadline)
+	for len(got) < want {
+		select {
+		case f := <-frames:
+			got = append(got, f)
+		case <-timeout:
+			return got
+		}
+	}
+	return got
+}
+
+// listenerDSNFromPool returns a bare pgx URL pointing at the shared
+// testcontainer's Postgres. The relay's LISTEN connection must NOT use a pool
+// (LISTEN requires session affinity that PgBouncer transaction-pooling would
+// drop) — mirrors controlplane/nats/nats_integration_test.go's helper of the
+// same name.
+func listenerDSNFromPool() string {
+	cc := testPool.Config().ConnConfig
+	return fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		cc.User, cc.Password, cc.Host, cc.Port, cc.Database,
+	)
+}
+
+// TestStreamEndToEnd is the streaming integration proof: a real outbox relay
+// (DB -> NATS), run-processor (run.created -> worker.graph.execute), and a
+// live Runner executing the 2-step counter graph, all feeding the SSE bridge
+// (controlplane/endpoints RunsStreamPerRun) over a live Subscriber. The SSE
+// client must see the real event sequence a worker execution actually
+// produces: run.started, two execution.node_completed (nodes A and B), then
+// run.completed — thin passthrough frames, sourced from actual DB events
+// relayed onto NATS, not synthesized. (run.created itself is triggered by a
+// direct publish that never touches the DB events/outbox table — mirroring
+// TestExecuteRunEndToEnd's run-processor trigger — and the SSE connection is
+// opened only after that publish completes, so it is deliberately excluded:
+// see the comment at the publish site below.)
+//
+// Lands in controlplane/worker (package worker_test) rather than
+// controlplane/endpoints: this package already has the full worker e2e
+// harness (testPool/natsURL/serverURL + newPool/seedThreadAssistantRun/
+// purgeStream from worker_testmain_test.go and the run-processor+Runner
+// wiring pattern from execution_integration_test.go's
+// TestExecuteRunEndToEnd). Reusing it here only costs mounting a second
+// httptest server (the runs SSE group) plus one real outbox Relay — far
+// cheaper than porting testcontainers Postgres + embedded NATS + the
+// run-processor/Runner wiring into the endpoints package's test harness,
+// which has no worker-side pieces at all.
+func TestStreamEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	_, _, rid := seedThreadAssistantRun(t, ctx, pool)
+	// The run-processor enriches worker.graph.execute from the runs row via
+	// aggregate_id, so the seeded run needs graph_id set for the worker to
+	// pick the right executor.
+	if _, err := pool.Exec(ctx, `UPDATE runs SET graph_id = 'counter' WHERE id = $1`, rid); err != nil {
+		t.Fatalf("set graph_id: %v", err)
+	}
+
+	// run-processor: turns run.created into a worker.graph.execute command.
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	// A live worker + Runner consuming the graph-executor consumer, driving
+	// the real counter graph (nodes A, B) via HTTP calls to the worker
+	// endpoints — each call (leaseRun/nodeEvent/terminalRun) writes real
+	// events + outbox rows on pool via writeTx.
+	wid := uuid.New()
+	cl := worker.NewClient(serverURL, wid, nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, worker.CounterExecutor{}, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	// The real outbox relay: drains pool's outbox table and publishes each
+	// row to NATS, exactly as production does — without this, the worker's
+	// events would land in the DB but never reach the SSE bridge's live feed.
+	drain := dnats.NewOutboxDrain(pool)
+	relay := dnats.NewRelay(drain, dnats.NewPublisher(js), listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+
+	// Kick off the pipeline: publish the real relay envelope shape for
+	// run.created onto RUNS (mirrors TestExecuteRunEndToEnd — the run id is
+	// the envelope's aggregate_id, not a top-level run_id). This bypasses the
+	// DB events/outbox table for run.created itself (it's never written
+	// there, so it can never appear in the SSE catch-up query), and
+	// PublishWithID blocks for the JetStream ack — so by the time this
+	// returns, the publish is already complete. The SSE client's core-NATS
+	// Subscribe (below) only ever sees messages published AFTER it
+	// subscribes (no backlog for a fresh core subscription), so opening the
+	// SSE connection only now guarantees it never observes this run.created
+	// publish either — exactly matching the brief's expected sequence
+	// (run.started onward, no run.created).
+	envelope := map[string]any{
+		"event_id":       uuid.New().String(),
+		"aggregate_type": "Run",
+		"aggregate_id":   rid.String(),
+		"event_type":     "run.created",
+		"payload":        map[string]any{},
+		"metadata":       map[string]any{},
+	}
+	if err := dnats.NewPublisher(js).PublishWithID(ctx, dnats.SubjectFor("run.created"), rid.String(), envelope); err != nil {
+		t.Fatalf("publish run.created: %v", err)
+	}
+
+	// The SSE bridge itself: the runs group mounted on its own httptest
+	// server, with a live Subscriber over the same embedded NATS connection.
+	// Opened only after the run.created publish above (see comment).
+	e := echo.New()
+	(&endpoints.Server{Tenant: pool, Subscriber: dnats.NewSubscriberFromConn(nc)}).RegisterRuns(e.Group("/api/v1"))
+	sseSrv := httptest.NewServer(e)
+	defer sseSrv.Close()
+
+	url := sseSrv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/stream"
+	done := make(chan []sseFrame, 1)
+	go func() { done <- readSSE(t, url, 4, 15*time.Second) }()
+
+	frames := <-done
+	want := []string{"run.started", "execution.node_completed", "execution.node_completed", "run.completed"}
+	if len(frames) != len(want) {
+		t.Fatalf("want %d frames, got %d: %+v", len(want), len(frames), frames)
+	}
+	for i, w := range want {
+		if frames[i].Event != w {
+			t.Errorf("frame %d: want %s, got %s (full: %+v)", i, w, frames[i].Event, frames)
+		}
+	}
+
+	waitForRunStatus(t, ctx, pool, rid, "completed", 10*time.Second)
+}


### PR DESCRIPTION
## Pass D — runs streaming (SSE) + wait

Lets a client observe and await a run. Wires the existing `nats.Subscriber` into the endpoints and fills the runs `sse`/`wait` stubs.

### Endpoints (6, bespoke `custom` handlers)
- SSE (`text/event-stream`): `stream_per_run`, `stream_thread`, `create_and_stream`, `stateless_stream`
- wait (`application/json`, block-until-terminal): `join`, `stateless_wait`

### Lossless streaming (the central design)
`streamRun`: **subscribe-first** (before the catch-up DB read) → replay the run's persisted events from `events` (ordered `occurred_at, event_version`, multi-run safe) → go live, filtered by `aggregate_id==run_id`, **deduped by `event_id`** (bounded ring for the thread feed) → close on the run's terminal event or client disconnect. Frames are thin passthrough (`event: <type>\ndata: <payload>`). `wait`/`join` use the same subscribe-first discipline, block to terminal, return the run as JSON. `Subscriber == nil` → 503.

### Testing
Testcontainers Postgres + embedded NATS. Catch-up+live+dedup asserted (dedup mutation-tested). **End-to-end proof** (`TestStreamEndToEnd`): real relay + run-processor + worker drive the counter graph and the SSE client receives `run.started → node_completed×2 → run.completed`. Whole rebuild green incl. `-race`.

### Out of scope (recorded)
LangGraph SDK stream-mode format (needs the real graph engine); `cancel`/`resume`/`batch`; `Last-Event-ID` reconnect; thread-feed backpressure hardening under a slow client (buffer-64 edge).
