### PR TITLE
feat(worker): complete the HITL interrupt trigger set (interrupt_after, requires_human, human, tool_calls)

### DIFF
--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -110,42 +110,63 @@ func (c *Client) RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reas
 // RequiresAction suspends runID for human-in-the-loop, fenced on epoch: the
 // server flips the run to requires_action and records the interrupt row. nodeID
 // is the node the run paused at, reason is one of the interrupts.reason CHECK
-// values (tool_call|approval_required|input_needed), and state is the
-// checkpointed channel state at the pause point.
-func (c *Client) RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state []byte) error {
-	body := eventsRequest{Events: []workerEvent{{
+// values (tool_call|approval_required|input_needed), state is the checkpointed
+// channel state at the pause point, and toolCalls is the optional pending
+// tool-call payload persisted to interrupts.tool_calls (hitl.d2 on_interrupt
+// step 2 "INSERT interrupt: run_id, node_id, reason, tool_calls"). A nil
+// toolCalls is omitted from the request, leaving the column NULL.
+func (c *Client) RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error {
+	ev := workerEvent{
 		Type:       "run.requires_action",
 		LeaseEpoch: epoch,
 		NodeID:     nodeID,
 		Reason:     reason,
 		State:      json.RawMessage(state),
-	}}}
-	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	}
+	if len(toolCalls) > 0 {
+		ev.ToolCalls = json.RawMessage(toolCalls)
+	}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), eventsRequest{Events: []workerEvent{ev}}, nil)
 	return err
 }
 
-// WriteCheckpoint upserts a run snapshot, fenced on epoch.
-// POST /api/v1/threads/{tid}/checkpoints.
-func (c *Client) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error {
+// WriteCheckpoint upserts a run snapshot, fenced on epoch, and returns the
+// snapshot's id. The caller threads that id into the NEXT checkpoint's
+// parent_checkpoint_id, which is what gives the checkpoint chain its lineage
+// (graph-engine.d2 §4 checkpoint_mgr.metadata).
+// POST /api/v1/threads/{tid}/checkpoints -> {checkpoint_id}.
+func (c *Client) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) (int64, error) {
 	body := checkpointWriteRequest{RunID: runID, LeaseEpoch: epoch, Version: version, State: json.RawMessage(state)}
-	_, err := c.doJSON(ctx, http.MethodPost, "/api/v1/threads/"+threadID.String()+"/checkpoints", body, nil)
-	return err
+	var resp checkpointWriteResponse
+	if _, err := c.doJSON(ctx, http.MethodPost, "/api/v1/threads/"+threadID.String()+"/checkpoints", body, &resp); err != nil {
+		return 0, err
+	}
+	return resp.CheckpointID, nil
+}
+
+// Checkpoint is a restored run snapshot: the snapshots row id (which becomes
+// the parent_checkpoint_id of the next checkpoint written), its version, and
+// the raw state jsonb carrying the checkpointState envelope.
+type Checkpoint struct {
+	ID      int64
+	Version int
+	State   []byte
 }
 
 // LatestCheckpoint fetches the highest-version snapshot for runID, for worker
 // resume. GET /api/v1/threads/{tid}/checkpoints/latest?run_id={rid}. A 404
 // (no checkpoint yet) is not an error: found is false, err is nil.
-func (c *Client) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (version int, state []byte, found bool, err error) {
+func (c *Client) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (cp Checkpoint, found bool, err error) {
 	path := "/api/v1/threads/" + threadID.String() + "/checkpoints/latest?run_id=" + runID.String()
 	var resp checkpointResponse
 	status, err := c.doJSON(ctx, http.MethodGet, path, nil, &resp)
 	if err != nil {
 		if status == http.StatusNotFound {
-			return 0, nil, false, nil
+			return Checkpoint{}, false, nil
 		}
-		return 0, nil, false, err
+		return Checkpoint{}, false, err
 	}
-	return resp.Version, []byte(resp.State), true, nil
+	return Checkpoint{ID: resp.CheckpointID, Version: resp.Version, State: []byte(resp.State)}, true, nil
 }
 
 // LoadGraph fetches the GraphDefinition the worker must execute for runID: the

--- a/controlplane/worker/client_test.go
+++ b/controlplane/worker/client_test.go
@@ -31,12 +31,19 @@ func TestClientLifecycleAndCheckpoints(t *testing.T) {
 	if err != nil || epoch != 1 {
 		t.Fatalf("run started: epoch=%d err=%v", epoch, err)
 	}
-	if err := cl.WriteCheckpoint(ctx, tid, rid, epoch, 1, []byte(`{"count":1}`)); err != nil {
+	ckptID, err := cl.WriteCheckpoint(ctx, tid, rid, epoch, 1, []byte(`{"count":1}`))
+	if err != nil {
 		t.Fatal(err)
 	}
-	v, state, found, err := cl.LatestCheckpoint(ctx, tid, rid)
-	if err != nil || !found || v != 1 || string(state) != `{"count":1}` {
-		t.Fatalf("latest: v=%d found=%v state=%s err=%v", v, found, state, err)
+	if ckptID == 0 {
+		t.Error("WriteCheckpoint: want a non-zero snapshots.id (it becomes the next checkpoint's parent), got 0")
+	}
+	cp, found, err := cl.LatestCheckpoint(ctx, tid, rid)
+	if err != nil || !found || cp.Version != 1 || string(cp.State) != `{"count":1}` {
+		t.Fatalf("latest: v=%d found=%v state=%s err=%v", cp.Version, found, cp.State, err)
+	}
+	if cp.ID != ckptID {
+		t.Errorf("LatestCheckpoint id: want %d (the row WriteCheckpoint created), got %d", ckptID, cp.ID)
 	}
 	if err := cl.NodeCompleted(ctx, rid, epoch, "A", "tool"); err != nil {
 		t.Fatal(err)

--- a/controlplane/worker/graph.go
+++ b/controlplane/worker/graph.go
@@ -9,8 +9,11 @@
 // Slice scope (see the d2 legend): node typing + edge routing + input seeding
 // are IMPLEMENTED here; the executors are deterministic and self-contained (no
 // LLM keys, no sub-worker delegation) so the whole engine is testcontainers-
-// testable offline. HITL interrupts and real llm/tool delegation to
-// worker.llm.invoke / worker.tool.execute are TARGET — later slices.
+// testable offline. All three of hitl.d2's interrupt triggers are implemented
+// (interrupt_before, interrupt_after, requires_human — see pausesAfter), as is
+// the tool_calls→approval trigger from graph-engine.d2 §3. Real llm/tool
+// delegation to worker.llm.invoke / worker.tool.execute remains TARGET, as does
+// the end node's output-freeze to runs.output.
 package worker
 
 import (
@@ -33,24 +36,106 @@ type Node struct {
 	Config map[string]any `json:"config,omitempty"`
 }
 
+// Node types that carry engine meaning. nodeTypeHuman exists purely to collect
+// human input: graph-engine.d2 §3 human_ex specifies it as "always interrupt —
+// requires_human", so it suspends unconditionally regardless of config.
+const nodeTypeHuman = "human"
+
+// The interrupts.reason CHECK constants (003_run.up.sql:43) —
+// tool_call | approval_required | input_needed. reasonToolCall is recorded when
+// a tool node emits pending tool_calls for human approval (graph-engine.d2 §3
+// tool_ex "may: emit tool_calls → interrupt (approval)").
+const (
+	reasonToolCall         = "tool_call"
+	reasonApprovalRequired = "approval_required"
+	reasonInputNeeded      = "input_needed"
+)
+
+// toolCallsKey is the channel-write key a tool node uses to surface pending
+// tool calls that need a human decision. Its presence is itself an interrupt
+// trigger (graph-engine.d2 §3 tool_ex), and the value is persisted to
+// interrupts.tool_calls (hitl.d2 on_interrupt step 2).
+const toolCallsKey = "tool_calls"
+
+// requiresHumanKey is the channel-write key a node uses to signal, from its own
+// output, that it needs human input — graph-engine.d2 §5 triggers
+// "requires_human: node output signals need for input".
+const requiresHumanKey = "requires_human"
+
 // interruptsBefore reports whether this node suspends the run for
-// human-in-the-loop BEFORE it executes (config.interrupt_before: true). Mirrors
-// the hitl.d2 interrupt_before trigger. interrupt_after / requires_human are
-// later slices.
+// human-in-the-loop BEFORE it executes: either config.interrupt_before is set,
+// or the node is a "human" node, which graph-engine.d2 §3 defines as always
+// interrupting. Pausing BEFORE (rather than after) is what makes a human node
+// meaningful — the walk parks, the client supplies the human's contribution via
+// the resume Command, and the node then executes with that state in channels.
+// The first of hitl.d2's three triggers.
 func (n Node) interruptsBefore() bool {
+	if n.Type == nodeTypeHuman {
+		return true
+	}
 	v, _ := n.Config["interrupt_before"].(bool)
 	return v
 }
 
+// interruptsAfter reports whether this node suspends the run AFTER it executes
+// and its writes are merged (config.interrupt_after: true). The second of
+// hitl.d2's three triggers.
+func (n Node) interruptsAfter() bool {
+	v, _ := n.Config["interrupt_after"].(bool)
+	return v
+}
+
+// pausesAfter reports whether the walk must suspend AFTER this node has run,
+// and with which interrupts.reason. It folds the two post-execution triggers
+// the spec names, in precedence order:
+//
+//   - pending tool_calls in the node's writes (graph-engine.d2 §3 tool_ex) →
+//     reason tool_call. Most specific: there is a concrete decision to approve.
+//   - requires_human, either statically via config.requires_human (hitl.d2
+//     graph_node.definition) or dynamically when the node's own output carries
+//     it (graph-engine.d2 §5 triggers) → reason input_needed.
+//   - config.interrupt_after → the node's configured reason.
+//
+// writes (not the merged channel state) is the input on purpose: a
+// requires_human or tool_calls value that arrived in the RUN'S INPUT would
+// otherwise pause the walk at every single node.
+func (n Node) pausesAfter(writes map[string]any) (bool, string) {
+	if len(n.toolCalls(writes)) > 0 {
+		return true, reasonToolCall
+	}
+	if v, _ := n.Config[requiresHumanKey].(bool); v {
+		return true, reasonInputNeeded
+	}
+	if v, _ := writes[requiresHumanKey].(bool); v {
+		return true, reasonInputNeeded
+	}
+	if n.interruptsAfter() {
+		return true, n.interruptReason()
+	}
+	return false, ""
+}
+
+// toolCalls returns the pending tool calls this node emitted, if any. Only a
+// non-empty list counts: an empty array is a tool node reporting it needs no
+// approval, not an interrupt trigger.
+func (n Node) toolCalls(writes map[string]any) []any {
+	calls, _ := writes[toolCallsKey].([]any)
+	return calls
+}
+
 // interruptReason returns the HITL interrupt reason recorded when this node
-// suspends the run (config.interrupt_reason), defaulting to "approval_required".
-// The value must be one of the interrupts.reason CHECK constants
+// suspends the run (config.interrupt_reason). Defaults to input_needed for a
+// human node (it exists to ask a human for input) and approval_required
+// otherwise. The value must be one of the interrupts.reason CHECK constants
 // (tool_call | approval_required | input_needed).
 func (n Node) interruptReason() string {
 	if s, ok := n.Config["interrupt_reason"].(string); ok && s != "" {
 		return s
 	}
-	return "approval_required"
+	if n.Type == nodeTypeHuman {
+		return reasonInputNeeded
+	}
+	return reasonApprovalRequired
 }
 
 // Edge connects Source→Target, optionally guarded by Condition (an expression
@@ -191,16 +276,24 @@ type NodeExecutor interface {
 	Execute(ctx context.Context, node Node, channels map[string]any) (writes map[string]any, err error)
 }
 
-// defaultExecutors maps Node.type → its executor for this slice. start/end/
-// conditional pass through (start's seeding happens before the loop; end's
-// output-freeze is a server-side TARGET; conditional's routing lives in the
-// edge evaluator). llm/tool are stood in by configExecutor — declarative,
-// deterministic, dependency-free — until real sub-worker delegation lands.
+// defaultExecutors maps Node.type → its executor for this slice, covering every
+// type graph-engine.d2 §3 names. start/end/conditional/human pass through
+// (start's seeding happens before the loop; end's output-freeze to runs.output
+// is a server-side TARGET; conditional's routing lives in the edge evaluator;
+// human contributes no writes of its own — it exists to suspend, and the state
+// it "produces" arrives via the resume Command). llm/tool are stood in by
+// configExecutor — declarative, deterministic, dependency-free — until real
+// sub-worker delegation lands.
+//
+// human MUST have an entry even though it does nothing: without one, the walk
+// hits the "no executor for node type" guard and fails the run outright on the
+// delivery that resumes past the interrupt.
 func defaultExecutors() map[string]NodeExecutor {
 	return map[string]NodeExecutor{
 		"start":       passthroughExecutor{},
 		"end":         passthroughExecutor{},
 		"conditional": passthroughExecutor{},
+		nodeTypeHuman: passthroughExecutor{},
 		"llm":         configExecutor{},
 		"tool":        configExecutor{},
 	}

--- a/controlplane/worker/interrupt_triggers_integration_test.go
+++ b/controlplane/worker/interrupt_triggers_integration_test.go
@@ -1,0 +1,654 @@
+// Integration coverage for the interrupt triggers hitl.d2 §triggers and
+// graph-engine.d2 §5 specify beyond interrupt_before (which #230 covered):
+// interrupt_after, requires_human (static config + dynamic node output),
+// pending tool_calls, and the always-interrupting "human" node type. Also
+// covers the checkpoint metadata graph-engine.d2 §4 names (node,
+// parent_checkpoint_id) and the re-announce path that closes the window
+// between checkpointing a pause and announcing it.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// seedGraph inserts an arbitrary graph for assistantID under the given name.
+func seedGraph(t *testing.T, ctx context.Context, pool *pgxpool.Pool, assistantID uuid.UUID, name, nodes, edges string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO graphs (assistant_id, name, version, nodes, edges, config)
+		VALUES ($1, $2, '1', $3::jsonb, $4::jsonb, '{}'::jsonb)`,
+		assistantID, name, nodes, edges); err != nil {
+		t.Fatalf("seed graph %s: %v", name, err)
+	}
+}
+
+// newLiveRunner builds a Runner backed by a real registered worker Client.
+func newLiveRunner(t *testing.T, ctx context.Context, graphName string) (*worker.Runner, *worker.Client) {
+	t.Helper()
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{graphName}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return worker.NewRunner(nil, cl, dnats.GraphExecutorMaxDeliver), cl
+}
+
+// interruptRow is the interrupts row recorded for a parked run.
+type interruptRow struct {
+	ID        uuid.UUID
+	NodeID    string
+	Reason    string
+	Resolved  bool
+	ToolCalls []byte
+}
+
+// soleInterrupt reads the one interrupts row for rid, failing if there is not
+// exactly one.
+func soleInterrupt(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID) interruptRow {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM interrupts WHERE run_id=$1`, rid).Scan(&n); err != nil {
+		t.Fatalf("count interrupts: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("interrupts for run: want exactly 1, got %d", n)
+	}
+	var got interruptRow
+	if err := pool.QueryRow(ctx,
+		`SELECT id, node_id, reason, resolved, tool_calls FROM interrupts WHERE run_id=$1`, rid,
+	).Scan(&got.ID, &got.NodeID, &got.Reason, &got.Resolved, &got.ToolCalls); err != nil {
+		t.Fatalf("select interrupt: %v", err)
+	}
+	return got
+}
+
+// TestInterruptAfterPausesPastNode proves the interrupt_after trigger: node A
+// carries config.interrupt_after, so the walk executes A, merges its writes,
+// records it completed — and only THEN parks, before its successor B.
+//
+// The distinction from interrupt_before is the whole point: A must show up in
+// execution_history (it genuinely ran) while B must not (the pause sits between
+// them), and the checkpoint must mark the pause as a pause-AFTER by setting
+// interrupted == node.
+func TestInterruptAfterPausesPastNode(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "after",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"},"interrupt_after":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "after")
+
+	acked, epoch, err := runner.ProcessOne(ctx, worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "after"})
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (parked for human input), got false")
+	}
+	if epoch != 1 {
+		t.Errorf("epoch: want 1, got %d", epoch)
+	}
+
+	// A ran; B did not; the run is parked.
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	in := soleInterrupt(t, ctx, pool, rid)
+	if in.NodeID != "A" {
+		t.Errorf("interrupt node_id: want A, got %q", in.NodeID)
+	}
+	if in.Reason != "approval_required" {
+		t.Errorf("interrupt reason: want approval_required (interrupt_after default), got %q", in.Reason)
+	}
+	if in.Resolved {
+		t.Error("interrupt: want unresolved at pause")
+	}
+
+	// The checkpoint marks a pause-AFTER: interrupted == node == A, A is in
+	// completed_nodes, and the frontier already holds its successor.
+	cp := latestCheckpointState(t, ctx, pool, rid)
+	if cp["interrupted"] != "A" || cp["node"] != "A" {
+		t.Errorf("checkpoint: want interrupted==node==A (pause-after), got interrupted=%v node=%v", cp["interrupted"], cp["node"])
+	}
+	if completed, _ := cp["completed_nodes"].([]any); len(completed) != 1 || completed[0] != "A" {
+		t.Errorf("checkpoint completed_nodes: want [A], got %v", cp["completed_nodes"])
+	}
+	// Routing is deferred across a pause-after: B is deliberately NOT queued
+	// yet, because the human's patch may decide whether the A→B edge holds.
+	if frontier, _ := cp["frontier"].([]any); len(frontier) != 0 {
+		t.Errorf("checkpoint frontier: want empty (routing deferred to resume), got %v", cp["frontier"])
+	}
+}
+
+// TestRequiresHumanTriggers covers hitl.d2's third trigger in both forms the
+// spec names it: statically via config.requires_human (hitl.d2
+// graph_node.definition) and dynamically when the node's OWN OUTPUT carries
+// requires_human (graph-engine.d2 §5 "node output signals need for input").
+// Both park the run AFTER the node with reason input_needed.
+func TestRequiresHumanTriggers(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		aNode string
+	}{
+		{
+			name:  "static config",
+			aNode: `{"id":"A","type":"tool","config":{"set":{"stage":"a"},"requires_human":true}}`,
+		},
+		{
+			name:  "dynamic node output",
+			aNode: `{"id":"A","type":"tool","config":{"set":{"requires_human":true}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			pool := newPool(t)
+
+			tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+			seedGraph(t, ctx, pool, aid, "rh",
+				`[`+tc.aNode+`,{"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+				`[{"source":"A","target":"B"}]`)
+			runner, _ := newLiveRunner(t, ctx, "rh")
+
+			acked, _, err := runner.ProcessOne(ctx, worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "rh"})
+			if err != nil {
+				t.Fatalf("ProcessOne: %v", err)
+			}
+			if !acked {
+				t.Fatal("ProcessOne: want acked=true (parked), got false")
+			}
+
+			assertRunStatus(t, ctx, pool, rid, "requires_action")
+			assertNodeCount(t, ctx, pool, rid, "A", 1)
+			assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+			in := soleInterrupt(t, ctx, pool, rid)
+			if in.NodeID != "A" {
+				t.Errorf("interrupt node_id: want A, got %q", in.NodeID)
+			}
+			if in.Reason != "input_needed" {
+				t.Errorf("interrupt reason: want input_needed, got %q", in.Reason)
+			}
+		})
+	}
+}
+
+// TestRequiresHumanFromInputDoesNotPause is the negative control for the
+// dynamic trigger: requires_human is read from the node's WRITES, never from
+// the merged channel state. A requires_human that arrived in the run's INPUT
+// must not park the walk — otherwise a single input key would interrupt at
+// every node in the graph.
+func TestRequiresHumanFromInputDoesNotPause(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "rh-input",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"}}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "rh-input")
+
+	acked, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "rh-input",
+		Input: json.RawMessage(`{"requires_human":true}`),
+	})
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (ran to completion), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+	var nInterrupts int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM interrupts WHERE run_id=$1`, rid).Scan(&nInterrupts); err != nil {
+		t.Fatalf("count interrupts: %v", err)
+	}
+	if nInterrupts != 0 {
+		t.Errorf("requires_human in run input must not trigger an interrupt: got %d interrupts", nInterrupts)
+	}
+}
+
+// TestHumanNodeAlwaysInterrupts covers graph-engine.d2 §3 human_ex ("always
+// interrupt — requires_human"): a bare `human` node with NO interrupt config
+// still parks the run, BEFORE it runs, with reason input_needed.
+//
+// It also pins the regression that made a human node unusable: before this
+// slice `human` had no entry in defaultExecutors, so the walk hit the "no
+// executor for node type" guard and failed the run outright.
+func TestHumanNodeAlwaysInterrupts(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "human",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"}}},
+		  {"id":"H","type":"human"},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"H"},{"source":"H","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "human")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "human"}
+
+	acked, _, err := runner.ProcessOne(ctx, cmd)
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (parked at the human node), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "H", 0) // paused BEFORE it ran
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	in := soleInterrupt(t, ctx, pool, rid)
+	if in.NodeID != "H" {
+		t.Errorf("interrupt node_id: want H, got %q", in.NodeID)
+	}
+	if in.Reason != "input_needed" {
+		t.Errorf("interrupt reason: want input_needed (a human node asks for input), got %q", in.Reason)
+	}
+
+	// It is a pause-BEFORE: interrupted != node (the boundary node is A, the
+	// last one that actually completed).
+	cp := latestCheckpointState(t, ctx, pool, rid)
+	if cp["interrupted"] != "H" || cp["node"] != "A" {
+		t.Errorf("checkpoint: want interrupted=H node=A (pause-before), got interrupted=%v node=%v", cp["interrupted"], cp["node"])
+	}
+}
+
+// TestToolCallsTriggerApprovalInterrupt covers graph-engine.d2 §3 tool_ex
+// ("may: emit tool_calls → interrupt (approval)"): a tool node whose writes
+// carry a non-empty tool_calls list parks the run with reason tool_call, and
+// the payload is persisted to interrupts.tool_calls — the column hitl.d2
+// on_interrupt step 2 names and which nothing populated before this slice.
+func TestToolCallsTriggerApprovalInterrupt(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "tc",
+		`[{"id":"A","type":"tool","config":{"set":{"tool_calls":[{"id":"tc1","name":"search"}]}}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "tc")
+
+	acked, _, err := runner.ProcessOne(ctx, worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "tc"})
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (parked for approval), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	in := soleInterrupt(t, ctx, pool, rid)
+	if in.Reason != "tool_call" {
+		t.Errorf("interrupt reason: want tool_call, got %q", in.Reason)
+	}
+	if len(in.ToolCalls) == 0 {
+		t.Fatal("interrupts.tool_calls: want the pending calls persisted, got NULL")
+	}
+	var calls []map[string]any
+	if err := json.Unmarshal(in.ToolCalls, &calls); err != nil {
+		t.Fatalf("decode tool_calls: %v", err)
+	}
+	if len(calls) != 1 || calls[0]["name"] != "search" {
+		t.Errorf("interrupts.tool_calls: want the emitted call round-tripped, got %v", calls)
+	}
+}
+
+// TestEmptyToolCallsDoNotPause is the negative control for the tool_calls
+// trigger: an EMPTY list is a tool node reporting it needs no approval, not an
+// interrupt.
+func TestEmptyToolCallsDoNotPause(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "tc-empty",
+		`[{"id":"A","type":"tool","config":{"set":{"tool_calls":[]}}}]`, `[]`)
+	runner, _ := newLiveRunner(t, ctx, "tc-empty")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "tc-empty"}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	var nInterrupts int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM interrupts WHERE run_id=$1`, rid).Scan(&nInterrupts); err != nil {
+		t.Fatalf("count interrupts: %v", err)
+	}
+	if nInterrupts != 0 {
+		t.Errorf("empty tool_calls must not interrupt: got %d interrupts", nInterrupts)
+	}
+}
+
+// TestInterruptBeforeAndAfterOnSameNode is the interaction case: one node
+// carrying BOTH triggers must pause twice — once before it runs and once after
+// — producing two distinct interrupts, not one.
+//
+// It is the case most likely to collapse, because the second pause has to mint
+// a new interrupts row at the SAME node_id the first one used. That only works
+// because the server's INSERT guard is on an UNRESOLVED (run_id, node_id): the
+// first interrupt is resolved by the first resume, so the second pause is not
+// mistaken for a redelivery of it.
+func TestInterruptBeforeAndAfterOnSameNode(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "both",
+		`[{"id":"G","type":"tool","config":{"interrupt_before":true,"interrupt_after":true,"set":{"ran":true}}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"G","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "both")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "both"}
+
+	// Pause 1: BEFORE G runs.
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("ProcessOne 1: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "G", 0)
+	first := soleInterrupt(t, ctx, pool, rid)
+
+	// Resume 1 → G runs → pause 2: AFTER G.
+	postResume(t, tid, rid, `{"command":{"update":{"approved":true}}}`)
+	cmd.Resume = json.RawMessage(`{"update":{"approved":true}}`)
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("ProcessOne 2: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "G", 1) // it ran between the two pauses
+	assertNodeCount(t, ctx, pool, rid, "B", 0) // but the walk stopped again
+
+	var nInterrupts int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM interrupts WHERE run_id=$1`, rid).Scan(&nInterrupts); err != nil {
+		t.Fatalf("count interrupts: %v", err)
+	}
+	if nInterrupts != 2 {
+		t.Fatalf("interrupts: want 2 (one per trigger), got %d", nInterrupts)
+	}
+	var unresolvedID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM interrupts WHERE run_id=$1 AND NOT resolved`, rid).Scan(&unresolvedID); err != nil {
+		t.Fatalf("select unresolved interrupt: %v", err)
+	}
+	if unresolvedID == first.ID {
+		t.Error("second pause reused the first interrupt row instead of minting a new one")
+	}
+
+	// Resume 2 → the walk finally reaches B.
+	postResume(t, tid, rid, `{"command":{}}`)
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("ProcessOne 3: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "G", 1) // still exactly once across both resumes
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+}
+
+// postResume drives the real HITL resume endpoint.
+func postResume(t *testing.T, tid, rid uuid.UUID, body string) {
+	t.Helper()
+	resp, err := http.Post(fmt.Sprintf("%s/api/v1/threads/%s/runs/%s/resume", serverURL, tid, rid),
+		"application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST resume: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		out, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST resume: want 200, got %d (%s)", resp.StatusCode, out)
+	}
+}
+
+// TestResumePastInterruptAfter proves the resume half of the pause-AFTER phase.
+// #230 only ever resumed a pause-BEFORE, where the parked node still has to
+// run. Here the parked node has ALREADY run, so resuming must continue with its
+// successors and must NOT re-execute it — A staying at exactly one execution is
+// the assertion that separates the two phases.
+//
+// The B edge is conditional on approved == true so that B running also proves
+// the resume's command.update actually merged into channels.
+func TestResumePastInterruptAfter(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "after-resume",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"},"interrupt_after":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B","condition":"approved == true"}]`)
+	runner, _ := newLiveRunner(t, ctx, "after-resume")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "after-resume"}
+
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("first ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	before := soleInterrupt(t, ctx, pool, rid)
+
+	// Resume through the real endpoint, then redeliver the command the way
+	// run-processor would — carrying the Command as `resume`.
+	postResume(t, tid, rid, `{"command":{"update":{"approved":true}}}`)
+	assertRunStatus(t, ctx, pool, rid, "in_progress")
+
+	cmd.Resume = json.RawMessage(`{"update":{"approved":true}}`)
+	acked, _, err := runner.ProcessOne(ctx, cmd)
+	if err != nil {
+		t.Fatalf("resume ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("resume ProcessOne: want acked=true (run finished), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1) // THE PROOF: the parked node did not re-run
+	assertNodeCount(t, ctx, pool, rid, "B", 1) // and the state patch merged, so the edge held
+
+	// The interrupt the resume resolved is the one the pause created, and no
+	// second interrupt was minted on the way past.
+	after := soleInterrupt(t, ctx, pool, rid)
+	if after.ID != before.ID {
+		t.Errorf("interrupt id: want the original %s resolved, got a new row %s", before.ID, after.ID)
+	}
+	if !after.Resolved {
+		t.Error("interrupt: want resolved after resume")
+	}
+}
+
+// TestCheckpointLineage covers the two checkpoint-metadata fields
+// graph-engine.d2 §4 names but nothing implemented: `node` (the boundary node
+// that created the checkpoint) and `parent_checkpoint_id` (the id of the
+// checkpoint it supersedes), which together chain the snapshots into a walk
+// history.
+func TestCheckpointLineage(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false) // A → B, both plain tool nodes
+	runner, _ := newLiveRunner(t, ctx, "counter")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter"}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+
+	type snap struct {
+		id    int64
+		state map[string]any
+	}
+	rows, err := pool.Query(ctx,
+		`SELECT id, state FROM snapshots WHERE aggregate_id=$1 ORDER BY version ASC`, rid)
+	if err != nil {
+		t.Fatalf("select snapshots: %v", err)
+	}
+	defer rows.Close()
+	var snaps []snap
+	for rows.Next() {
+		var s snap
+		var raw []byte
+		if err := rows.Scan(&s.id, &raw); err != nil {
+			t.Fatalf("scan snapshot: %v", err)
+		}
+		if err := json.Unmarshal(raw, &s.state); err != nil {
+			t.Fatalf("decode snapshot state: %v", err)
+		}
+		snaps = append(snaps, s)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("snapshots: want 2 (one per node boundary), got %d", len(snaps))
+	}
+
+	// Each checkpoint names the node whose boundary created it.
+	if snaps[0].state["node"] != "A" {
+		t.Errorf("checkpoint 1 node: want A, got %v", snaps[0].state["node"])
+	}
+	if snaps[1].state["node"] != "B" {
+		t.Errorf("checkpoint 2 node: want B, got %v", snaps[1].state["node"])
+	}
+
+	// The first has no parent; the second points back at the first.
+	if _, ok := snaps[0].state["parent_checkpoint_id"]; ok {
+		t.Errorf("checkpoint 1 parent_checkpoint_id: want absent (first in the chain), got %v", snaps[0].state["parent_checkpoint_id"])
+	}
+	parent, ok := snaps[1].state["parent_checkpoint_id"].(float64)
+	if !ok {
+		t.Fatalf("checkpoint 2 parent_checkpoint_id: want the previous snapshot id, got %v", snaps[1].state["parent_checkpoint_id"])
+	}
+	if int64(parent) != snaps[0].id {
+		t.Errorf("checkpoint 2 parent_checkpoint_id: want %d (checkpoint 1), got %d", snaps[0].id, int64(parent))
+	}
+}
+
+// flakyAnnounceClient wraps a real worker.Client and fails the first `failures`
+// RequiresAction calls transiently — reproducing the window where a pause has
+// been checkpointed but its announcement has not landed.
+type flakyAnnounceClient struct {
+	*worker.Client
+	failures int
+}
+
+func (c *flakyAnnounceClient) RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error {
+	if c.failures > 0 {
+		c.failures--
+		return errors.New("transient: announce boom")
+	}
+	return c.Client.RequiresAction(ctx, runID, epoch, nodeID, reason, state, toolCalls)
+}
+
+// TestInterruptAfterSurvivesFailedAnnounce is the regression proof for the
+// window this slice closes.
+//
+// A pause is two writes: checkpoint the state, then announce it (flip the run
+// to requires_action + insert the interrupt). If the announce fails
+// transiently, the runner Naks and JetStream redelivers — but the status flip
+// never happened, so the run is still 'in_progress' and RunStarted succeeds on
+// the redelivery instead of being fenced off as it would be for an
+// already-parked run.
+//
+// For a pause-BEFORE that is harmless: the paused node is not in
+// completed_nodes, so it sits at the frontier head and re-triggers. For a
+// pause-AFTER it is NOT harmless: the node IS completed, so a runner that
+// simply resumed the walk would skip straight past its own interrupt and run
+// the successor. B never running is the proof that does not happen.
+func TestInterruptAfterSurvivesFailedAnnounce(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "after",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"},"interrupt_after":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B"}]`)
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"after"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	flaky := &flakyAnnounceClient{Client: cl, failures: 1}
+	runner := worker.NewRunner(nil, flaky, dnats.GraphExecutorMaxDeliver)
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "after"}
+
+	// Delivery 1: A runs and the pause is checkpointed, but the announce fails.
+	acked, _, err := runner.ProcessOne(ctx, cmd)
+	if err == nil {
+		t.Fatal("first ProcessOne: want the transient announce error surfaced, got nil")
+	}
+	if acked {
+		t.Fatal("first ProcessOne: want acked=false (Nak so the pause is retried), got true")
+	}
+
+	// The run is mid-window: A ran and the pause is durable in the checkpoint,
+	// but nothing marked the run parked.
+	assertRunStatus(t, ctx, pool, rid, "in_progress")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+	var nInterrupts int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM interrupts WHERE run_id=$1`, rid).Scan(&nInterrupts); err != nil {
+		t.Fatalf("count interrupts: %v", err)
+	}
+	if nInterrupts != 0 {
+		t.Fatalf("interrupts after failed announce: want 0, got %d", nInterrupts)
+	}
+	if cp := latestCheckpointState(t, ctx, pool, rid); cp["interrupted"] != "A" {
+		t.Fatalf("checkpoint must carry the pause even though the announce failed: got interrupted=%v", cp["interrupted"])
+	}
+
+	// Delivery 2 (the redelivery): must re-announce, NOT walk on to B.
+	acked, _, err = runner.ProcessOne(ctx, cmd)
+	if err != nil {
+		t.Fatalf("second ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("second ProcessOne: want acked=true (re-announced, parked), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "A", 1) // not re-executed
+	assertNodeCount(t, ctx, pool, rid, "B", 0) // THE PROOF: never walked past the interrupt
+
+	in := soleInterrupt(t, ctx, pool, rid)
+	if in.NodeID != "A" || in.Resolved {
+		t.Errorf("re-announced interrupt: want unresolved at A, got node=%q resolved=%v", in.NodeID, in.Resolved)
+	}
+}
+
+// latestCheckpointState decodes the highest-version snapshot's state jsonb.
+func latestCheckpointState(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID) map[string]any {
+	t.Helper()
+	var raw []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT state FROM snapshots WHERE aggregate_id=$1 ORDER BY version DESC, id DESC LIMIT 1`, rid,
+	).Scan(&raw); err != nil {
+		t.Fatalf("select latest snapshot: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode checkpoint state: %v", err)
+	}
+	return out
+}

--- a/controlplane/worker/protocol.go
+++ b/controlplane/worker/protocol.go
@@ -46,6 +46,13 @@ type checkpointWriteRequest struct {
 	State      json.RawMessage `json:"state"`
 }
 
+// checkpointWriteResponse mirrors endpoints.CheckpointWriteResponse (used to
+// decode the POST .../checkpoints response, whose id becomes the next
+// checkpoint's parent_checkpoint_id).
+type checkpointWriteResponse struct {
+	CheckpointID int64 `json:"checkpoint_id"`
+}
+
 // checkpointResponse mirrors endpoints.CheckpointResponse (used to decode the
 // GET .../checkpoints/latest response).
 type checkpointResponse struct {

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -81,12 +81,12 @@ func ackDecision(acked bool, epoch, numDelivered, maxDeliver int) decision {
 type runClient interface {
 	RunStarted(ctx context.Context, runID uuid.UUID) (int, error)
 	LoadGraph(ctx context.Context, runID uuid.UUID) (GraphDefinition, error)
-	LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (int, []byte, bool, error)
-	WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error
+	LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (Checkpoint, bool, error)
+	WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) (int64, error)
 	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
 	RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error
 	RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error
-	RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state []byte) error
+	RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error
 }
 
 // Runner consumes worker.graph.execute commands and walks each run's graph
@@ -208,26 +208,64 @@ func (r *Runner) escalate(ctx context.Context, runID uuid.UUID, epoch int, perr 
 }
 
 // checkpointState is the JSON envelope persisted by WriteCheckpoint and
-// restored by LatestCheckpoint. It captures the full graph-walk state so a
-// redelivery after a crash resumes exactly where it stopped:
+// restored by LatestCheckpoint. The snapshots table stores only (version,
+// state), so every field the spec calls "checkpoint metadata" rides inside this
+// state jsonb — see gen/endpoints.yaml:18 and its write_checkpoint step
+// "Metadata: parent_checkpoint_id, node, channel_versions, pending_sends".
 //
-//   - Channels: the run's channel values (accumulated node writes).
+// Spec-named metadata (graph-engine.d2 §4 checkpoint_mgr.metadata, hitl.d2
+// checkpoint.metadata):
+//
+//   - Node: the boundary node that created this checkpoint — the node that had
+//     just finished when it was written, or "" for a pause taken before any
+//     node ran.
+//   - ParentCheckpointID: the snapshots.id of the checkpoint this one
+//     supersedes (0 for the first), giving the chain its lineage.
 //   - CompletedNodes: node IDs already executed, in completion order. Its
 //     length is the checkpoint version, and it seeds the "already done" set so
-//     completed nodes are never re-run.
-//   - Frontier: node IDs pending execution (FIFO), i.e. the successors
-//     discovered but not yet run.
-//   - Interrupted: the node id the walk is paused at for HITL (interrupt_before),
-//     "" when the run is not paused. When set, that node sits at the head of
-//     Frontier; on resume the runner clears it and executes that node. It is the
-//     redelivery guard: a redelivered run.created finds Interrupted=node and
-//     re-pauses (server-idempotent), while a redelivered run.resumed finds
-//     Interrupted="" (already cleared) and does not re-merge the resume payload.
+//     completed nodes are never re-run ("skipped verbatim on resume").
+//
+// Engine working state (not spec-named, required to make the walk resumable):
+//
+//   - Channels: the run's channel values (accumulated node writes).
+//   - Frontier: node IDs pending execution (FIFO) — the successors discovered
+//     but not yet run.
+//   - Interrupted: the node the walk is parked at for HITL, "" when running.
+//
+// PHASE IS DERIVED, NOT STORED. hitl.d2 resume_behavior step 4 calls
+// checkpoint.node "the interrupted one", which only coincides with the boundary
+// node for a pause taken AFTER a node completes. So:
+//
+//	Interrupted == Node  → parked AFTER Node ran (interrupt_after /
+//	                       requires_human / tool_calls); it is in CompletedNodes
+//	                       and its successors are deliberately NOT yet on
+//	                       Frontier — routing is deferred until the resume
+//	                       patches channels (see ProcessOne).
+//	Interrupted != Node  → parked BEFORE Interrupted runs (interrupt_before /
+//	                       a human node); it is NOT in CompletedNodes and sits at
+//	                       the head of Frontier.
+//
+// Interrupted is also the redelivery guard, and it must live HERE rather than
+// be re-derived from the interrupts table: the checkpoint is written BEFORE
+// RequiresAction announces the pause, so in the window where the checkpoint
+// committed but the announce failed there is no interrupts row to find — yet
+// the run is genuinely parked and must not walk on.
 type checkpointState struct {
-	Channels       map[string]any `json:"channels"`
-	CompletedNodes []string       `json:"completed_nodes"`
-	Frontier       []string       `json:"frontier"`
-	Interrupted    string         `json:"interrupted,omitempty"`
+	Channels           map[string]any `json:"channels"`
+	CompletedNodes     []string       `json:"completed_nodes"`
+	Frontier           []string       `json:"frontier"`
+	Node               string         `json:"node,omitempty"`
+	ParentCheckpointID int64          `json:"parent_checkpoint_id,omitempty"`
+	Interrupted        string         `json:"interrupted,omitempty"`
+}
+
+// pausedAfter reports whether this checkpoint was taken AFTER its boundary node
+// completed, as opposed to before the interrupted node ran. A checkpoint that
+// is not a pause at all is never "after": without the Interrupted guard an
+// ordinary checkpoint taken before any node ran (Node == "") would compare
+// equal to an empty Interrupted and report a pause that does not exist.
+func (cp checkpointState) pausedAfter() bool {
+	return cp.Interrupted != "" && cp.Interrupted == cp.Node
 }
 
 // ProcessOne walks cmd's run graph with checkpoint resume, following the
@@ -268,20 +306,25 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 	var completed []string
 	completedSet := map[string]bool{}
 	var frontier []string
-	// interrupted is the node the walk is paused at for HITL (from the restored
-	// checkpoint); "" when not paused. resumedPast records nodes whose pause has
-	// already been satisfied by a resume this delivery, so the walk executes
-	// them instead of re-pausing.
+	// interrupted is the node the walk is parked at for HITL (from the restored
+	// checkpoint); "" when not parked. pausedAfter distinguishes a pause taken
+	// after that node completed from one taken before it ran (derived, see
+	// checkpointState). parentCheckpointID chains the next checkpoint to the one
+	// we restored. resumedPast records nodes whose pause has already been
+	// satisfied by a resume this delivery, so the walk executes them instead of
+	// re-pausing.
 	interrupted := ""
+	pausedAfter := false
+	var parentCheckpointID int64
 	resumedPast := map[string]bool{}
 
-	_, raw, found, lerr := r.cl.LatestCheckpoint(ctx, cmd.ThreadID, cmd.RunID)
+	restored, found, lerr := r.cl.LatestCheckpoint(ctx, cmd.ThreadID, cmd.RunID)
 	if lerr != nil {
 		return false, epoch, lerr // transient — Nak, redeliver
 	}
-	if found && len(raw) > 0 {
+	if found && len(restored.State) > 0 {
 		var cp checkpointState
-		if uerr := json.Unmarshal(raw, &cp); uerr != nil {
+		if uerr := json.Unmarshal(restored.State, &cp); uerr != nil {
 			return false, epoch, fmt.Errorf("runner: decode checkpoint state: %w", uerr)
 		}
 		if cp.Channels != nil {
@@ -293,6 +336,8 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		}
 		frontier = cp.Frontier
 		interrupted = cp.Interrupted
+		pausedAfter = cp.pausedAfter()
+		parentCheckpointID = restored.ID
 	} else {
 		// Fresh run: seed channels from the command input, frontier from the
 		// graph's entry nodes.
@@ -327,8 +372,55 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		for k, v := range command.Update {
 			channels[k] = v
 		}
+		// Expand the routing that was deferred at a pause-after, now that the
+		// human's patch is merged: the paused node's edges are evaluated
+		// against the UPDATED channels, which is what lets a conditional edge
+		// out of that node depend on the answer. Prepended so this branch
+		// continues ahead of anything queued from a parallel branch.
+		if pausedAfter {
+			succs, serr := graph.successors(interrupted, channels)
+			if serr != nil {
+				return r.failRun(ctx, cmd.RunID, epoch, serr.Error())
+			}
+			frontier = append(succs, frontier...)
+		}
+		// A pause taken AFTER the node ran needs no resumedPast entry (the node
+		// is already in completedSet), but recording it is harmless and keeps
+		// the two phases symmetric.
 		resumedPast[interrupted] = true
 		interrupted = ""
+		pausedAfter = false
+	}
+
+	// Still parked: the restored checkpoint carries a pause this delivery did
+	// not clear — no resume command arrived, or one arrived for a run that is
+	// not paused. Re-announce and ack rather than walking on.
+	//
+	// This is what closes the gap between WriteCheckpoint and RequiresAction. A
+	// transient RequiresAction failure Naks; on redelivery RunStarted still
+	// succeeds (the status flip never happened, so the run is
+	// in_progress, not requires_action) and the walk would otherwise resume —
+	// harmlessly for a pause-BEFORE, whose node is not in completedSet and so
+	// re-triggers in the loop below, but incorrectly for a pause-AFTER, whose
+	// node IS completed and would be skipped straight past its own interrupt.
+	//
+	// Re-announcing is safe under redelivery: the server's interrupt INSERT is
+	// guarded by NOT EXISTS on an unresolved (run_id, node_id) and its status
+	// UPDATE tolerates a run already in requires_action (workers.go
+	// requiresActionRun).
+	if interrupted != "" {
+		reason, toolCalls := r.pauseAnnouncement(graph, interrupted, pausedAfter, channels)
+		channelsJSON, merr := json.Marshal(channels)
+		if merr != nil {
+			return false, epoch, fmt.Errorf("runner: encode parked state: %w", merr)
+		}
+		if aerr := r.cl.RequiresAction(ctx, cmd.RunID, epoch, interrupted, reason, channelsJSON, toolCalls); aerr != nil {
+			if errors.Is(aerr, ErrStaleLease) {
+				return true, epoch, nil // superseded — stop, ack
+			}
+			return false, epoch, aerr // transient — Nak, redeliver
+		}
+		return true, epoch, nil // still parked — ack, await run.resumed
 	}
 
 	maxIter := graph.maxIterations()
@@ -368,26 +460,31 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		// cmd.Resume set (handled before the loop).
 		if node.interruptsBefore() && !resumedPast[nodeID] {
 			pauseFrontier := append([]string{nodeID}, frontier...)
-			channelsJSON, merr := json.Marshal(channels)
-			if merr != nil {
-				return false, epoch, fmt.Errorf("runner: encode interrupt state: %w", merr)
-			}
+			// Node is the boundary node — the one that last completed, NOT the
+			// node we are pausing before. Interrupted != Node is exactly what
+			// marks this as a pause-BEFORE on restore.
 			pauseJSON, merr := json.Marshal(checkpointState{
-				Channels:       channels,
-				CompletedNodes: completed,
-				Frontier:       pauseFrontier,
-				Interrupted:    nodeID,
+				Channels:           channels,
+				CompletedNodes:     completed,
+				Frontier:           pauseFrontier,
+				Node:               lastNode(completed),
+				ParentCheckpointID: parentCheckpointID,
+				Interrupted:        nodeID,
 			})
 			if merr != nil {
 				return false, epoch, fmt.Errorf("runner: encode pause checkpoint: %w", merr)
 			}
-			if werr := r.cl.WriteCheckpoint(ctx, cmd.ThreadID, cmd.RunID, epoch, len(completed), pauseJSON); werr != nil {
+			channelsJSON, merr := json.Marshal(channels)
+			if merr != nil {
+				return false, epoch, fmt.Errorf("runner: encode interrupt state: %w", merr)
+			}
+			if _, werr := r.cl.WriteCheckpoint(ctx, cmd.ThreadID, cmd.RunID, epoch, len(completed), pauseJSON); werr != nil {
 				if errors.Is(werr, ErrStaleLease) {
 					return true, epoch, nil // superseded — stop, ack
 				}
 				return false, epoch, werr // transient — Nak, redeliver
 			}
-			if aerr := r.cl.RequiresAction(ctx, cmd.RunID, epoch, nodeID, node.interruptReason(), channelsJSON); aerr != nil {
+			if aerr := r.cl.RequiresAction(ctx, cmd.RunID, epoch, nodeID, node.interruptReason(), channelsJSON, nil); aerr != nil {
 				if errors.Is(aerr, ErrStaleLease) {
 					return true, epoch, nil
 				}
@@ -413,32 +510,80 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		completed = append(completed, nodeID)
 		completedSet[nodeID] = true
 
-		succs, serr := graph.successors(nodeID, channels)
-		if serr != nil {
-			return r.failRun(ctx, cmd.RunID, epoch, serr.Error())
+		// HITL post-execution triggers (interrupt_after / requires_human /
+		// pending tool_calls). The node has run and its writes are merged, so it
+		// is already in completed — the pause boundary sits between it and its
+		// successors. Fold the marker into the checkpoint this node boundary
+		// writes anyway, so the pause is ONE atomic write rather than two.
+		// Interrupted == Node marks it a pause-AFTER on restore.
+		pauseAfter, pauseReason := node.pausesAfter(writes)
+		markInterrupted := ""
+
+		if pauseAfter {
+			// ROUTING IS DEFERRED across a pause-after. Evaluating this node's
+			// edges now would decide the route from PRE-approval state — but the
+			// entire point of pausing after a node is that a human then changes
+			// that state, and a conditional edge out of the paused node is
+			// exactly the state they are being asked about. Expanding here would
+			// silently drop such an edge (its condition is false until the
+			// human answers) and the run would resume with nothing to walk.
+			// Successors are expanded on resume instead, against patched
+			// channels. Any OTHER branch already on the frontier stays queued.
+			markInterrupted = nodeID
+		} else {
+			succs, serr := graph.successors(nodeID, channels)
+			if serr != nil {
+				return r.failRun(ctx, cmd.RunID, epoch, serr.Error())
+			}
+			frontier = append(frontier, succs...)
 		}
-		frontier = append(frontier, succs...)
 
 		stateJSON, merr := json.Marshal(checkpointState{
-			Channels:       channels,
-			CompletedNodes: completed,
-			Frontier:       frontier,
-			Interrupted:    interrupted, // "" here — executing past a resumed node clears the marker
+			Channels:           channels,
+			CompletedNodes:     completed,
+			Frontier:           frontier,
+			Node:               nodeID,
+			ParentCheckpointID: parentCheckpointID,
+			Interrupted:        markInterrupted,
 		})
 		if merr != nil {
 			return false, epoch, fmt.Errorf("runner: encode checkpoint state: %w", merr)
 		}
-		if werr := r.cl.WriteCheckpoint(ctx, cmd.ThreadID, cmd.RunID, epoch, len(completed), stateJSON); werr != nil {
+		ckptID, werr := r.cl.WriteCheckpoint(ctx, cmd.ThreadID, cmd.RunID, epoch, len(completed), stateJSON)
+		if werr != nil {
 			if errors.Is(werr, ErrStaleLease) {
 				return true, epoch, nil // superseded by a newer lease — stop, ack
 			}
 			return false, epoch, werr // transient — Nak, redeliver
 		}
+		parentCheckpointID = ckptID
 		if nerr := r.cl.NodeCompleted(ctx, cmd.RunID, epoch, node.ID, node.Type); nerr != nil {
 			if errors.Is(nerr, ErrStaleLease) {
 				return true, epoch, nil
 			}
 			return false, epoch, nerr
+		}
+
+		// Announce the pause only after NodeCompleted, so execution_history
+		// records that the node genuinely ran before the run parked.
+		if pauseAfter {
+			channelsJSON, merr := json.Marshal(channels)
+			if merr != nil {
+				return false, epoch, fmt.Errorf("runner: encode interrupt state: %w", merr)
+			}
+			var toolCalls []byte
+			if calls := node.toolCalls(writes); len(calls) > 0 {
+				if toolCalls, merr = json.Marshal(calls); merr != nil {
+					return false, epoch, fmt.Errorf("runner: encode tool_calls: %w", merr)
+				}
+			}
+			if aerr := r.cl.RequiresAction(ctx, cmd.RunID, epoch, nodeID, pauseReason, channelsJSON, toolCalls); aerr != nil {
+				if errors.Is(aerr, ErrStaleLease) {
+					return true, epoch, nil
+				}
+				return false, epoch, aerr // transient — Nak, redeliver
+			}
+			return true, epoch, nil // parked after this node — ack, await run.resumed
 		}
 	}
 
@@ -449,6 +594,54 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		return false, epoch, cerr
 	}
 	return true, epoch, nil
+}
+
+// lastNode returns the most recently completed node id, or "" when nothing has
+// completed yet. That is the "boundary node that created this checkpoint" of
+// graph-engine.d2 §4.
+func lastNode(completed []string) string {
+	if len(completed) == 0 {
+		return ""
+	}
+	return completed[len(completed)-1]
+}
+
+// pauseAnnouncement recovers the interrupts.reason and tool_calls payload for a
+// run that is being RE-announced from a restored checkpoint (the pause was
+// checkpointed but its announce did not land). The trigger inputs themselves
+// are not stored — they are recomputed from the parked node and the channel
+// state:
+//
+//   - pause-AFTER: the node's writes were merged into channels before the
+//     checkpoint, so re-running the pausesAfter precedence over channels yields
+//     the same reason and tool_calls it did originally. The one imprecision is
+//     that a tool_calls or requires_human value arriving in the RUN'S INPUT
+//     would be attributed to the node here; that only affects which reason
+//     label a re-announce writes, and only in the window where no interrupts
+//     row exists yet (once it does, the server's NOT EXISTS guard ignores what
+//     we send).
+//   - pause-BEFORE: nothing has been computed by the node yet, so the reason is
+//     its configured one.
+//
+// An unknown node (the graph changed under a parked run) degrades to
+// approval_required rather than failing the run — the run IS parked, and
+// re-announcing that fact is strictly better than dropping it.
+func (r *Runner) pauseAnnouncement(graph GraphDefinition, nodeID string, pausedAfter bool, channels map[string]any) (reason string, toolCalls []byte) {
+	node, ok := graph.node(nodeID)
+	if !ok {
+		return reasonApprovalRequired, nil
+	}
+	if !pausedAfter {
+		return node.interruptReason(), nil
+	}
+	_, reason = node.pausesAfter(channels)
+	if reason == "" {
+		reason = node.interruptReason()
+	}
+	if calls := node.toolCalls(channels); len(calls) > 0 {
+		toolCalls, _ = json.Marshal(calls)
+	}
+	return reason, toolCalls
 }
 
 // failRun records a deterministic (poison) failure as run.failed and returns

--- a/controlplane/worker/runner_escalation_test.go
+++ b/controlplane/worker/runner_escalation_test.go
@@ -30,12 +30,12 @@ func (c *stubEscalationClient) LoadGraph(ctx context.Context, runID uuid.UUID) (
 	return GraphDefinition{Nodes: []Node{{ID: "A", Type: "tool"}}}, nil
 }
 
-func (c *stubEscalationClient) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (int, []byte, bool, error) {
-	return 0, nil, false, nil
+func (c *stubEscalationClient) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (Checkpoint, bool, error) {
+	return Checkpoint{}, false, nil
 }
 
-func (c *stubEscalationClient) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) error {
-	return errors.New("transient: write checkpoint boom")
+func (c *stubEscalationClient) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) (int64, error) {
+	return 0, errors.New("transient: write checkpoint boom")
 }
 
 func (c *stubEscalationClient) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
@@ -52,7 +52,7 @@ func (c *stubEscalationClient) RunFailed(ctx context.Context, runID uuid.UUID, e
 	return nil
 }
 
-func (c *stubEscalationClient) RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state []byte) error {
+func (c *stubEscalationClient) RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error {
 	return nil
 }
 


### PR DESCRIPTION
Completes `graph-engine.d2` §5 `interrupt_ctl.triggers` / `hitl.d2`'s trigger set. #230 shipped `interrupt_before` only.

Built from the d2 diagrams as source of truth. `[spec-skip]` — impl-only: contract is `spec/models/d2/{hitl,graph-engine}.d2`, the `interrupts.reason` CHECK already admits all three reasons, and there is no OpenAPI, schema, or generated-code change (codegen verified idempotent).

## Triggers

| Trigger | Spec | Status before |
|---|---|---|
| `interrupt_after` | `graph-engine.d2` §5 | not implemented |
| `requires_human` (static `config` + dynamic node output) | `hitl.d2` `graph_node.definition`, `graph-engine.d2` §5 | not implemented |
| `tool_calls` → approval | `graph-engine.d2` §3 `tool_ex` | `interrupts.tool_calls` always NULL |
| `human` node type | `graph-engine.d2` §3 `human_ex` "always interrupt" | **no executor → guaranteed `run.failed`** |

`requires_human` and `tool_calls` are read from the node's **writes**, never the merged channel state — otherwise the same key arriving in the run's *input* would pause at every node in the graph. Both have negative-control tests.

## Checkpoint metadata

Adds `node` (boundary node) and `parent_checkpoint_id` (lineage) from `graph-engine.d2` §4, carried in the state jsonb per `gen/endpoints.yaml:18`.

**Pause phase is derived, not stored.** `hitl.d2` `resume_behavior` step 4 calls `checkpoint.node` "the interrupted one", which only coincides with the boundary node for a pause-after — so `interrupted == node` distinguishes the phases with no new field.

## Two correctness fixes found by tracing

**1. Failed-announce window.** A pause is checkpoint-then-announce. If the announce fails transiently the status flip never happened, so the run is still `in_progress` and the redelivery's `RunStarted` succeeds instead of being fenced. Harmless for a pause-*before* (the node re-triggers from the frontier head); **not** harmless for a pause-*after*, whose node is already in `completedSet` and would be skipped straight past its own interrupt. Restore now re-announces and acks.

Verified the test catches it — reverting the guard yields:
```
run status: want "requires_action", got "completed"
execution_history[node_id=B]: want 0, got 1
interrupts for run: want exactly 1, got 0
```

**2. Deferred routing across a pause-after.** Expanding the paused node's edges at pause time decides the route from *pre-approval* state, so a conditional edge out of that node — exactly what the human is being asked about — evaluates false and is silently dropped, leaving the resume with an empty frontier and the run completing without ever taking the branch. Successors are now expanded on resume, against patched channels. Found by `TestResumePastInterruptAfter` failing.

## Tests

10 new, incl. both negative controls, the `interrupt_before`+`interrupt_after`-on-one-node interaction (proves the second pause mints a new interrupt rather than colliding with the first via the server's unresolved-only INSERT guard), and checkpoint lineage. Full controlplane suite green; #229/#230 tests unchanged and passing.

## Not in this PR

- `command.resume`/`goto` merge — `runner.go` still applies only `.update`, so the canonical LangGraph resume field is silently dropped. `graph-engine.d2` §5 `on_resume` puts it in this block; it is the immediate follow-up (PR-B).
- Run-level `interrupt_before`/`interrupt_after` from the OpenAPI axis (`RunCreate`), currently accepted and silently discarded (PR-C).

## Pre-existing, observed but not fixed here

- If `WriteCheckpoint` commits and `NodeCompleted` then fails transiently, the redelivery restores a checkpoint where the node is already in `completed_nodes`, so `execution_history` permanently misses that row. At-least-once seam predating #230.
- Nothing publishes `interrupt.created`/`interrupt.resolved` despite `nats/streams.go:56` declaring the `INTERRUPTS` stream.
- `end` node's "freeze output channel → `run.output`" (`graph-engine.d2` §3) — `runs.output` is never written.
- `execution.node_started` / `execution.node_failed` are handled server-side (`workers.go:112`) but the worker only ever sends `NodeCompleted`.