### PR TITLE
feat(controlplane): honor thread_id + if_exists on thread create

### DIFF
--- a/controlplane/docs/superpowers/plans/2026-08-06-tenant-crud-completion.md
+++ b/controlplane/docs/superpowers/plans/2026-08-06-tenant-crud-completion.md
@@ -1,0 +1,165 @@
+# Tenant CRUD Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fill 8 remaining tenant read/write stubs (assistants graph read; thread state/history/checkpoint reads + write; run cancel-stateless/batch/thread-copy) as bespoke hand-written handlers.
+
+**Architecture:** All 8 are marked `custom: true` (routes generated, bodies hand-written), mapping DB rows to the existing OpenAPI types (`GraphSchema`, `ThreadState`, `Run`, `Thread`) — the manifest needs no `response:` binding because custom handlers hand-map. Reuse `snapshotRow`/`runRow`/`threadRow`; add `graphRow`.
+
+**Tech Stack:** Go 1.25, Echo v4, pgx v5, testcontainers Postgres.
+
+## Global Constraints
+
+- Design doc: `controlplane/docs/superpowers/specs/2026-08-06-tenant-crud-completion-design.md`.
+- All 8 endpoints are `custom` hand-written handlers; verify the exact fields of the OpenAPI response types (`GraphSchema`, `ThreadState`, `Run`, `Thread`) in `types_gen.go` and hand-map what corresponds, recording any divergence in `rows.go`'s DIVERGENCES block (the established pattern).
+- Thread-scoping is required on thread reads: a checkpoint/state belonging to another thread's runs → 404, never leaked.
+- Writes emit their domain event via `writeTx` + the projection (mirror the existing create/cancel impls): `run.cancelled` (cancel_stateless), `run.created`×N (batch), `thread.created` (copy). `create_checkpoint` is a plain `snapshots` INSERT (infrastructure, no event — mirror the worker's `write_checkpoint`, but client-driven so NO lease_epoch fence).
+- Generated `*_gen.go` never hand-edited; the `custom` flag change must leave other groups byte-identical after regen.
+- Integration tests: testcontainers Postgres, no build tag, standard CI. Never weaken assertions.
+- Never hand-edit go.mod/go.sum. Conventional commits. No PR/push/merge without explicit approval (the controller handles PR/merge).
+- Run from the worktree root `~/worktrees/duragraph/feat/controlplane-server` (branch `feat/controlplane-tenant-crud`).
+
+## File Structure
+
+- `controlplane/gen/endpoints.yaml` — `custom: true` on the 8 endpoints.
+- `controlplane/endpoints/{assistants,threads,runs}_gen.go` (regenerate) — routes-only for the 8.
+- `controlplane/endpoints/rows.go` — add `graphRow` + `toAPI() GraphSchema`; a `snapshotRow.toThreadState()` mapper.
+- `controlplane/endpoints/threads_state.go` (new) — `ThreadsGetState`, `ThreadsGetCheckpointState`, `ThreadsGetHistory`, `ThreadsCreateCheckpoint`, `ThreadsCopy`.
+- `controlplane/endpoints/assistants_graph.go` (new) — `AssistantsGetGraph`.
+- `controlplane/endpoints/runs_writes.go` (new) — `RunsCancelStateless`, `RunsBatchCreate`.
+- Tests alongside.
+
+---
+
+## Task 1: Reads — assistant graph + thread state/checkpoint/history
+
+**Files:**
+- Modify: `controlplane/gen/endpoints.yaml` (custom on `get_graph`, `get_state`, `get_checkpoint_state`, `get_history`)
+- Regenerate: `assistants_gen.go`, `threads_gen.go`
+- Modify: `controlplane/endpoints/rows.go` (`graphRow`+`toAPI`, `snapshotRow.toThreadState`)
+- Create: `controlplane/endpoints/assistants_graph.go`, `controlplane/endpoints/threads_state.go`
+- Test: `controlplane/endpoints/tenant_reads_integration_test.go`
+
+**Interfaces:**
+- Produces: `graphRow`+`toAPI() GraphSchema`; `snapshotRow.toThreadState() ThreadState`; handlers `AssistantsGetGraph`, `ThreadsGetState`, `ThreadsGetCheckpointState`, `ThreadsGetHistory`.
+- Consumes: `GraphSchema`, `ThreadState` (types_gen.go — read their fields), `snapshotRow` (rows.go).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `controlplane/endpoints/tenant_reads_integration_test.go`:
+- `TestAssistantGetGraph`: seed an assistant + a `graphs` row (nodes/edges/config); `GET /api/v1/assistants/{id}/graph` → 200, assert graph fields (nodes/edges); missing assistant → 404.
+- `TestThreadGetState`: seed a thread + a run on it + 2 `snapshots` (versions 1,2); `GET /api/v1/threads/{tid}/state` → 200 returns the LATEST (version 2) state; a thread with no snapshots → 404 (or empty per the ThreadState contract — pick and assert one).
+- `TestThreadGetCheckpointState`: `GET /threads/{tid}/state/{ckpt}` → 200 for the thread's snapshot; a snapshot id from ANOTHER thread's run → 404 (thread-scoping).
+- `TestThreadGetHistory`: `GET /threads/{tid}/history` → list of the thread's snapshots newest-first.
+
+(Reuse the shared `testPool`; seed helpers may mirror the store/worker tests.)
+
+- [ ] **Step 2: Run — fails (stubs)**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestAssistantGetGraph|TestThreadGet' -v`
+Expected: FAIL (sse/read stubs).
+
+- [ ] **Step 3: Mark custom + regen**
+
+`custom: true` on `get_graph`, `get_state`, `get_checkpoint_state`, `get_history` in `endpoints.yaml`; `go run ./controlplane/gen`; confirm other groups byte-identical (`git diff --stat` empty for them); `assistants_gen.go`/`threads_gen.go` route `AssistantsGetGraph`/`ThreadsGetState`/`ThreadsGetCheckpointState`/`ThreadsGetHistory` bodiless.
+
+- [ ] **Step 4: Add rows + mappers**
+
+In `rows.go`: add `graphRow` (db tags for `graphs`: id, assistant_id, name, version, description, nodes []byte, edges []byte, config []byte, timestamps) + `toAPI() GraphSchema` (read `GraphSchema`'s fields in `types_gen.go`; map nodes/edges/config, best-effort unmarshal jsonb; record divergences). Add `func (r snapshotRow) toThreadState() ThreadState` (map `state`→values and whatever `ThreadState` defines; leave unmapped fields zero, record divergence).
+
+- [ ] **Step 5: Write the read handlers**
+
+`assistants_graph.go`: `AssistantsGetGraph` — `SELECT ... FROM graphs WHERE assistant_id=$1` (or by the assistant's graph_id) → `graphRow` → `c.JSON(200, row.toAPI())`; `pgx.ErrNoRows` → 404.
+
+`threads_state.go`: `ThreadsGetState` — latest snapshot across the thread's runs: `SELECT ... FROM snapshots WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id=$1) ORDER BY version DESC LIMIT 1` → `toThreadState()`; none → 404. `ThreadsGetCheckpointState` — `SELECT ... FROM snapshots WHERE id=$ckpt AND aggregate_id IN (SELECT id FROM runs WHERE thread_id=$tid)` (thread-scoped) → 404 if absent. `ThreadsGetHistory` — `SELECT ... FROM snapshots WHERE aggregate_id IN (thread's runs) ORDER BY version DESC` → `[]ThreadState`.
+
+- [ ] **Step 6: Build + tests + regression**
+
+Run: `go build ./controlplane/... && go test ./controlplane/endpoints/ -run 'TestAssistantGetGraph|TestThreadGet' -v -count=1` → PASS.
+Run: `go test ./controlplane/endpoints/ -count=1` → PASS (other groups green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add controlplane/gen/endpoints.yaml controlplane/endpoints/assistants_gen.go \
+  controlplane/endpoints/threads_gen.go controlplane/endpoints/rows.go \
+  controlplane/endpoints/assistants_graph.go controlplane/endpoints/threads_state.go \
+  controlplane/endpoints/tenant_reads_integration_test.go
+git commit -m "feat(controlplane): assistant graph read + thread state/checkpoint/history reads"
+```
+
+---
+
+## Task 2: Writes — create_checkpoint, cancel_stateless, batch_create, copy
+
+**Files:**
+- Modify: `controlplane/gen/endpoints.yaml` (custom on `create_checkpoint`, `cancel_stateless`, `batch_create`, `copy`)
+- Regenerate: `threads_gen.go`, `runs_gen.go`
+- Modify: `controlplane/endpoints/threads_state.go` (add `ThreadsCreateCheckpoint`, `ThreadsCopy`)
+- Create: `controlplane/endpoints/runs_writes.go` (`RunsCancelStateless`, `RunsBatchCreate`)
+- Test: `controlplane/endpoints/tenant_writes_integration_test.go`
+
+**Interfaces:**
+- Consumes: `writeTx`, `Event`, `mustJSON`, `runRow`/`threadRow`, the existing `RunsCancel`/`RunsCreateStateless` SQL as the mirror.
+- Produces: `ThreadsCreateCheckpoint`, `ThreadsCopy`, `RunsCancelStateless`, `RunsBatchCreate`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `controlplane/endpoints/tenant_writes_integration_test.go`:
+- `TestCancelStateless`: seed a queued/in_progress stateless run; `POST /api/v1/runs/cancel` (body with run_id) → run status `cancelled`, `run.cancelled` in outbox.
+- `TestBatchCreate`: `POST /api/v1/runs/batch` with N create specs → N `runs` rows + N `run.created` outbox rows in ONE tx; returns the ids.
+- `TestCreateCheckpoint`: seed a thread + run (+ its event_stream via a run.started, so snapshots FK resolves); `POST /threads/{tid}/state/checkpoint` → a `snapshots` row written; read it back via `get_checkpoint_state` (from Task 1) round-trips.
+- `TestThreadCopy`: seed a source thread with a snapshot (state); `POST /threads/{tid}/copy` → a NEW thread row + `thread.created` outbox row; the new thread carries the copied state (assert via get_state).
+
+- [ ] **Step 2: Run — fails**
+
+Run: `go test ./controlplane/endpoints/ -run 'TestCancelStateless|TestBatchCreate|TestCreateCheckpoint|TestThreadCopy' -v` → FAIL.
+
+- [ ] **Step 3: Mark custom + regen**
+
+`custom: true` on `create_checkpoint`, `cancel_stateless`, `batch_create`, `copy`; regen; confirm other groups byte-identical; the 4 handlers route bodiless.
+
+- [ ] **Step 4: Write the handlers**
+
+`runs_writes.go`:
+- `RunsCancelStateless` — mirror `RunsCancel` (which is impl `update` mode: `writeTx([run.cancelled]) + UPDATE runs SET status='cancelled' WHERE id=$rid`), keyed on the body's run id (stateless — no thread param). Read the generated `RunsCancel` in `runs_gen.go` for the exact SQL and mirror it.
+- `RunsBatchCreate` — bind a list of create specs; in ONE `writeTx`-style transaction append `run.created` per spec + `INSERT runs` per spec, single `pg_notify` at end; return the created run ids. (writeTx does one pg_notify already; for a batch, either call a batch-aware path or open the tx directly appending N events + N inserts + one notify — mirror `endpoint-queries.d2` batch_create.)
+
+`threads_state.go` (append):
+- `ThreadsCreateCheckpoint` — resolve the run/thread's `stream_id` from `event_streams` (like the worker's `WorkersWriteCheckpoint`), then INSERT `snapshots` (no lease fence — client checkpoint). Return the checkpoint id. (Reuse the worker checkpoint SQL shape; it is client-driven here.)
+- `ThreadsCopy` — read the source thread's latest snapshot state; `writeTx([thread.created]) + INSERT threads` seeded with that state (values); return the new `Thread`. Thread-scoped read of the source.
+
+- [ ] **Step 5: Build + tests + full regression**
+
+Run: `go build ./... && go test ./controlplane/endpoints/ -run 'TestCancelStateless|TestBatchCreate|TestCreateCheckpoint|TestThreadCopy' -v -count=1` → PASS.
+Run: `go test ./controlplane/... -count=1` → whole rebuild green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add controlplane/gen/endpoints.yaml controlplane/endpoints/threads_gen.go \
+  controlplane/endpoints/runs_gen.go controlplane/endpoints/threads_state.go \
+  controlplane/endpoints/runs_writes.go controlplane/endpoints/tenant_writes_integration_test.go
+git commit -m "feat(controlplane): run cancel-stateless + batch-create + thread checkpoint + copy"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** get_graph → T1; get_state/get_checkpoint_state/get_history → T1; create_checkpoint/cancel_stateless/batch_create/copy → T2. Deferred (resume, get_versions, set_latest) explicitly out of scope. ✓
+
+**Placeholder scan:** the row→type mappers (`graphRow.toAPI`, `snapshotRow.toThreadState`) are specified by contract ("read `GraphSchema`/`ThreadState` fields in types_gen.go and map what corresponds, record divergence") rather than transcribed, because the exact target fields must be read from the generated types — this matches how every other `toAPI` in `rows.go` was built and is the correct just-in-time step, not a vague requirement. All SQL and handler control flow are concrete.
+
+**Type consistency:** handler names match `pascal(group)+pascal(name)`: `AssistantsGetGraph`, `ThreadsGetState`, `ThreadsGetCheckpointState`, `ThreadsGetHistory`, `ThreadsCreateCheckpoint`, `ThreadsCopy`, `RunsCancelStateless`, `RunsBatchCreate`. `snapshotRow` reused across get_checkpoint_state/get_state/get_history/create_checkpoint/copy.
+
+**Open risks:**
+- Verify `GraphSchema`/`ThreadState` field names against `types_gen.go` before mapping (a wrong field name fails the build; a missing concept → record a divergence, don't invent).
+- `create_checkpoint` needs the run/thread's `event_stream` to exist (snapshots FK). For a thread with no run yet, decide: 404 / create-a-stream — match the worker's `write_checkpoint` behavior (it requires the stream from run.started).
+- `batch_create` must do ONE `pg_notify` for the whole batch (not per run) per `endpoint-queries.d2`.
+
+## Notes for the implementer
+
+- All 8 handlers are `custom` — hand-map rows to the OpenAPI types; the manifest needs no `response:` binding.
+- Thread reads MUST be thread-scoped (a resource from another thread → 404).
+- Do not push/PR/merge without explicit approval (the controller handles that).

--- a/controlplane/docs/superpowers/specs/2026-08-06-tenant-crud-completion-design.md
+++ b/controlplane/docs/superpowers/specs/2026-08-06-tenant-crud-completion-design.md
@@ -1,0 +1,97 @@
+# Tenant CRUD completion — assistants/threads/runs remaining reads + writes
+
+**Date:** 2026-08-06
+**Branch:** `feat/controlplane-tenant-crud` (off `main`)
+**Status:** approved design, pending implementation plan
+
+## Context
+
+The tenant endpoint groups are mostly done. This slice fills the remaining
+well-defined read/write stubs so the tenant CRUD surface is complete. It excludes
+stubs that depend on subsystems not yet built.
+
+### Scope
+
+**In (8):**
+| Endpoint | Method / path | Kind | Approach |
+|----------|---------------|------|----------|
+| assistants.get_graph | `GET /assistants/{id}/graph` | read | SELECT from `graphs` by assistant → GraphSchema |
+| threads.get_state | `GET /threads/{id}/state` | read | latest `snapshots` row for the thread's runs |
+| threads.get_checkpoint_state | `GET /threads/{id}/state/{checkpoint_id}` | read | `snapshots` by id, thread-scoped |
+| threads.get_history | `GET /threads/{id}/history` | read | list `snapshots` for the thread |
+| threads.create_checkpoint | `POST /threads/{id}/state/checkpoint` | write | INSERT `snapshots` (mirror the worker's `write_checkpoint`) |
+| runs.cancel_stateless | `POST /runs/cancel` | write | `run.cancelled` (mirror the existing `cancel` impl, stateless) |
+| runs.batch_create | `POST /runs/batch` | write | loop the existing create, one `pg_notify` at end |
+| threads.copy | `POST /threads/{id}/copy` | write | read thread's latest state → create a new thread (`thread.created`) |
+
+**Deferred (recorded):**
+- `runs.resume` (`run.resumed`) — HITL resume needs interrupts to actually be
+  raised by the executor; the counter graph never interrupts, so there is nothing
+  to resume. Belongs with the HITL / real-graph-engine work.
+- `assistants.get_versions` + `set_latest` — assistant graph *versioning* is thin
+  and underspecified today (the `graphs` row carries a version string but there is
+  no version history or defined "set latest" semantics). Do it as one coherent
+  versioning feature later, not two half-defined stubs now.
+
+## Approach
+
+Two mechanisms, per endpoint:
+
+**Generator impl-mode (add an `impl:` block to `endpoints.yaml`)** where the
+endpoint is a single-statement, path-keyed read/write matching an existing mode:
+- `get_graph` → `read_one` (row: a new `graphRow` + `toAPI()` → the OpenAPI graph
+  type; verify the response type name in `types_gen.go`).
+- `get_checkpoint_state` → `read_one` from `snapshots` (reuse `snapshotRow`).
+- `get_history` → `read_list` from `snapshots` for the thread.
+- `cancel_stateless` → `update` mode emitting `run.cancelled`, mirroring the
+  existing `cancel` handler's SQL but keyed on the run id alone (stateless).
+
+**Bespoke `custom` handler** where the logic is multi-statement or shaped
+unlike any mode:
+- `create_checkpoint` — the same epoch-free INSERT into `snapshots` the worker's
+  `write_checkpoint` does, but client-driven (no lease fence: this is an explicit
+  client checkpoint of thread state, not a worker execution checkpoint). Resolve
+  `stream_id` from the run/thread's event stream.
+- `batch_create` — bind a list, loop `run.created` writes + `INSERT runs` in one
+  transaction, single `pg_notify` at the end (per `endpoint-queries.d2`), return
+  the created run ids.
+- `copy` — read the source thread's latest `snapshots` state, create a new thread
+  (`thread.created` event + `INSERT threads`) seeded with that state, return the
+  new thread.
+- `get_state` — latest snapshot across the thread's runs (`SELECT … WHERE
+  aggregate_id IN (run ids of thread) ORDER BY version DESC LIMIT 1`), shaped to
+  the OpenAPI ThreadState response.
+
+Row/type verification is done in the plan against `types_gen.go` — where an
+OpenAPI response type is missing (e.g. the graph or thread-state shape), define a
+hand-mapped row `toAPI()` as elsewhere in `rows.go`, recording the divergence.
+
+## Testing
+
+Testcontainers Postgres, no build tag, standard CI. Per group:
+- Reads: seed the underlying row(s) (graph / snapshots) + assert the read returns
+  them; 404 on missing; thread-scoping (a checkpoint from another thread → 404).
+- `create_checkpoint`: write then read-back round-trip; `cancel_stateless`: run →
+  cancelled + `run.cancelled` in outbox; `batch_create`: N runs created + N
+  `run.created` outbox rows in one tx; `copy`: source thread with state → new
+  thread with copied state + `thread.created` outbox row.
+- Full `go test ./controlplane/... -count=1` green; generator regen leaves other
+  groups byte-identical.
+
+## Files
+
+- `controlplane/gen/endpoints.yaml` — impl blocks for the 4 impl-mode endpoints;
+  `custom: true` for the 4 bespoke ones.
+- `controlplane/endpoints/runs_gen.go`, `assistants_gen.go`, `threads_gen.go`
+  (regenerate).
+- `controlplane/endpoints/rows.go` — `graphRow` (+ `toAPI`) if no existing type;
+  reuse `snapshotRow`.
+- `controlplane/endpoints/threads_state.go` (new) — bespoke thread state/checkpoint
+  handlers (`get_state`, `create_checkpoint`, `copy`).
+- `controlplane/endpoints/runs_batch.go` (new) — `batch_create`.
+- Tests alongside each.
+
+## Out of scope (recorded)
+
+`resume` (HITL), `get_versions`/`set_latest` (versioning) — deferred as above. No
+new tables; all target tables (`graphs`, `snapshots`, `threads`, `runs`) exist.

--- a/controlplane/endpoints/assistants_gen.go
+++ b/controlplane/endpoints/assistants_gen.go
@@ -201,15 +201,7 @@ func (s *Server) AssistantsDelete(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// AssistantsGetGraph — GET /assistants/{id}/graph  (kind: read)
-//   - SELECT * FROM graphs WHERE assistant_id = :id AND version = (SELECT max version)
-func (s *Server) AssistantsGetGraph(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   SELECT * FROM graphs WHERE assistant_id = :id AND version = (SELECT max version)
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// AssistantsGetGraph — GET /assistants/{id}/graph  (kind: read) — hand-written in assistants.go
 
 // AssistantsGetVersions — GET /assistants/{id}/versions  (kind: read)
 //   - SELECT * FROM graphs WHERE assistant_id = :id ORDER BY version DESC

--- a/controlplane/endpoints/assistants_gen.go
+++ b/controlplane/endpoints/assistants_gen.go
@@ -44,10 +44,10 @@ func (s *Server) AssistantsCreate(c echo.Context) error {
 	}
 	var row assistantRow
 	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `INSERT INTO assistants (id, graph_id, name, description, config, metadata)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
-`, aggID, req.GraphId, deref(req.Name), req.Description, mustJSON(req.Config), mustJSON(req.Metadata))
+		rows, err := tx.Query(ctx, `INSERT INTO assistants (id, graph_id, name, description, config, context, metadata)
+VALUES ($1, $2, $3, $4, $5, COALESCE($6::jsonb, '{}'::jsonb), $7)
+RETURNING id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
+`, aggID, req.GraphId, deref(req.Name), req.Description, mustJSON(req.Config), jsonbOrNil(req.Context), mustJSON(req.Metadata))
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func (s *Server) AssistantsSearch(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	rows, err := s.Tenant.Query(ctx, `SELECT id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
+	rows, err := s.Tenant.Query(ctx, `SELECT id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
 FROM assistants
 WHERE ($1::jsonb IS NULL OR metadata @> $1::jsonb)
 ORDER BY created_at DESC
@@ -115,7 +115,7 @@ func (s *Server) AssistantsGet(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	rows, err := s.Tenant.Query(ctx, `SELECT id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
+	rows, err := s.Tenant.Query(ctx, `SELECT id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
 FROM assistants WHERE id = $1
 `, pathID)
 	if err != nil {
@@ -161,7 +161,7 @@ func (s *Server) AssistantsUpdate(c echo.Context) error {
   context = COALESCE($6, context),
   metadata = COALESCE($7, metadata)
 WHERE id = $1
-RETURNING id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
+RETURNING id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
 `, pathID, req.GraphId, req.Name, req.Description, jsonbOrNil(req.Config), jsonbOrNil(req.Context), jsonbOrNil(req.Metadata))
 		if err != nil {
 			return err

--- a/controlplane/endpoints/assistants_graph.go
+++ b/controlplane/endpoints/assistants_graph.go
@@ -1,0 +1,37 @@
+// Hand-written assistant graph read. Route is generated into assistants_gen.go
+// (get_graph marked custom in endpoints.yaml); body lives here. See rows.go's
+// graphRow.toAPI + DIVERGENCES for the GraphSchema hand-mapping.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// AssistantsGetGraph returns the latest graph definition for an assistant.
+// GET /assistants/{id}/graph -> 200 GraphSchema / 404 (no assistant, or an
+// assistant with no graph row).
+func (s *Server) AssistantsGetGraph(c echo.Context) error {
+	ctx := c.Request().Context()
+	aid := c.Param("id")
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, assistant_id, name, version, description, nodes, edges, config, created_at, updated_at
+		FROM graphs
+		WHERE assistant_id = $1
+		ORDER BY version DESC
+		LIMIT 1`, aid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[graphRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toAPI())
+}

--- a/controlplane/endpoints/assistants_integration_test.go
+++ b/controlplane/endpoints/assistants_integration_test.go
@@ -340,3 +340,93 @@ func TestAssistantsCRUD(t *testing.T) {
 		t.Errorf("count after delete: want 1, got %d", count)
 	}
 }
+
+// TestAssistantsContextVersion proves the two LangGraph-Cloud contract fields
+// that the assistants table carries — context (jsonb) and version (int) — are
+// persisted on create and returned on every read path (create response, get,
+// update). context is a real column, so a create that carries it must round-trip
+// verbatim; an omitted context must default to {} (not null); version must
+// surface as 1 for a freshly-created assistant.
+func TestAssistantsContextVersion(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServer()
+
+	// --- create WITH a context object ---
+	body := `{"graph_id":"g","name":"n","context":{"model":"gpt-4o","temp":0.2}}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/assistants", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created Assistant
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("create decode: %v", err)
+	}
+	// context round-trips verbatim on the create response
+	if created.Context == nil {
+		t.Fatalf("create: context nil, want {model,temp}")
+	}
+	if (*created.Context)["model"] != "gpt-4o" {
+		t.Errorf("create context.model: want gpt-4o, got %v", (*created.Context)["model"])
+	}
+	if (*created.Context)["temp"].(float64) != 0.2 {
+		t.Errorf("create context.temp: want 0.2, got %v", (*created.Context)["temp"])
+	}
+	// version defaults to 1
+	if created.Version == nil || *created.Version != 1 {
+		t.Errorf("create version: want 1, got %v", created.Version)
+	}
+
+	// --- get returns the same context + version ---
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/assistants/"+created.AssistantId.String(), nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Assistant
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.Context == nil || (*got.Context)["model"] != "gpt-4o" {
+		t.Errorf("get context.model: want gpt-4o, got %v", got.Context)
+	}
+	if got.Version == nil || *got.Version != 1 {
+		t.Errorf("get version: want 1, got %v", got.Version)
+	}
+
+	// --- an omitted context defaults to {} (not null) ---
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/assistants",
+		strings.NewReader(`{"graph_id":"g2","name":"n2"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	e.ServeHTTP(rec, req)
+	var noCtx Assistant
+	_ = json.Unmarshal(rec.Body.Bytes(), &noCtx)
+	if noCtx.Context == nil {
+		t.Errorf("create without context: want {} object, got nil")
+	} else if len(*noCtx.Context) != 0 {
+		t.Errorf("create without context: want empty {}, got %v", *noCtx.Context)
+	}
+
+	// --- update replaces context; version still surfaces ---
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/assistants/"+created.AssistantId.String(),
+		strings.NewReader(`{"context":{"model":"claude"}}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var updated Assistant
+	_ = json.Unmarshal(rec.Body.Bytes(), &updated)
+	if updated.Context == nil || (*updated.Context)["model"] != "claude" {
+		t.Errorf("update context.model: want claude, got %v", updated.Context)
+	}
+	if updated.Version == nil {
+		t.Errorf("update version: want non-nil, got nil")
+	}
+}

--- a/controlplane/endpoints/rows.go
+++ b/controlplane/endpoints/rows.go
@@ -24,8 +24,10 @@ type assistantRow struct {
 	Description  *string   `db:"description"`
 	Model        *string   `db:"model"`
 	Instructions *string   `db:"instructions"`
-	Tools        []byte    `db:"tools"`    // jsonb
-	Config       []byte    `db:"config"`   // jsonb
+	Tools        []byte    `db:"tools"`   // jsonb
+	Config       []byte    `db:"config"`  // jsonb
+	Context      []byte    `db:"context"` // jsonb
+	Version      int       `db:"version"`
 	Metadata     []byte    `db:"metadata"` // jsonb
 	CreatedAt    time.Time `db:"created_at"`
 	UpdatedAt    time.Time `db:"updated_at"`
@@ -49,9 +51,16 @@ func (r assistantRow) toAPI() Assistant {
 	if len(r.Config) > 0 {
 		_ = json.Unmarshal(r.Config, &a.Config)
 	}
+	if len(r.Context) > 0 {
+		var ctx map[string]interface{}
+		_ = json.Unmarshal(r.Context, &ctx)
+		a.Context = &ctx
+	}
 	if len(r.Metadata) > 0 {
 		_ = json.Unmarshal(r.Metadata, &a.Metadata)
 	}
+	v := r.Version
+	a.Version = &v
 	return a
 }
 
@@ -359,9 +368,10 @@ type execHistoryRow struct {
 }
 
 // DIVERGENCES (OpenAPI ↔ postgres.d2) — reconcile before tightening mappers:
-//   assistants: API has {config(structured), context, version}; DB has
-//     {tools, model, instructions, config(jsonb)}. version/context not in DB;
-//     tools/model/instructions not in the API Assistant response.
+//   assistants: context (jsonb) and version (int) ARE real DB columns and are
+//     now persisted on create + returned on every read (config/context/version).
+//     Remaining divergence: DB has {tools, model, instructions} with no API
+//     Assistant-response equivalent (legacy columns, unused by the contract).
 //   threads: API Thread.interrupts is derived from active runs (not a column);
 //     ThreadCreate.{thread_id, if_exists, supersteps, ttl} not yet honored by
 //     the create impl (always mints a fresh id). ThreadPatch.ttl not honored

--- a/controlplane/endpoints/rows.go
+++ b/controlplane/endpoints/rows.go
@@ -373,9 +373,10 @@ type execHistoryRow struct {
 //     Remaining divergence: DB has {tools, model, instructions} with no API
 //     Assistant-response equivalent (legacy columns, unused by the contract).
 //   threads: API Thread.interrupts is derived from active runs (not a column);
-//     ThreadCreate.{thread_id, if_exists, supersteps, ttl} not yet honored by
-//     the create impl (always mints a fresh id). ThreadPatch.ttl not honored
-//     by the update impl (metadata merge only).
+//     ThreadCreate.{thread_id, if_exists} ARE honored by the create impl now
+//     (client id + idempotent create with raise/do_nothing; see
+//     threads_create.go); {supersteps, ttl} still not honored. ThreadPatch.ttl
+//     not honored by the update impl (metadata merge only).
 //   runs: API RunStatus {pending,running,error,success,timeout,interrupted} ≠
 //     DB status {queued,in_progress,requires_action,completed,failed,cancelled}.
 //     cancelled has no API equivalent (mapped to error). API Run has no

--- a/controlplane/endpoints/rows.go
+++ b/controlplane/endpoints/rows.go
@@ -10,6 +10,7 @@ package endpoints
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -91,6 +92,51 @@ func (r threadRow) toAPI() Thread {
 		_ = json.Unmarshal(r.Metadata, &t.Metadata)
 	}
 	return t
+}
+
+// graphRow mirrors the graphs table (postgres.d2 workflow_ctx). name is the
+// graph_id from the SDK's langgraph.json (see migration 002_workflow.up.sql);
+// version is a free-form VARCHAR, not numeric.
+type graphRow struct {
+	ID          uuid.UUID  `db:"id"`
+	AssistantID *uuid.UUID `db:"assistant_id"` // nullable
+	Name        string     `db:"name"`
+	Version     *string    `db:"version"` // nullable
+	Description *string    `db:"description"`
+	Nodes       []byte     `db:"nodes"`  // jsonb
+	Edges       []byte     `db:"edges"`  // jsonb
+	Config      []byte     `db:"config"` // jsonb
+	CreatedAt   time.Time  `db:"created_at"`
+	UpdatedAt   time.Time  `db:"updated_at"`
+}
+
+// toAPI maps a row to the OpenAPI GraphSchema response type. GraphSchema
+// describes JSON schemas (config/context/input/output/state_schema) while the
+// DB stores the graph's actual definition (nodes/edges/config) — these are
+// different concepts (see DIVERGENCES). Best-effort mapping: name -> GraphId
+// (name IS the graph_id per the DB comment); nodes+edges -> StateSchema (the
+// closest required field to "the graph's structure"); config -> ConfigSchema.
+// context_schema/input_schema/output_schema have no DB source and stay nil.
+func (r graphRow) toAPI() GraphSchema {
+	g := GraphSchema{GraphId: r.Name}
+	state := map[string]interface{}{}
+	if len(r.Nodes) > 0 {
+		var nodes interface{}
+		_ = json.Unmarshal(r.Nodes, &nodes)
+		state["nodes"] = nodes
+	}
+	if len(r.Edges) > 0 {
+		var edges interface{}
+		_ = json.Unmarshal(r.Edges, &edges)
+		state["edges"] = edges
+	}
+	g.StateSchema = state
+	if len(r.Config) > 0 {
+		var cfg map[string]interface{}
+		_ = json.Unmarshal(r.Config, &cfg)
+		g.ConfigSchema = &cfg
+	}
+	return g
 }
 
 // runRow mirrors the runs table (postgres.d2 run_ctx).
@@ -277,6 +323,31 @@ func (r snapshotRow) toAPI() CheckpointResponse {
 	}
 }
 
+// toThreadState maps a snapshot row to the OpenAPI ThreadState response type.
+// state (jsonb, the channel values) -> Values, the direct correspondence.
+// Checkpoint.CheckpointId is the snapshot's bigserial id, stringified (the
+// LangGraph checkpoint id contract is opaque string). CreatedAt is formatted
+// RFC3339 to match ThreadState's string type (DB column is timestamptz).
+// aggregate_id is the RUN id, not the thread id, so Checkpoint.ThreadId is not
+// populated here (the row alone doesn't carry it — see DIVERGENCES).
+// Interrupts/ParentCheckpoint/Tasks/Metadata/Next have no snapshots-table
+// source and stay zero/empty.
+func (r snapshotRow) toThreadState() ThreadState {
+	cid := strconv.FormatInt(r.ID, 10)
+	ts := ThreadState{
+		Checkpoint: CheckpointConfig{CheckpointId: &cid},
+		CreatedAt:  r.CreatedAt.Format(time.RFC3339),
+		Metadata:   map[string]interface{}{},
+		Next:       []string{},
+	}
+	var v interface{} = map[string]interface{}{}
+	if len(r.State) > 0 {
+		_ = json.Unmarshal(r.State, &v)
+	}
+	ts.Values = v
+	return ts
+}
+
 // execHistoryRow mirrors execution_history (postgres.d2 run_ctx). Not returned
 // over the API in this slice; used by tests to assert node execution.
 type execHistoryRow struct {
@@ -316,3 +387,39 @@ type execHistoryRow struct {
 //     search) is not honored — no vector index in the new control plane yet;
 //     filter + namespace_prefix only. StoreListNamespacesRequest.max_depth and
 //     .suffix are best-effort (prefix + limit/offset honored).
+//   graphs (assistants.get_graph): GraphSchema describes JSON schemas
+//     (config_schema/context_schema/input_schema/output_schema/state_schema —
+//     LangGraph's introspected I/O shapes) but the DB graphs table stores the
+//     graph's actual definition (nodes/edges/config). These are different
+//     concepts with no clean 1:1 mapping. graphRow.toAPI() maps name -> GraphId
+//     (name IS the graph_id per migration 002's comment), nodes+edges ->
+//     StateSchema (bundled as {"nodes":.., "edges":..} — the closest required
+//     field to "the graph's structure"), config -> ConfigSchema. context_schema/
+//     input_schema/output_schema have no DB source and stay nil. assistant_id/
+//     version/description/timestamps on graphRow are not surfaced by GraphSchema
+//     at all. The get_graph query also uses `ORDER BY version DESC` even though
+//     graphs.version is VARCHAR(50) (free-form, not numeric) — lexicographic,
+//     not numeric, ordering; matches the endpoint-queries.d2 steps literally but
+//     is a latent bug if versions ever exceed one digit.
+//   snapshots (threads.get_state/get_checkpoint_state/get_history): ThreadState
+//     is LangGraph's per-checkpoint state envelope; snapshots is the plain
+//     event-sourcing snapshot table. snapshotRow.toThreadState() maps state
+//     (jsonb) -> Values directly (the one clean correspondence), id -> stringified
+//     Checkpoint.CheckpointId, created_at -> CreatedAt (RFC3339 string, since
+//     ThreadState types it as string not time.Time). Checkpoint.ThreadId/
+//     CheckpointNs/CheckpointMap are NOT populated — the row only carries
+//     aggregate_id (the run id), not the thread id, so the mapper has no thread
+//     id to put there. Interrupts, ParentCheckpoint, Tasks, and Metadata/Next
+//     (required but contentless) have no snapshots-table source and are left
+//     nil/empty. get_state/get_history read snapshots (the snapshots-as-
+//     checkpoints design), NOT the endpoint-queries.d2's messages/events steps:
+//     the LangGraph-Cloud contract for GET /threads/{id}/state returns the
+//     latest checkpoint's channel values, which is exactly snapshots.state; the
+//     d2's messages+completed-run / events sketch predates that design (the
+//     messages table is unrelated to checkpoint state). "Latest" and
+//     newest-first order by `id DESC`, NOT `version DESC`: snapshots.version is
+//     incremented per event-stream (trigger increments WHERE stream_id=...), so
+//     across a thread's multiple runs version does not order globally, whereas
+//     id (BIGSERIAL) is the true global write order. Single-run threads behave
+//     identically; multi-run threads now correctly pick the most recently
+//     written checkpoint.

--- a/controlplane/endpoints/runs_batch.go
+++ b/controlplane/endpoints/runs_batch.go
@@ -1,0 +1,65 @@
+// Hand-written batch run creation. Route is generated into runs_gen.go
+// (batch_create marked custom in endpoints.yaml); body lives here. POST
+// /runs/batch takes a RunBatchCreate ([]RunCreateStateless) and creates every
+// run in one transaction: N run.created events + N runs-projection inserts + a
+// single pg_notify wake-up, all atomic. The response schema is unconstrained
+// ({}), so we return the created runs ([]Run) — the useful result and what the
+// LangGraph SDK expects.
+package endpoints
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// RunsBatchCreate creates a batch of stateless runs atomically.
+// POST /runs/batch -> 200 []Run.
+func (s *Server) RunsBatchCreate(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req RunBatchCreate
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if len(req) == 0 {
+		return c.JSON(http.StatusOK, []Run{})
+	}
+
+	// Pre-mint an id per run so the run.created events (built before the TX
+	// projection) and the projection inserts agree on ids.
+	ids := make([]uuid.UUID, len(req))
+	events := make([]Event, len(req))
+	for i, r := range req {
+		ids[i] = uuid.New()
+		events[i] = Event{
+			AggregateType: "Run",
+			AggregateID:   ids[i],
+			EventType:     "run.created",
+			Payload:       mustJSON(r),
+		}
+	}
+
+	out := make([]Run, 0, len(req))
+	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
+		for i, r := range req {
+			rows, err := tx.Query(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata)
+VALUES ($1, $2, 'queued', $3, $4)
+RETURNING id, thread_id, assistant_id, status, input, output, error, metadata, kwargs, multitask_strategy, version, lease_epoch, worker_id, priority, graph_id, created_at, started_at, completed_at, updated_at
+`, ids[i], asUUID(r.AssistantId), mustJSON(r.Input), mustJSON(r.Metadata))
+			if err != nil {
+				return err
+			}
+			row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[runRow])
+			if err != nil {
+				return err
+			}
+			out = append(out, row.toAPI())
+		}
+		return nil
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, out)
+}

--- a/controlplane/endpoints/runs_cancel.go
+++ b/controlplane/endpoints/runs_cancel.go
@@ -1,0 +1,104 @@
+// Hand-written batch/stateless run cancellation. Route is generated into
+// runs_gen.go (cancel_stateless marked custom in endpoints.yaml); body lives
+// here. POST /runs/cancel takes a RunsCancel selector — either an explicit
+// run_ids list or a status filter (pending/running/all), optionally narrowed to
+// one thread — cancels the matching in-flight runs, and returns 204 (the
+// LangGraph-Cloud contract; no body). One run.cancelled event is emitted per
+// run that is actually transitioned, through the transactional-outbox path.
+package endpoints
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// cancellableStatuses are the runs.status values a cancel may transition from.
+// A run already completed/failed/cancelled is left untouched.
+const cancellableStatuses = "'queued', 'in_progress', 'requires_action'"
+
+// cancelStatusToDB maps an API RunsCancel.status filter to the DB run statuses
+// it selects. Returns nil for an unrecognized value (→ 422).
+func cancelStatusToDB(status string) []string {
+	switch status {
+	case "pending":
+		return []string{"queued"}
+	case "running":
+		return []string{"in_progress"}
+	case "all":
+		return []string{"queued", "in_progress", "requires_action"}
+	default:
+		return nil
+	}
+}
+
+// RunsCancelStateless cancels a set of runs selected by run_ids or status
+// filter. POST /runs/cancel -> 204 / 422 (no selector) / 500.
+//
+// Selection and mutation are two statements (resolve cancellable ids, then
+// UPDATE). Both carry the cancellable-status guard, so a run that reaches a
+// terminal state in the gap between them is not clobbered; the only residue is
+// a run.cancelled event for a run that finished first, which is benign for an
+// idempotent cancel. Events are built from the resolved set because writeTx
+// appends them before running the projection.
+func (s *Server) RunsCancelStateless(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req RunsCancel
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	where := "status IN (" + cancellableStatuses + ")"
+	args := []any{}
+	n := 1
+	switch {
+	case req.RunIds != nil && len(*req.RunIds) > 0:
+		where += fmt.Sprintf(" AND id = ANY($%d)", n)
+		args = append(args, *req.RunIds)
+		n++
+	case req.Status != nil:
+		dbStatuses := cancelStatusToDB(string(*req.Status))
+		if dbStatuses == nil {
+			return echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid status filter")
+		}
+		where += fmt.Sprintf(" AND status = ANY($%d)", n)
+		args = append(args, dbStatuses)
+		n++
+	default:
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, "must provide run_ids or status")
+	}
+	if req.ThreadId != nil {
+		where += fmt.Sprintf(" AND thread_id = $%d", n)
+		args = append(args, *req.ThreadId)
+		n++
+	}
+
+	rows, err := s.Tenant.Query(ctx, "SELECT id FROM runs WHERE "+where, args...)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[uuid.UUID])
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if len(ids) == 0 {
+		// Nothing in flight matched — cancel is idempotent, so this is success.
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	events := make([]Event, len(ids))
+	for i, id := range ids {
+		events[i] = Event{AggregateType: "Run", AggregateID: id, EventType: "run.cancelled"}
+	}
+	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE runs SET status='cancelled', version=version+1, updated_at=now()
+WHERE id = ANY($1) AND status IN (`+cancellableStatuses+`)`, ids)
+		return err
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/controlplane/endpoints/runs_gen.go
+++ b/controlplane/endpoints/runs_gen.go
@@ -103,30 +103,7 @@ RETURNING id, thread_id, assistant_id, status, input, output, error, metadata, k
 	return c.JSON(http.StatusCreated, row.toAPI())
 }
 
-// RunsBatchCreate — POST /runs/batch  (kind: write)
-//   - FOR EACH run in batch: event_streams + events + outbox + projection
-//   - pg_notify('outbox_new',”) once at end of TX
-func (s *Server) RunsBatchCreate(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (RunsBatchCreate request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "Run", AggregateID: aggID, EventType: "run.created"},
-	}
-	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   FOR EACH run in batch: event_streams + events + outbox + projection
-		//   pg_notify('outbox_new','') once at end of TX
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// RunsBatchCreate — POST /runs/batch  (kind: write) — hand-written in runs.go
 
 // RunsGet — GET /threads/{id}/runs/{rid}  (kind: read)
 //   - SELECT * FROM runs WHERE id = :rid AND thread_id = :id
@@ -206,28 +183,7 @@ RETURNING id, thread_id, assistant_id, status, input, output, error, metadata, k
 
 // RunsStatelessWait — POST /runs/wait  (kind: wait) — hand-written in runs.go
 
-// RunsCancelStateless — POST /runs/cancel  (kind: write)
-//   - same as POST /threads/{id}/runs/{rid}/cancel
-func (s *Server) RunsCancelStateless(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (RunsCancelStateless request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "Run", AggregateID: aggID, EventType: "run.cancelled"},
-	}
-	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   same as POST /threads/{id}/runs/{rid}/cancel
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// RunsCancelStateless — POST /runs/cancel  (kind: write) — hand-written in runs.go
 
 // RunsResume — POST /threads/{id}/runs/{rid}/resume  (kind: write)
 //   - SELECT runs WHERE id=:rid AND status='requires_action' (validate)

--- a/controlplane/endpoints/tenant_reads_integration_test.go
+++ b/controlplane/endpoints/tenant_reads_integration_test.go
@@ -1,0 +1,256 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// newTestServerWithTenantReads mounts assistants + threads so the read-only
+// graph/state/checkpoint/history tests can hit both groups on one Echo
+// instance, sharing the package-level testPool testcontainer.
+func newTestServerWithTenantReads() *echo.Echo {
+	e := echo.New()
+	s := &Server{Tenant: testPool}
+	s.RegisterAssistants(e.Group("/api/v1"))
+	s.RegisterThreads(e.Group("/api/v1"))
+	return e
+}
+
+// seedAssistant inserts a minimal assistants row and returns its id.
+func seedAssistant(t *testing.T, ctx context.Context, name string) string {
+	t.Helper()
+	var id string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (name) VALUES ($1) RETURNING id`, name).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// seedThread inserts a minimal threads row and returns its id.
+func seedThread(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	var id string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// seedRun inserts a minimal runs row on the given thread + assistant, and
+// returns its id.
+func seedRun(t *testing.T, ctx context.Context, tid, aid string) string {
+	t.Helper()
+	var id string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'completed') RETURNING id`,
+		tid, aid).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// seedSnapshot writes a snapshots row for rid at the given version, creating
+// (or reusing) the run's event_streams row that snapshots.stream_id FKs to.
+// Returns the new snapshot's bigserial id.
+func seedSnapshot(t *testing.T, ctx context.Context, rid string, version int, state string) int64 {
+	t.Helper()
+	var streamID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO event_streams (aggregate_type, aggregate_id) VALUES ('Run', $1)
+		ON CONFLICT (aggregate_type, aggregate_id) DO UPDATE SET aggregate_type = EXCLUDED.aggregate_type
+		RETURNING stream_id`, rid).Scan(&streamID); err != nil {
+		t.Fatal(err)
+	}
+	var id int64
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+		VALUES ($1, 'Run', $2, $3, $4::jsonb) RETURNING id`,
+		streamID, rid, version, state).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// TestAssistantGetGraph proves GET /assistants/{id}/graph reads the graphs
+// row for the assistant (nodes/edges hand-mapped into GraphSchema.StateSchema,
+// name into GraphId — see rows.go's graphRow.toAPI + DIVERGENCES), and 404s
+// for an assistant with no graph.
+func TestAssistantGetGraph(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE graphs, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantReads()
+
+	aid := seedAssistant(t, ctx, "a")
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO graphs (assistant_id, name, version, description, nodes, edges, config)
+		VALUES ($1, 'my_graph', '1', 'desc', $2::jsonb, $3::jsonb, $4::jsonb)`,
+		aid, `[{"id":"n1"}]`, `[{"source":"n1","target":"n2"}]`, `{"k":"v"}`); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/assistants/"+aid+"/graph", nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get graph: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got GraphSchema
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.GraphId != "my_graph" {
+		t.Errorf("graph_id: want my_graph, got %q", got.GraphId)
+	}
+	if got.StateSchema["nodes"] == nil {
+		t.Errorf("state_schema.nodes: want non-nil, got %v", got.StateSchema)
+	}
+	if got.StateSchema["edges"] == nil {
+		t.Errorf("state_schema.edges: want non-nil, got %v", got.StateSchema)
+	}
+
+	// --- missing assistant -> 404 ---
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/assistants/11111111-1111-1111-1111-111111111111/graph", nil)
+	e.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotFound {
+		t.Errorf("get graph missing: want 404, got %d", rec2.Code)
+	}
+}
+
+// TestThreadGetState proves GET /threads/{id}/state returns the LATEST
+// snapshot (highest version) across the thread's runs, and 404s for a thread
+// with no snapshots.
+func TestThreadGetState(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantReads()
+
+	aid := seedAssistant(t, ctx, "a")
+	tid := seedThread(t, ctx)
+	rid := seedRun(t, ctx, tid, aid)
+	seedSnapshot(t, ctx, rid, 1, `{"count":1}`)
+	seedSnapshot(t, ctx, rid, 2, `{"count":2}`)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/threads/"+tid+"/state", nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get state: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got ThreadState
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	values, ok := got.Values.(map[string]interface{})
+	if !ok {
+		t.Fatalf("values: want object, got %T (%v)", got.Values, got.Values)
+	}
+	if count, _ := values["count"].(float64); count != 2 {
+		t.Errorf("values.count: want 2 (latest version), got %v", values["count"])
+	}
+
+	// --- thread with no snapshots -> 404 ---
+	tidEmpty := seedThread(t, ctx)
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/threads/"+tidEmpty+"/state", nil)
+	e.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotFound {
+		t.Errorf("get state empty: want 404, got %d", rec2.Code)
+	}
+}
+
+// TestThreadGetCheckpointState proves GET /threads/{id}/state/{checkpoint_id}
+// returns the thread's own snapshot, and thread-scopes strictly: a snapshot
+// id belonging to ANOTHER thread's run must 404, never leak.
+func TestThreadGetCheckpointState(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantReads()
+
+	aid := seedAssistant(t, ctx, "a")
+
+	tid := seedThread(t, ctx)
+	rid := seedRun(t, ctx, tid, aid)
+	ckpt := seedSnapshot(t, ctx, rid, 1, `{"count":1}`)
+
+	otherTid := seedThread(t, ctx)
+	otherRid := seedRun(t, ctx, otherTid, aid)
+	otherCkpt := seedSnapshot(t, ctx, otherRid, 1, `{"count":99}`)
+
+	// --- own checkpoint -> 200 ---
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/threads/"+tid+"/state/"+itoa64(ckpt), nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get checkpoint: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got ThreadState
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	values, _ := got.Values.(map[string]interface{})
+	if count, _ := values["count"].(float64); count != 1 {
+		t.Errorf("values.count: want 1, got %v", values["count"])
+	}
+
+	// --- another thread's checkpoint -> 404 (thread-scoping, never leak) ---
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/threads/"+tid+"/state/"+itoa64(otherCkpt), nil)
+	e.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotFound {
+		t.Errorf("get checkpoint cross-thread: want 404, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+}
+
+// TestThreadGetHistory proves GET /threads/{id}/history returns the thread's
+// snapshots newest-first.
+func TestThreadGetHistory(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantReads()
+
+	aid := seedAssistant(t, ctx, "a")
+	tid := seedThread(t, ctx)
+	rid := seedRun(t, ctx, tid, aid)
+	seedSnapshot(t, ctx, rid, 1, `{"count":1}`)
+	seedSnapshot(t, ctx, rid, 2, `{"count":2}`)
+	seedSnapshot(t, ctx, rid, 3, `{"count":3}`)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/threads/"+tid+"/history", nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get history: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []ThreadState
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("history: want 3, got %d", len(got))
+	}
+	wantOrder := []float64{3, 2, 1}
+	for i, want := range wantOrder {
+		values, ok := got[i].Values.(map[string]interface{})
+		if !ok {
+			t.Fatalf("history[%d].values: want object, got %T", i, got[i].Values)
+		}
+		if count, _ := values["count"].(float64); count != want {
+			t.Errorf("history[%d].values.count: want %v (newest-first), got %v", i, want, values["count"])
+		}
+	}
+}

--- a/controlplane/endpoints/tenant_writes_integration_test.go
+++ b/controlplane/endpoints/tenant_writes_integration_test.go
@@ -1,0 +1,286 @@
+package endpoints
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// newTestServerWithTenantWrites mounts runs + threads so the write tests
+// (cancel_stateless, batch_create, create_checkpoint, copy) can hit both groups
+// on one Echo instance, sharing the package-level testPool testcontainer.
+func newTestServerWithTenantWrites() *echo.Echo {
+	e := echo.New()
+	s := &Server{Tenant: testPool}
+	s.RegisterRuns(e.Group("/api/v1"))
+	s.RegisterThreads(e.Group("/api/v1"))
+	return e
+}
+
+// seedRunWithStatus inserts a runs row (optionally stateless: tid == "") with an
+// explicit status, and returns its id.
+func seedRunWithStatus(t *testing.T, ctx context.Context, tid, aid, status string) string {
+	t.Helper()
+	var (
+		id  string
+		err error
+	)
+	if tid == "" {
+		err = testPool.QueryRow(ctx,
+			`INSERT INTO runs (assistant_id, status) VALUES ($1,$2) RETURNING id`,
+			aid, status).Scan(&id)
+	} else {
+		err = testPool.QueryRow(ctx,
+			`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,$3) RETURNING id`,
+			tid, aid, status).Scan(&id)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func countRows(t *testing.T, ctx context.Context, sql string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(ctx, sql, args...).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func runStatus(t *testing.T, ctx context.Context, rid string) string {
+	t.Helper()
+	var s string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// TestCancelStateless proves POST /runs/cancel cancels the selected in-flight
+// runs, returns 204, transitions runs.status -> 'cancelled', and emits one
+// run.cancelled event (events + outbox) per cancelled run — via both the
+// explicit run_ids selector and the status filter.
+func TestCancelStateless(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistant(t, ctx, "a")
+
+	// --- by run_ids: cancel one queued stateless run ---
+	rid := seedRunWithStatus(t, ctx, "", aid, "queued")
+	ridUUID := uuid.MustParse(rid)
+	body, _ := json.Marshal(RunsCancel{RunIds: &[]uuid.UUID{ridUUID}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/cancel", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("cancel by ids: want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := runStatus(t, ctx, rid); got != "cancelled" {
+		t.Errorf("run status: want cancelled, got %q", got)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='run.cancelled'`, rid); n != 1 {
+		t.Errorf("run.cancelled events: want 1, got %d", n)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.cancelled'`, rid); n != 1 {
+		t.Errorf("run.cancelled outbox: want 1, got %d", n)
+	}
+
+	// --- by status filter: 'running' cancels only the in_progress run ---
+	running := seedRunWithStatus(t, ctx, "", aid, "in_progress")
+	done := seedRunWithStatus(t, ctx, "", aid, "completed")
+	st := RunsCancelStatus("running")
+	body2, _ := json.Marshal(RunsCancel{Status: &st})
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/runs/cancel", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNoContent {
+		t.Fatalf("cancel by status: want 204, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+	if got := runStatus(t, ctx, running); got != "cancelled" {
+		t.Errorf("running run: want cancelled, got %q", got)
+	}
+	if got := runStatus(t, ctx, done); got != "completed" {
+		t.Errorf("completed run must be untouched: got %q", got)
+	}
+
+	// --- no selector -> 422 ---
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodPost, "/api/v1/runs/cancel", bytes.NewReader([]byte(`{}`)))
+	req3.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusUnprocessableEntity {
+		t.Errorf("no selector: want 422, got %d", rec3.Code)
+	}
+}
+
+// TestBatchCreate proves POST /runs/batch creates every run atomically,
+// returns the created runs, and emits one run.created event per run.
+func TestBatchCreate(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistant(t, ctx, "a")
+
+	batch := RunBatchCreate{
+		{AssistantId: aid, Input: map[string]any{"n": 1}},
+		{AssistantId: aid, Input: map[string]any{"n": 2}},
+	}
+	body, _ := json.Marshal(batch)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("batch: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("batch runs: want 2, got %d", len(got))
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM runs WHERE status='queued'`); n != 2 {
+		t.Errorf("queued runs: want 2, got %d", n)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM events WHERE event_type='run.created'`); n != 2 {
+		t.Errorf("run.created events: want 2, got %d", n)
+	}
+
+	// --- empty batch -> 200 [] ---
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/runs/batch", bytes.NewReader([]byte(`[]`)))
+	req2.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Errorf("empty batch: want 200, got %d", rec2.Code)
+	}
+}
+
+// TestCreateCheckpoint proves POST /threads/{id}/state/checkpoint reads the
+// thread's state AT the checkpoint carried in the body (get-state-at-checkpoint,
+// NOT a write), falls back to the latest when the checkpoint id is absent, and
+// thread-scopes strictly (another thread's checkpoint 404s).
+func TestCreateCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistant(t, ctx, "a")
+	tid := seedThread(t, ctx)
+	rid := seedRun(t, ctx, tid, aid)
+	c1 := seedSnapshot(t, ctx, rid, 1, `{"count":1}`)
+	seedSnapshot(t, ctx, rid, 2, `{"count":2}`)
+
+	// --- explicit checkpoint id -> that snapshot's values ---
+	cid := itoa64(c1)
+	body, _ := json.Marshal(ThreadStateCheckpointRequest{Checkpoint: CheckpointConfig{CheckpointId: &cid}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/threads/"+tid+"/state/checkpoint", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("checkpoint by id: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got ThreadState
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v, _ := got.Values.(map[string]interface{}); v["count"].(float64) != 1 {
+		t.Errorf("values.count: want 1 (the requested checkpoint), got %v", got.Values)
+	}
+
+	// --- no checkpoint id -> latest ---
+	body2, _ := json.Marshal(ThreadStateCheckpointRequest{})
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/threads/"+tid+"/state/checkpoint", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("checkpoint latest: want 200, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+	var got2 ThreadState
+	_ = json.Unmarshal(rec2.Body.Bytes(), &got2)
+	if v, _ := got2.Values.(map[string]interface{}); v["count"].(float64) != 2 {
+		t.Errorf("values.count: want 2 (latest), got %v", got2.Values)
+	}
+
+	// --- another thread's checkpoint -> 404 ---
+	otherTid := seedThread(t, ctx)
+	otherRid := seedRun(t, ctx, otherTid, aid)
+	oc := seedSnapshot(t, ctx, otherRid, 1, `{"count":99}`)
+	ocid := itoa64(oc)
+	body3, _ := json.Marshal(ThreadStateCheckpointRequest{Checkpoint: CheckpointConfig{CheckpointId: &ocid}})
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodPost, "/api/v1/threads/"+tid+"/state/checkpoint", bytes.NewReader(body3))
+	req3.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusNotFound {
+		t.Errorf("cross-thread checkpoint: want 404, got %d", rec3.Code)
+	}
+}
+
+// TestThreadCopy proves POST /threads/{id}/copy duplicates the thread's state
+// (values) and message history under a new id, returns the new Thread, and
+// emits a thread.created event.
+func TestThreadCopy(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, messages, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+
+	var srcID string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO threads (values, metadata) VALUES ($1::jsonb, $2::jsonb) RETURNING id`,
+		`{"count":7}`, `{"k":"v"}`).Scan(&srcID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO messages (thread_id, role, content) VALUES ($1,'user','hi'), ($1,'assistant','yo')`, srcID); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/threads/"+srcID+"/copy", nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("copy: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Thread
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	newID := got.ThreadId.String()
+	if newID == srcID {
+		t.Fatalf("copy must mint a new id, got the source id %s", newID)
+	}
+	if got.Values == nil {
+		t.Fatalf("copied thread must carry values")
+	}
+	if v := (*got.Values)["count"]; v == nil || v.(float64) != 7 {
+		t.Errorf("copied values.count: want 7, got %v", v)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM messages WHERE thread_id=$1`, newID); n != 2 {
+		t.Errorf("copied messages: want 2, got %d", n)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='thread.created'`, newID); n != 1 {
+		t.Errorf("thread.created event: want 1, got %d", n)
+	}
+}

--- a/controlplane/endpoints/threads_copy.go
+++ b/controlplane/endpoints/threads_copy.go
@@ -1,0 +1,78 @@
+// Hand-written thread copy. Route is generated into threads_gen.go (copy marked
+// custom in endpoints.yaml); body lives here. POST /threads/{id}/copy takes no
+// request body and returns the new Thread (LangGraph-Cloud contract). The copy
+// carries the source thread's state (values), config, and metadata, plus its
+// message history, under a fresh thread id; status resets to the default
+// ('idle') since the copy has no in-flight run. A single thread.created event is
+// emitted for the new thread through the transactional-outbox path.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// ThreadsCopy duplicates a thread (values/config/metadata + message history)
+// under a new id. POST /threads/{id}/copy -> 200 Thread / 404 (source missing).
+func (s *Server) ThreadsCopy(c echo.Context) error {
+	ctx := c.Request().Context()
+	srcID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	// Read the source thread's copyable columns up front (outside the write TX):
+	// the thread.created payload records the source id + copied fields, and the
+	// event slice must be built before writeTx runs the projection.
+	var src threadRow
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, status, values, config, metadata, created_at, updated_at
+		FROM threads WHERE id = $1`, srcID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	src, err = pgx.CollectOneRow(rows, pgx.RowToStructByName[threadRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	newID := uuid.New()
+	events := []Event{{
+		AggregateType: "Thread",
+		AggregateID:   newID,
+		EventType:     "thread.created",
+		Payload:       mustJSON(map[string]any{"copied_from": srcID}),
+	}}
+
+	var out threadRow
+	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
+		r, err := tx.Query(ctx, `
+			INSERT INTO threads (id, values, config, metadata)
+			VALUES ($1, $2, $3, $4)
+			RETURNING id, status, values, config, metadata, created_at, updated_at`,
+			newID, src.Values, jsonOrEmpty(src.Config), jsonOrEmpty(src.Metadata))
+		if err != nil {
+			return err
+		}
+		if out, err = pgx.CollectOneRow(r, pgx.RowToStructByName[threadRow]); err != nil {
+			return err
+		}
+		// Copy message history with fresh ids under the new thread, preserving
+		// role/content/metadata and original ordering (created_at carried over).
+		_, err = tx.Exec(ctx, `
+			INSERT INTO messages (thread_id, role, content, metadata, created_at)
+			SELECT $1, role, content, metadata, created_at
+			FROM messages WHERE thread_id = $2`, newID, srcID)
+		return err
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, out.toAPI())
+}

--- a/controlplane/endpoints/threads_create.go
+++ b/controlplane/endpoints/threads_create.go
@@ -1,0 +1,106 @@
+// Hand-written thread create. Route is generated into threads_gen.go (create
+// marked custom in endpoints.yaml); body lives here. POST /threads implements
+// the LangGraph-Cloud idempotent-create contract: a client MAY supply thread_id
+// to make creation idempotent, and if_exists selects what happens on a clash —
+// "raise" (the default) returns 409, "do_nothing" returns the existing thread.
+// When thread_id is omitted a fresh id is minted and creation always succeeds.
+// A single thread.created event is emitted through the transactional-outbox path
+// only on an actual insert; a no-op (do_nothing) hit and a 409 emit nothing.
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// errThreadConflict is a sentinel returned from inside the write TX when the
+// INSERT hit ON CONFLICT DO NOTHING (row already exists). Returning an error
+// rolls the TX back so the pre-appended thread.created event is discarded — an
+// idempotent create must not emit a second creation event for the same id.
+var errThreadConflict = errors.New("thread already exists")
+
+// ThreadsCreate creates a thread, honoring a client-supplied thread_id and the
+// if_exists policy. POST /threads -> 201 (created) / 200 (existing, do_nothing) /
+// 409 (existing, raise).
+func (s *Server) ThreadsCreate(c echo.Context) error {
+	ctx := c.Request().Context()
+	var req ThreadCreate
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	// Honor a client-supplied thread_id (makes create idempotent); otherwise mint
+	// one. gen_random_uuid() on the column would ignore the client's id, so the id
+	// is chosen here and passed explicitly.
+	id := uuid.New()
+	if req.ThreadId != nil {
+		id = *req.ThreadId
+	}
+
+	events := []Event{
+		{AggregateType: "Thread", AggregateID: id, EventType: "thread.created", Payload: mustJSON(req)},
+	}
+
+	var (
+		out        threadRow
+		conflicted bool
+	)
+	err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			INSERT INTO threads (id, metadata)
+			VALUES ($1, $2)
+			ON CONFLICT (id) DO NOTHING
+			RETURNING id, status, values, config, metadata, created_at, updated_at`,
+			id, mustJSON(req.Metadata))
+		if err != nil {
+			return err
+		}
+		out, err = pgx.CollectOneRow(rows, pgx.RowToStructByName[threadRow])
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Row already exists (ON CONFLICT DO NOTHING returned nothing). Abort
+			// the TX so the thread.created event is rolled back; the if_exists
+			// policy is applied outside the TX.
+			conflicted = true
+			return errThreadConflict
+		}
+		return err
+	})
+	if conflicted {
+		return s.threadCreateConflict(c, ctx, id, req.IfExists)
+	}
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusCreated, out.toAPI())
+}
+
+// threadCreateConflict resolves a thread_id collision per the if_exists policy:
+// "do_nothing" returns the pre-existing thread (200, no event emitted); anything
+// else — "raise" or an omitted policy — is a 409. LangGraph-Cloud defaults
+// if_exists to "raise", so nil maps to 409.
+func (s *Server) threadCreateConflict(c echo.Context, ctx context.Context, id uuid.UUID, ifExists *ThreadCreateIfExists) error {
+	if ifExists == nil || *ifExists != ThreadCreateIfExistsDoNothing {
+		return echo.NewHTTPError(http.StatusConflict, "thread already exists")
+	}
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, status, values, config, metadata, created_at, updated_at
+		FROM threads WHERE id = $1`, id)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	existing, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[threadRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Raced: the conflicting row was deleted between our INSERT and this
+			// SELECT. Report a conflict rather than fabricate a thread.
+			return echo.NewHTTPError(http.StatusConflict, "thread already exists")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, existing.toAPI())
+}

--- a/controlplane/endpoints/threads_create_integration_test.go
+++ b/controlplane/endpoints/threads_create_integration_test.go
@@ -1,0 +1,106 @@
+package endpoints
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestThreadsIdempotentCreate proves POST /threads honors the LangGraph-Cloud
+// idempotent-create contract: a client-supplied thread_id is used verbatim; a
+// second create for the same id is a no-op returning the existing thread (200)
+// under if_exists=do_nothing and a 409 under if_exists=raise (and the default);
+// an omitted thread_id mints a fresh id. Exactly one thread.created event is
+// emitted for the id — the conflict paths roll their event back.
+func TestThreadsIdempotentCreate(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, messages, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+
+	post := func(body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/threads", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+	eventCount := func(id string) int {
+		return countRows(t, ctx, `SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='thread.created'`, id)
+	}
+
+	tid := uuid.New().String()
+
+	// --- 1. client-supplied thread_id round-trips (201) ---
+	rec := post(fmt.Sprintf(`{"thread_id":%q,"metadata":{"k":"v"}}`, tid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created Thread
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.ThreadId.String() != tid {
+		t.Errorf("thread_id: want %s (client-supplied), got %s", tid, created.ThreadId)
+	}
+	if created.Metadata["k"] != "v" {
+		t.Errorf("metadata.k: want v, got %v", created.Metadata["k"])
+	}
+	if n := eventCount(tid); n != 1 {
+		t.Fatalf("thread.created events after create: want 1, got %d", n)
+	}
+
+	// --- 2. same id, if_exists=do_nothing -> 200 existing, NO new event ---
+	rec = post(fmt.Sprintf(`{"thread_id":%q,"if_exists":"do_nothing","metadata":{"k":"ignored"}}`, tid))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("do_nothing: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var existing Thread
+	_ = json.Unmarshal(rec.Body.Bytes(), &existing)
+	if existing.ThreadId.String() != tid {
+		t.Errorf("do_nothing id: want %s, got %s", tid, existing.ThreadId)
+	}
+	// the existing thread is returned unchanged — the second call's metadata is discarded
+	if existing.Metadata["k"] != "v" {
+		t.Errorf("do_nothing must return the ORIGINAL thread: metadata.k want v, got %v", existing.Metadata["k"])
+	}
+	if n := eventCount(tid); n != 1 {
+		t.Errorf("do_nothing must not emit an event: want 1 total, got %d", n)
+	}
+
+	// --- 3. same id, if_exists=raise -> 409, still no new event ---
+	rec = post(fmt.Sprintf(`{"thread_id":%q,"if_exists":"raise"}`, tid))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("raise: want 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if n := eventCount(tid); n != 1 {
+		t.Errorf("raise must not emit an event: want 1 total, got %d", n)
+	}
+
+	// --- 4. same id, if_exists omitted (defaults to raise) -> 409 ---
+	rec = post(fmt.Sprintf(`{"thread_id":%q}`, tid))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("default (no if_exists): want 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// --- 5. omitted thread_id mints a fresh id (201) ---
+	rec = post(`{"metadata":{"fresh":true}}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("no id: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var minted Thread
+	_ = json.Unmarshal(rec.Body.Bytes(), &minted)
+	if minted.ThreadId.String() == tid || minted.ThreadId == uuid.Nil {
+		t.Errorf("no id: want a fresh non-nil id distinct from %s, got %s", tid, minted.ThreadId)
+	}
+	if n := eventCount(minted.ThreadId.String()); n != 1 {
+		t.Errorf("minted thread.created events: want 1, got %d", n)
+	}
+}

--- a/controlplane/endpoints/threads_gen.go
+++ b/controlplane/endpoints/threads_gen.go
@@ -193,27 +193,9 @@ func (s *Server) ThreadsDelete(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// ThreadsGetState — GET /threads/{id}/state  (kind: read)
-//   - SELECT * FROM messages WHERE thread_id = :id ORDER BY created_at
-//   - SELECT * FROM runs WHERE thread_id = :id AND status='completed' ORDER BY completed_at DESC LIMIT 1
-func (s *Server) ThreadsGetState(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   SELECT * FROM messages WHERE thread_id = :id ORDER BY created_at
-	//   SELECT * FROM runs WHERE thread_id = :id AND status='completed' ORDER BY completed_at DESC LIMIT 1
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// ThreadsGetState — GET /threads/{id}/state  (kind: read) — hand-written in threads.go
 
-// ThreadsGetCheckpointState — GET /threads/{id}/state/{checkpoint_id}  (kind: read)
-//   - SELECT * FROM snapshots WHERE stream_id = :checkpoint_id
-func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   SELECT * FROM snapshots WHERE stream_id = :checkpoint_id
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// ThreadsGetCheckpointState — GET /threads/{id}/state/{checkpoint_id}  (kind: read) — hand-written in threads.go
 
 // ThreadsCreateCheckpoint — POST /threads/{id}/state/checkpoint  (kind: write)
 //   - INSERT snapshots (stream_id, aggregate_type, aggregate_id, version, state)  # infra, not domain event
@@ -229,15 +211,7 @@ func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
 }
 
-// ThreadsGetHistory — GET /threads/{id}/history  (kind: read)
-//   - SELECT * FROM events WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id=:id) ORDER BY occurred_at
-func (s *Server) ThreadsGetHistory(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   SELECT * FROM events WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id=:id) ORDER BY occurred_at
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// ThreadsGetHistory — GET /threads/{id}/history  (kind: read) — hand-written in threads.go
 
 // ThreadsCopy — POST /threads/{id}/copy  (kind: write)
 //   - INSERT threads (new id, copy metadata)

--- a/controlplane/endpoints/threads_gen.go
+++ b/controlplane/endpoints/threads_gen.go
@@ -197,49 +197,8 @@ func (s *Server) ThreadsDelete(c echo.Context) error {
 
 // ThreadsGetCheckpointState — GET /threads/{id}/state/{checkpoint_id}  (kind: read) — hand-written in threads.go
 
-// ThreadsCreateCheckpoint — POST /threads/{id}/state/checkpoint  (kind: write)
-//   - INSERT snapshots (stream_id, aggregate_type, aggregate_id, version, state)  # infra, not domain event
-func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (ThreadsCreateCheckpoint request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	// projection-only write (not event-sourced — no outbox):
-	//   INSERT snapshots (stream_id, aggregate_type, aggregate_id, version, state)  # infra, not domain event
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// ThreadsCreateCheckpoint — POST /threads/{id}/state/checkpoint  (kind: read) — hand-written in threads.go
 
 // ThreadsGetHistory — GET /threads/{id}/history  (kind: read) — hand-written in threads.go
 
-// ThreadsCopy — POST /threads/{id}/copy  (kind: write)
-//   - INSERT threads (new id, copy metadata)
-//   - INSERT messages (copy all with new thread_id)
-//   - INSERT events: event_type='thread.created' for the new thread
-//   - INSERT outbox (same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) ThreadsCopy(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (ThreadsCopy request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "Thread", AggregateID: aggID, EventType: "thread.created"},
-	}
-	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   INSERT threads (new id, copy metadata)
-		//   INSERT messages (copy all with new thread_id)
-		//   INSERT events: event_type='thread.created' for the new thread
-		//   INSERT outbox (same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// ThreadsCopy — POST /threads/{id}/copy  (kind: write) — hand-written in threads.go

--- a/controlplane/endpoints/threads_gen.go
+++ b/controlplane/endpoints/threads_gen.go
@@ -27,39 +27,7 @@ func (s *Server) RegisterThreads(g *echo.Group) {
 	g.POST("/threads/:id/copy", s.ThreadsCopy)
 }
 
-// ThreadsCreate — POST /threads  (kind: write)
-//   - INSERT events: event_type='thread.created', payload={metadata}
-//   - INSERT outbox (same event_id, same TX)
-//   - pg_notify('outbox_new',”)
-//   - INSERT threads projection (id, metadata)
-func (s *Server) ThreadsCreate(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req ThreadCreate
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New()
-	payload := mustJSON(req)
-	events := []Event{
-		{AggregateType: "Thread", AggregateID: aggID, EventType: "thread.created", Payload: payload},
-	}
-	var row threadRow
-	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `INSERT INTO threads (id, metadata)
-VALUES ($1, $2)
-RETURNING id, status, values, config, metadata, created_at, updated_at
-`, aggID, mustJSON(req.Metadata))
-		if err != nil {
-			return err
-		}
-		row, err = pgx.CollectOneRow(rows, pgx.RowToStructByName[threadRow])
-		return err
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusCreated, row.toAPI())
-}
+// ThreadsCreate — POST /threads  (kind: write) — hand-written in threads.go
 
 // ThreadsSearch — POST /threads/search  (kind: read)
 //   - SELECT * FROM threads WHERE metadata @> :filter ORDER BY created_at DESC LIMIT :limit

--- a/controlplane/endpoints/threads_state.go
+++ b/controlplane/endpoints/threads_state.go
@@ -67,6 +67,55 @@ func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
 	return c.JSON(http.StatusOK, row.toThreadState())
 }
 
+// ThreadsCreateCheckpoint, despite its name, is a READ: the OpenAPI
+// ThreadStateCheckpointRequest -> ThreadState contract is "get the state of a
+// thread AT a checkpoint" (the checkpoint id travels in the body's
+// CheckpointConfig, not the path, because a full checkpoint config is richer
+// than a path param). It is the body-carried twin of ThreadsGetCheckpointState.
+// The endpoint-queries.d2 "INSERT snapshots" step mismodels it as a write — see
+// DIVERGENCES in rows.go. When checkpoint.checkpoint_id is absent we fall back
+// to the latest snapshot (same as ThreadsGetState). All lookups are scoped to
+// the thread's own runs so another thread's checkpoint 404s.
+// POST /threads/{id}/state/checkpoint -> 200 ThreadState / 404.
+func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
+	ctx := c.Request().Context()
+	tid := c.Param("id")
+	var req ThreadStateCheckpointRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if req.Checkpoint.CheckpointId != nil && *req.Checkpoint.CheckpointId != "" {
+		rows, err = s.Tenant.Query(ctx, `
+			SELECT id, stream_id, aggregate_id, version, state, created_at
+			FROM snapshots
+			WHERE id = $1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = $2)`,
+			*req.Checkpoint.CheckpointId, tid)
+	} else {
+		rows, err = s.Tenant.Query(ctx, `
+			SELECT id, stream_id, aggregate_id, version, state, created_at
+			FROM snapshots
+			WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id = $1)
+			ORDER BY id DESC
+			LIMIT 1`, tid)
+	}
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toThreadState())
+}
+
 // ThreadsGetHistory returns every snapshot across the thread's runs,
 // newest-first (ORDER BY id DESC — global write order, since version is
 // per-stream). GET /threads/{id}/history -> 200 []ThreadState.

--- a/controlplane/endpoints/threads_state.go
+++ b/controlplane/endpoints/threads_state.go
@@ -1,0 +1,93 @@
+// Hand-written thread state/checkpoint/history reads. Routes are generated
+// into threads_gen.go (get_state/get_checkpoint_state/get_history marked
+// custom in endpoints.yaml); bodies live here. All three read the snapshots
+// table scoped to the thread's own runs (aggregate_id IN (SELECT id FROM runs
+// WHERE thread_id=...)) — mirrors WorkersReadCheckpoint's thread-scoping in
+// workers.go, so a checkpoint belonging to another thread's run always 404s,
+// never leaks. See rows.go's snapshotRow.toThreadState + DIVERGENCES for the
+// ThreadState hand-mapping.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// ThreadsGetState returns the latest snapshot (highest bigserial id = most
+// recently written) across the thread's runs. Ordering is by id, not version:
+// snapshots.version is incremented per event-stream, so with more than one run
+// on a thread it does not order globally — id (BIGSERIAL) is the true
+// chronological key. GET /threads/{id}/state -> 200 ThreadState / 404.
+func (s *Server) ThreadsGetState(c echo.Context) error {
+	ctx := c.Request().Context()
+	tid := c.Param("id")
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots
+		WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id = $1)
+		ORDER BY id DESC
+		LIMIT 1`, tid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toThreadState())
+}
+
+// ThreadsGetCheckpointState returns one snapshot by id, scoped to the
+// thread's own runs — a checkpoint id from another thread's run 404s.
+// GET /threads/{id}/state/{checkpoint_id} -> 200 ThreadState / 404.
+func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
+	ctx := c.Request().Context()
+	tid := c.Param("id")
+	ckpt := c.Param("checkpoint_id")
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots
+		WHERE id = $1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = $2)`, ckpt, tid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, row.toThreadState())
+}
+
+// ThreadsGetHistory returns every snapshot across the thread's runs,
+// newest-first (ORDER BY id DESC — global write order, since version is
+// per-stream). GET /threads/{id}/history -> 200 []ThreadState.
+func (s *Server) ThreadsGetHistory(c echo.Context) error {
+	ctx := c.Request().Context()
+	tid := c.Param("id")
+	rows, err := s.Tenant.Query(ctx, `
+		SELECT id, stream_id, aggregate_id, version, state, created_at
+		FROM snapshots
+		WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id = $1)
+		ORDER BY id DESC`, tid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	list, err := pgx.CollectRows(rows, pgx.RowToStructByName[snapshotRow])
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	out := make([]ThreadState, len(list))
+	for i := range list {
+		out[i] = list[i].toThreadState()
+	}
+	return c.JSON(http.StatusOK, out)
+}

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -300,9 +300,14 @@ groups:
       - name: create_checkpoint
         method: POST
         path: /threads/{id}/state/checkpoint
-        kind: write
+        kind: read
         outbox: false
-        steps: ["INSERT snapshots (stream_id, aggregate_type, aggregate_id, version, state)  # infra, not domain event"]
+        custom: true
+        # NOT a write: the OpenAPI ThreadStateCheckpointRequest -> ThreadState
+        # contract is "get the state of a thread AT a checkpoint" (checkpoint id
+        # carried in the body's CheckpointConfig). The d2 INSERT-snapshots step
+        # mismodels it — see DIVERGENCES in rows.go. Body in threads_state.go.
+        steps: ["SELECT * FROM snapshots WHERE id = :body.checkpoint.checkpoint_id (thread-scoped); latest when absent"]
       - name: get_history
         method: GET
         path: /threads/{id}/history
@@ -315,6 +320,7 @@ groups:
         path: /threads/{id}/copy
         kind: write
         outbox: true
+        custom: true
         events: [thread.created]
         nats: {subject: thread.created, stream: RUNS}
         steps:
@@ -382,6 +388,7 @@ groups:
         path: /runs/batch
         kind: write
         outbox: true
+        custom: true
         events: [run.created]
         nats: {subject: run.created, stream: RUNS}
         steps:
@@ -500,9 +507,13 @@ groups:
         path: /runs/cancel
         kind: write
         outbox: true
+        custom: true
         events: [run.cancelled]
         nats: {subject: run.cancelled, stream: RUNS}
-        steps: ["same as POST /threads/{id}/runs/{rid}/cancel"]
+        # Cancels a SET of runs (RunsCancel: run_ids OR status filter, optionally
+        # thread-scoped) and returns 204 — not one run returning a Run object.
+        # One run.cancelled event per actually-cancelled run. Body in runs_cancel.go.
+        steps: ["UPDATE runs SET status='cancelled' WHERE id = ANY(:run_ids) | status IN (:status) AND status IN (queued,in_progress,requires_action)"]
       - name: resume
         method: POST
         path: /threads/{id}/runs/{rid}/resume

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -151,6 +151,7 @@ groups:
         path: /assistants/{id}/graph
         kind: read
         outbox: false
+        custom: true
         steps: ["SELECT * FROM graphs WHERE assistant_id = :id AND version = (SELECT max version)"]
       - name: get_versions
         method: GET
@@ -285,6 +286,7 @@ groups:
         path: /threads/{id}/state
         kind: read
         outbox: false
+        custom: true
         steps:
           - "SELECT * FROM messages WHERE thread_id = :id ORDER BY created_at"
           - "SELECT * FROM runs WHERE thread_id = :id AND status='completed' ORDER BY completed_at DESC LIMIT 1"
@@ -293,6 +295,7 @@ groups:
         path: /threads/{id}/state/{checkpoint_id}
         kind: read
         outbox: false
+        custom: true
         steps: ["SELECT * FROM snapshots WHERE stream_id = :checkpoint_id"]
       - name: create_checkpoint
         method: POST
@@ -305,6 +308,7 @@ groups:
         path: /threads/{id}/history
         kind: read
         outbox: false
+        custom: true
         steps: ["SELECT * FROM events WHERE aggregate_id IN (SELECT id FROM runs WHERE thread_id=:id) ORDER BY occurred_at"]
       - name: copy
         method: POST

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -181,24 +181,21 @@ groups:
         path: /threads
         kind: write
         outbox: true
+        # custom: honors a client-supplied thread_id + if_exists (LangGraph-Cloud
+        # idempotent-create). The ON CONFLICT (id) DO NOTHING branch — insert-or-
+        # return-existing with distinct 201/200/409 outcomes — can't be expressed
+        # by the write_returning generated body; hand-written in threads_create.go.
+        custom: true
         events: [thread.created]
         nats: {subject: thread.created, stream: RUNS}
         request: ThreadCreate
         response: Thread
-        impl:
-          mode: write_returning
-          aggregate: Thread
-          row: threadRow
-          query: |
-            INSERT INTO threads (id, metadata)
-            VALUES ($1, $2)
-            RETURNING id, status, values, config, metadata, created_at, updated_at
-          args: ["aggID", "mustJSON(req.Metadata)"]
         steps:
-          - "INSERT events: event_type='thread.created', payload={metadata}"
-          - "INSERT outbox (same event_id, same TX)"
-          - "pg_notify('outbox_new','')"
-          - "INSERT threads projection (id, metadata)"
+          - "id = req.thread_id when supplied, else a fresh uuid"
+          - "INSERT threads (id, metadata) ON CONFLICT (id) DO NOTHING RETURNING *"
+          - "inserted: emit thread.created via outbox (event + outbox + pg_notify) -> 201"
+          - "conflict + if_exists=do_nothing: SELECT existing thread -> 200 (no event)"
+          - "conflict + if_exists=raise (default/nil): 409, TX rolled back (no event)"
       - name: search
         method: POST
         path: /threads/search

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -43,10 +43,10 @@ groups:
           aggregate: Assistant
           row: assistantRow
           query: |
-            INSERT INTO assistants (id, graph_id, name, description, config, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6)
-            RETURNING id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
-          args: ["aggID", "req.GraphId", "deref(req.Name)", "req.Description", "mustJSON(req.Config)", "mustJSON(req.Metadata)"]
+            INSERT INTO assistants (id, graph_id, name, description, config, context, metadata)
+            VALUES ($1, $2, $3, $4, $5, COALESCE($6::jsonb, '{}'::jsonb), $7)
+            RETURNING id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
+          args: ["aggID", "req.GraphId", "deref(req.Name)", "req.Description", "mustJSON(req.Config)", "jsonbOrNil(req.Context)", "mustJSON(req.Metadata)"]
         steps:
           - "INSERT events: event_type='assistant.created', payload={name, graph_id, config, tools}"
           - "INSERT outbox (same event_id, same TX)"
@@ -63,7 +63,7 @@ groups:
           mode: read_list
           row: assistantRow
           query: |
-            SELECT id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
+            SELECT id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
             FROM assistants
             WHERE ($1::jsonb IS NULL OR metadata @> $1::jsonb)
             ORDER BY created_at DESC
@@ -94,7 +94,7 @@ groups:
           row: assistantRow
           path_param: id
           query: |
-            SELECT id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
+            SELECT id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
             FROM assistants WHERE id = $1
           args: ["pathID"]
         steps: ["SELECT * FROM assistants WHERE id = :id"]
@@ -121,7 +121,7 @@ groups:
               context = COALESCE($6, context),
               metadata = COALESCE($7, metadata)
             WHERE id = $1
-            RETURNING id, graph_id, name, description, model, instructions, tools, config, metadata, created_at, updated_at
+            RETURNING id, graph_id, name, description, model, instructions, tools, config, context, version, metadata, created_at, updated_at
           args: ["pathID", "req.GraphId", "req.Name", "req.Description", "jsonbOrNil(req.Config)", "jsonbOrNil(req.Context)", "jsonbOrNil(req.Metadata)"]
         steps:
           - "INSERT events: event_type='assistant.updated', payload={changed fields}"


### PR DESCRIPTION
## What

`POST /threads` now implements the LangGraph-Cloud idempotent-create contract:

- a client-supplied `thread_id` is used verbatim (was always minting a fresh id)
- `if_exists` selects clash behavior: `raise` (default/omitted) → **409**, `do_nothing` → return the existing thread **200**
- omitted `thread_id` mints a fresh id → **201** (unchanged)

## How

Converts `threads.create` from the `write_returning` generated mode to a **custom** handler (`threads_create.go`). The `INSERT ... ON CONFLICT (id) DO NOTHING RETURNING` branch — with distinct 201/200/409 outcomes — can't be expressed by the generated body. On an actual insert, exactly one `thread.created` event is emitted through the transactional-outbox path; both conflict paths roll their pre-appended event back (a deliberate sentinel-error rollback), so an idempotent create never emits a second creation event.

`ON CONFLICT (id)` targets the PK, so concurrent same-id creates serialize at the DB: one wins (201), the loser takes the conflict branch. `DO NOTHING` is a no-op (not a unique-violation error), so it doesn't poison the TX.

## Tests

`TestThreadsIdempotentCreate` (testcontainers Postgres): client id round-trips (201); repeat + `do_nothing` → 200 returning the **original** thread (second call's metadata discarded); repeat + `raise` → 409; repeat with omitted `if_exists` → 409; omitted id mints a fresh id. Asserts exactly one `thread.created` event survives across all paths. Full `controlplane/...` suite green; codegen regen byte-identical.

[spec-skip] impl-only; `thread_id` + `if_exists` are already in the OpenAPI ThreadCreate contract.