### PR TITLE
feat(worker): apply the full resume Command (resume + goto), not just update

### DIFF
--- a/controlplane/endpoints/runs_resume.go
+++ b/controlplane/endpoints/runs_resume.go
@@ -15,7 +15,11 @@
 // The run.resumed event lands on the RUNS stream; run-processor turns it into a
 // fresh worker.graph.execute command carrying the command as `resume` (deduped
 // on the event id, not the run id — see nats/run_processor.go). The worker
-// restores the pause checkpoint, applies command.update, and continues the walk.
+// restores the pause checkpoint, applies the Command — update, resume and goto
+// (worker/command.go) — and continues the walk.
+//
+// The body is passed through verbatim: the Command's shape is the worker's
+// contract, not this endpoint's, so a field added there needs no change here.
 package endpoints
 
 import (
@@ -42,9 +46,9 @@ func (s *Server) RunsResume(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid run id")
 	}
 
-	// Body is a ResumeRunRequest; for this slice we carry only the nested
-	// `command` through to the worker. An absent command resumes with no state
-	// change (the worker applies command.update, which is then empty).
+	// Body is a ResumeRunRequest; we carry the nested `command` through to the
+	// worker verbatim. An absent command resumes with no state change and no
+	// redirection (the worker's Command apply is then a no-op).
 	var req struct {
 		Command json.RawMessage `json:"command,omitempty"`
 	}

--- a/controlplane/worker/command.go
+++ b/controlplane/worker/command.go
@@ -1,0 +1,167 @@
+// The LangGraph resume Command — the payload a client POSTs to
+// /threads/{tid}/runs/{rid}/resume to un-park a run, carried to the worker as
+// GraphCommand.Resume.
+//
+// Contract: the OpenAPI Command schema (spec/api/duragraph-latest.yaml) is the
+// wire shape — update, resume, goto. graph-engine.d2 §5 on_resume additionally
+// lists "send", but there is no `send` field in the schema: a Send is one of
+// the shapes `goto` may take, so send folds into goto rather than being its own
+// key. OpenAPI wins on wire shape (the precedent set when endpoints.yaml's
+// stale assistant-version steps lost to the schema).
+//
+// Semantics, reconciling the two places the spec describes the merge:
+//
+//	graph-engine.d2 §5 on_resume  "command.resume/update/goto/send → channel_values"
+//	hitl.d2 resume_behavior #5    "Inject Command.resume: as input to that node"
+//
+// Both are satisfied by landing the resume value IN channel_values (which is
+// what the interrupted node reads as its input) under the reserved `resume`
+// key — the field's own name, the least inventive binding available, since the
+// spec names no key for it.
+package worker
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// resumeChannelKey is where Command.resume lands in channel_values. The
+// interrupted node reads it as its input, and edge conditions can route on it.
+const resumeChannelKey = "resume"
+
+// sendTarget is the OpenAPI Send schema: a node to navigate to, plus the input
+// to run it with. Both fields are required by the schema.
+type sendTarget struct {
+	Node  string          `json:"node"`
+	Input json.RawMessage `json:"input"`
+}
+
+// resumeCommand is the decoded Command. Goto stays raw because the schema
+// declares it as an anyOf over four shapes (Send, []Send, string, []string)
+// that only a custom decode can collapse.
+type resumeCommand struct {
+	Update map[string]any  `json:"update,omitempty"`
+	Resume json.RawMessage `json:"resume,omitempty"`
+	Goto   json.RawMessage `json:"goto,omitempty"`
+}
+
+// gotoTargets is the normalized form of Command.goto: the nodes to navigate to,
+// in order, each with the optional state patch its Send carried.
+type gotoTargets struct {
+	Nodes []string
+	// Patch is the union of every Send.input that decoded to an object,
+	// merged into channel_values before the targets run. A Send whose input is
+	// a bare scalar or array has no channel name to bind to, so it is carried
+	// as the target's `resume` value instead — the same reserved key
+	// Command.resume uses, since both mean "the input this node resumes with".
+	Patch map[string]any
+}
+
+// decodeGoto collapses the four shapes Command.goto may take into an ordered
+// node list plus the state patch its Send inputs carry. A null/absent goto
+// yields no targets (routing proceeds normally).
+//
+// The array forms are attempted before the scalar forms because a JSON array
+// cannot decode into a string or a Send, so the ordering is unambiguous.
+func decodeGoto(raw json.RawMessage) (gotoTargets, error) {
+	var out gotoTargets
+	if len(raw) == 0 || string(raw) == "null" {
+		return out, nil
+	}
+
+	// []string — ["a","b"]
+	var names []string
+	if err := json.Unmarshal(raw, &names); err == nil {
+		out.Nodes = names
+		return out, out.validate()
+	}
+	// []Send — [{"node":"a","input":{...}}]
+	var sends []sendTarget
+	if err := json.Unmarshal(raw, &sends); err == nil {
+		for _, s := range sends {
+			out.Nodes = append(out.Nodes, s.Node)
+			out.absorb(s)
+		}
+		return out, out.validate()
+	}
+	// string — "a"
+	var name string
+	if err := json.Unmarshal(raw, &name); err == nil {
+		out.Nodes = []string{name}
+		return out, out.validate()
+	}
+	// Send — {"node":"a","input":{...}}
+	var send sendTarget
+	if err := json.Unmarshal(raw, &send); err == nil {
+		out.Nodes = []string{send.Node}
+		out.absorb(send)
+		return out, out.validate()
+	}
+	return out, fmt.Errorf("worker: command.goto is not a node name, Send, or list of either: %s", raw)
+}
+
+// absorb folds one Send's input into the target patch. An object input merges
+// key-by-key; any other JSON value binds to the reserved resume key, because a
+// bare scalar carries no channel name of its own.
+func (g *gotoTargets) absorb(s sendTarget) {
+	if len(s.Input) == 0 || string(s.Input) == "null" {
+		return
+	}
+	if g.Patch == nil {
+		g.Patch = map[string]any{}
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(s.Input, &obj); err == nil && obj != nil {
+		for k, v := range obj {
+			g.Patch[k] = v
+		}
+		return
+	}
+	var scalar any
+	if err := json.Unmarshal(s.Input, &scalar); err == nil {
+		g.Patch[resumeChannelKey] = scalar
+	}
+}
+
+// validate rejects a goto naming an empty node, which would silently redirect
+// the walk to nowhere.
+func (g gotoTargets) validate() error {
+	for _, n := range g.Nodes {
+		if n == "" {
+			return fmt.Errorf("worker: command.goto names an empty node")
+		}
+	}
+	return nil
+}
+
+// apply merges this Command into channels and reports where the walk should go
+// next. It is the whole of graph-engine.d2 §5 on_resume's "merge" step:
+//
+//   - update patches channel_values key-by-key.
+//   - resume lands under the reserved resume key (see resumeChannelKey).
+//   - goto contributes its Send inputs to the same patch, and returns the
+//     targets that redirect the frontier.
+//
+// Order matters: update lands first so a resume value or Send input for the
+// same key wins over it — the more specific signal about THIS pause beats the
+// general state patch.
+func (c resumeCommand) apply(channels map[string]any) (gotoTargets, error) {
+	for k, v := range c.Update {
+		channels[k] = v
+	}
+	if len(c.Resume) > 0 && string(c.Resume) != "null" {
+		var v any
+		if err := json.Unmarshal(c.Resume, &v); err != nil {
+			return gotoTargets{}, fmt.Errorf("worker: decode command.resume: %w", err)
+		}
+		channels[resumeChannelKey] = v
+	}
+	targets, err := decodeGoto(c.Goto)
+	if err != nil {
+		return gotoTargets{}, err
+	}
+	for k, v := range targets.Patch {
+		channels[k] = v
+	}
+	return targets, nil
+}

--- a/controlplane/worker/command_test.go
+++ b/controlplane/worker/command_test.go
@@ -1,0 +1,131 @@
+package worker
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestDecodeGotoShapes covers every shape the OpenAPI Command.goto anyOf
+// allows: a node name, a list of names, a Send, and a list of Sends — plus the
+// null/absent cases that must mean "route normally", not "route nowhere".
+func TestDecodeGotoShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		raw       string
+		wantNodes []string
+		wantPatch map[string]any
+	}{
+		{name: "absent", raw: ``, wantNodes: nil},
+		{name: "null", raw: `null`, wantNodes: nil},
+		{name: "string", raw: `"b"`, wantNodes: []string{"b"}},
+		{name: "string list", raw: `["b","c"]`, wantNodes: []string{"b", "c"}},
+		{
+			name:      "send with object input",
+			raw:       `{"node":"b","input":{"x":1}}`,
+			wantNodes: []string{"b"},
+			wantPatch: map[string]any{"x": float64(1)},
+		},
+		{
+			name:      "send list merges every input",
+			raw:       `[{"node":"b","input":{"x":1}},{"node":"c","input":{"y":2}}]`,
+			wantNodes: []string{"b", "c"},
+			wantPatch: map[string]any{"x": float64(1), "y": float64(2)},
+		},
+		{
+			// A bare scalar Send input has no channel name to bind to, so it
+			// lands on the same reserved key Command.resume uses.
+			name:      "send with scalar input binds to resume key",
+			raw:       `{"node":"b","input":"yes"}`,
+			wantNodes: []string{"b"},
+			wantPatch: map[string]any{resumeChannelKey: "yes"},
+		},
+		{
+			name:      "send with null input contributes no patch",
+			raw:       `{"node":"b","input":null}`,
+			wantNodes: []string{"b"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := decodeGoto(json.RawMessage(tc.raw))
+			if err != nil {
+				t.Fatalf("decodeGoto(%s): %v", tc.raw, err)
+			}
+			if !reflect.DeepEqual(got.Nodes, tc.wantNodes) {
+				t.Errorf("nodes: want %v, got %v", tc.wantNodes, got.Nodes)
+			}
+			if len(tc.wantPatch) == 0 && len(got.Patch) != 0 {
+				t.Errorf("patch: want none, got %v", got.Patch)
+			}
+			if len(tc.wantPatch) > 0 && !reflect.DeepEqual(got.Patch, tc.wantPatch) {
+				t.Errorf("patch: want %v, got %v", tc.wantPatch, got.Patch)
+			}
+		})
+	}
+}
+
+// TestDecodeGotoRejectsGarbage pins that an unusable goto is a hard error, not
+// a silent "route normally" — a client typo must not quietly become a no-op.
+func TestDecodeGotoRejectsGarbage(t *testing.T) {
+	for _, raw := range []string{`5`, `true`, `{"input":{"x":1}}`, `["a",""]`} {
+		if _, err := decodeGoto(json.RawMessage(raw)); err == nil {
+			t.Errorf("decodeGoto(%s): want an error, got nil", raw)
+		}
+	}
+}
+
+// TestCommandApplyPrecedence pins the merge order graph-engine.d2 §5 on_resume
+// implies: update is the general state patch, so a resume value or a Send input
+// naming the same key — both more specific statements about THIS pause — win
+// over it.
+func TestCommandApplyPrecedence(t *testing.T) {
+	channels := map[string]any{"keep": "me"}
+	var cmd resumeCommand
+	if err := json.Unmarshal([]byte(`{
+		"update": {"a": 1, "resume": "from-update", "shared": "from-update"},
+		"resume": "from-resume",
+		"goto":   {"node": "n", "input": {"shared": "from-send"}}
+	}`), &cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := cmd.apply(channels)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !reflect.DeepEqual(targets.Nodes, []string{"n"}) {
+		t.Errorf("goto nodes: want [n], got %v", targets.Nodes)
+	}
+	if channels["keep"] != "me" {
+		t.Error("apply must not disturb untouched channels")
+	}
+	if channels["a"] != float64(1) {
+		t.Errorf("update key: want 1, got %v", channels["a"])
+	}
+	if channels[resumeChannelKey] != "from-resume" {
+		t.Errorf("resume must beat an update writing the same key: got %v", channels[resumeChannelKey])
+	}
+	if channels["shared"] != "from-send" {
+		t.Errorf("Send input must beat an update writing the same key: got %v", channels["shared"])
+	}
+}
+
+// TestCommandApplyEmpty pins that an empty command is inert: no channel is
+// invented and routing is left to the graph.
+func TestCommandApplyEmpty(t *testing.T) {
+	channels := map[string]any{}
+	var cmd resumeCommand
+	if err := json.Unmarshal([]byte(`{}`), &cmd); err != nil {
+		t.Fatal(err)
+	}
+	targets, err := cmd.apply(channels)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(targets.Nodes) != 0 {
+		t.Errorf("goto nodes: want none, got %v", targets.Nodes)
+	}
+	if len(channels) != 0 {
+		t.Errorf("channels: want untouched, got %v", channels)
+	}
+}

--- a/controlplane/worker/resume_command_integration_test.go
+++ b/controlplane/worker/resume_command_integration_test.go
@@ -1,0 +1,196 @@
+// Integration coverage for the resume Command fields graph-engine.d2 §5
+// on_resume names — command.resume and command.goto — which were carried to the
+// worker but silently discarded until this slice (only command.update was
+// applied). Each test routes on the field's effect, so a dropped field fails
+// the assertion rather than passing vacuously.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// pauseThenResume drives a run to its interrupt, POSTs the given resume body
+// through the real endpoint, and redelivers the command the way run-processor
+// would. Returns the runner verdict of the resumed delivery.
+func pauseThenResume(t *testing.T, ctx context.Context, runner *worker.Runner, cmd worker.GraphCommand, tid uuid.UUID, resumeBody, workerResume string) (bool, error) {
+	t.Helper()
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("pause ProcessOne: %v", err)
+	}
+	postResume(t, tid, cmd.RunID, resumeBody)
+	cmd.Resume = json.RawMessage(workerResume)
+	acked, _, err := runner.ProcessOne(ctx, cmd)
+	return acked, err
+}
+
+// TestResumeValueReachesChannels is the regression proof for the silent drop.
+// command.resume is the canonical LangGraph resume field ("A value to pass to
+// an interrupted node"), and hitl.d2 resume_behavior step 5 says to inject it
+// as that node's input. Before this slice it was carried all the way to the
+// worker and then ignored.
+//
+// The GATE→B edge is conditional on the resume value, so B running is only
+// possible if the value actually landed in channel_values.
+func TestResumeValueReachesChannels(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "resume-val",
+		`[{"id":"GATE","type":"tool","config":{"interrupt_before":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"GATE","target":"B","condition":"resume == approved"}]`)
+	runner, _ := newLiveRunner(t, ctx, "resume-val")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "resume-val"}
+
+	acked, err := pauseThenResume(t, ctx, runner, cmd, tid,
+		`{"command":{"resume":"approved"}}`, `{"resume":"approved"}`)
+	if err != nil {
+		t.Fatalf("resume ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("resume ProcessOne: want acked=true, got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "GATE", 1)
+	// THE PROOF: the conditional edge only holds if command.resume merged.
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+
+	// And it is visible in the persisted state under the reserved key.
+	cp := latestCheckpointState(t, ctx, pool, rid)
+	channels, _ := cp["channels"].(map[string]any)
+	if channels["resume"] != "approved" {
+		t.Errorf("channels.resume: want \"approved\", got %v", channels["resume"])
+	}
+}
+
+// TestResumeGotoRedirects covers command.goto: the resume names where to go
+// next, overriding both the paused node and the edges leading out of it. GATE
+// must NOT execute (goto skips the node the run was parked before) and B must
+// not run despite being GATE's only successor — C does instead, even though no
+// edge leads to it.
+func TestResumeGotoRedirects(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "goto",
+		`[{"id":"GATE","type":"tool","config":{"interrupt_before":true}},
+		  {"id":"B","type":"tool","config":{"set":{"went":"b"}}},
+		  {"id":"C","type":"tool","config":{"set":{"went":"c"}}}]`,
+		`[{"source":"GATE","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "goto")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "goto"}
+
+	if _, err := pauseThenResume(t, ctx, runner, cmd, tid,
+		`{"command":{"goto":"C"}}`, `{"goto":"C"}`); err != nil {
+		t.Fatalf("resume ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "GATE", 0) // goto skips the parked node
+	assertNodeCount(t, ctx, pool, rid, "B", 0)    // and its natural successor
+	assertNodeCount(t, ctx, pool, rid, "C", 1)    // the goto target ran instead
+}
+
+// TestResumeGotoOverridesDeferredRouting is the interaction between this slice
+// and the deferred-routing fix: a pause-AFTER withholds the paused node's
+// successors until the resume, and a goto on that resume must override that
+// expansion rather than being appended alongside it. A alone would route to B;
+// the goto sends the walk to C instead, and B must not run.
+func TestResumeGotoOverridesDeferredRouting(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "goto-after",
+		`[{"id":"A","type":"tool","config":{"interrupt_after":true,"set":{"stage":"a"}}},
+		  {"id":"B","type":"tool","config":{"set":{"went":"b"}}},
+		  {"id":"C","type":"tool","config":{"set":{"went":"c"}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "goto-after")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "goto-after"}
+
+	if _, err := pauseThenResume(t, ctx, runner, cmd, tid,
+		`{"command":{"goto":"C"}}`, `{"goto":"C"}`); err != nil {
+		t.Fatalf("resume ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1) // ran before the pause, not re-run
+	assertNodeCount(t, ctx, pool, rid, "B", 0) // deferred successor overridden
+	assertNodeCount(t, ctx, pool, rid, "C", 1)
+}
+
+// TestResumeGotoUnknownNodeFailsRun pins that a goto naming a node the graph
+// does not contain is a deterministic client error: the run is recorded failed
+// and the command acked, never redelivered in a loop and never silently
+// treated as "route normally".
+func TestResumeGotoUnknownNodeFailsRun(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "goto-bad",
+		`[{"id":"GATE","type":"tool","config":{"interrupt_before":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"GATE","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "goto-bad")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "goto-bad"}
+
+	acked, err := pauseThenResume(t, ctx, runner, cmd, tid,
+		`{"command":{"goto":"NOPE"}}`, `{"goto":"NOPE"}`)
+	if err != nil {
+		t.Fatalf("resume ProcessOne: unexpected transport error: %v", err)
+	}
+	if !acked {
+		t.Fatal("resume ProcessOne: want acked=true (poison command, no redelivery), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "failed")
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	var errText string
+	if err := pool.QueryRow(ctx, `SELECT error FROM runs WHERE id=$1`, rid).Scan(&errText); err != nil {
+		t.Fatalf("select run error: %v", err)
+	}
+	if errText == "" {
+		t.Error("runs.error: want the goto failure recorded, got empty")
+	}
+}
+
+// TestResumeGotoSendCarriesInput covers the Send form of goto — the shape
+// graph-engine.d2 §5's "send" folds into. The Send's input must merge into
+// channel_values before the target runs, which the target's own conditional
+// edge then observes.
+func TestResumeGotoSendCarriesInput(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "goto-send",
+		`[{"id":"GATE","type":"tool","config":{"interrupt_before":true}},
+		  {"id":"C","type":"tool","config":{"set":{"went":"c"}}},
+		  {"id":"D","type":"tool","config":{"set":{"went":"d"}}}]`,
+		`[{"source":"C","target":"D","condition":"mode == fast"}]`)
+	runner, _ := newLiveRunner(t, ctx, "goto-send")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "goto-send"}
+
+	if _, err := pauseThenResume(t, ctx, runner, cmd, tid,
+		`{"command":{"goto":{"node":"C","input":{"mode":"fast"}}}}`,
+		`{"goto":{"node":"C","input":{"mode":"fast"}}}`); err != nil {
+		t.Fatalf("resume ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "C", 1)
+	// D only runs if the Send's input merged, making C→D's condition hold.
+	assertNodeCount(t, ctx, pool, rid, "D", 1)
+}

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -25,15 +25,21 @@
 //   - When the frontier empties: RunCompleted, fenced the same way. A
 //     max_iterations guard bounds cyclic graphs, escalating to run.failed.
 //
-// HITL (human-in-the-loop) interrupt_before is implemented: a node marked
-// config.interrupt_before pauses the walk BEFORE executing — the runner
-// checkpoints the walk state (with the paused node at the head of the frontier
-// and an Interrupted marker), calls RequiresAction (server flips the run to
-// requires_action + records the interrupt), and acks. A later run.resumed
-// redelivers the command carrying cmd.Resume; the runner merges the resume
-// payload into channels, marks the paused node resumed-past, clears the marker,
-// and continues the walk. interrupt_after / requires_human and real llm/tool
-// sub-worker delegation are deferred to later slices; the executors here are
+// HITL (human-in-the-loop) is implemented for all of hitl.d2's triggers. A node
+// may pause the walk BEFORE it executes (config.interrupt_before, or any node of
+// type human) or AFTER it has run and merged its writes (config.interrupt_after,
+// requires_human, or pending tool_calls — see graph.go pausesAfter). Either way
+// the runner checkpoints the walk state with an Interrupted marker, calls
+// RequiresAction (server flips the run to requires_action + records the
+// interrupt), and acks.
+//
+// A later run.resumed redelivers the command carrying cmd.Resume, the LangGraph
+// Command: the runner applies its update / resume / goto (command.go), marks the
+// paused node resumed-past, clears the marker, and continues the walk. Routing
+// out of a node that paused AFTER itself is deliberately deferred to this point
+// — see the resume block in ProcessOne.
+//
+// Real llm/tool sub-worker delegation remains deferred; the executors here are
 // deterministic (see graph.go).
 //
 // Source: spec/models/d2/graph-engine.d2 + hitl.d2 + the worker-execution design doc.
@@ -352,42 +358,58 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		frontier = graph.entryNodes()
 	}
 
-	// HITL resume: a run.resumed dispatch carries cmd.Resume, the LangGraph-style
-	// Command ({update, resume, goto, ...}; see spec/models/d2/hitl.d2). Only act
-	// on it when the restored checkpoint says we are actually paused
-	// (interrupted != "") — this makes a redelivered resume a no-op (the first
-	// resume already cleared the marker, so it won't re-merge) and ignores a
-	// stray resume on a run that is not paused. For this slice we apply
-	// command.update (the state patch merged into channels before the paused node
-	// runs); command.resume / command.goto / command.send are later slices. Then
-	// mark the paused node resumed-past so the loop executes it rather than
-	// re-pausing, and clear the marker.
+	// HITL resume: a run.resumed dispatch carries cmd.Resume, the LangGraph
+	// Command (update / resume / goto — see command.go for how the spec's
+	// "send" folds into goto). Only act on it when the restored checkpoint says
+	// we are actually paused (interrupted != "") — this makes a redelivered
+	// resume a no-op (the first resume already cleared the marker, so it won't
+	// re-merge) and ignores a stray resume on a run that is not paused.
 	if len(cmd.Resume) > 0 && interrupted != "" {
-		var command struct {
-			Update map[string]any `json:"update,omitempty"`
-		}
+		var command resumeCommand
 		if uerr := json.Unmarshal(cmd.Resume, &command); uerr != nil {
 			return false, epoch, fmt.Errorf("runner: decode resume command: %w", uerr)
 		}
-		for k, v := range command.Update {
-			channels[k] = v
+		// Merge update + resume + any Send inputs into channel_values, and
+		// collect where goto says to navigate. A malformed goto is the client's
+		// error, not a transient one, so it fails the run rather than looping.
+		targets, aerr := command.apply(channels)
+		if aerr != nil {
+			return r.failRun(ctx, cmd.RunID, epoch, aerr.Error())
 		}
-		// Expand the routing that was deferred at a pause-after, now that the
-		// human's patch is merged: the paused node's edges are evaluated
-		// against the UPDATED channels, which is what lets a conditional edge
-		// out of that node depend on the answer. Prepended so this branch
-		// continues ahead of anything queued from a parallel branch.
-		if pausedAfter {
-			succs, serr := graph.successors(interrupted, channels)
+
+		pausedNode := interrupted
+		switch {
+		case len(targets.Nodes) > 0:
+			// command.goto redirects THIS branch: the targets replace whatever
+			// this pause would have run next — the paused node itself for a
+			// pause-before, or its successors for a pause-after. Anything
+			// already queued from a parallel branch stays behind them.
+			for _, n := range targets.Nodes {
+				if _, ok := graph.node(n); !ok {
+					return r.failRun(ctx, cmd.RunID, epoch, fmt.Sprintf("command.goto names unknown node %q", n))
+				}
+			}
+			if !pausedAfter && len(frontier) > 0 && frontier[0] == pausedNode {
+				frontier = frontier[1:] // skip the node we were parked before
+			}
+			frontier = append(append([]string{}, targets.Nodes...), frontier...)
+		case pausedAfter:
+			// Expand the routing deferred at the pause, now that the patch is
+			// merged: the paused node's edges are evaluated against the UPDATED
+			// channels, which is what lets a conditional edge out of that node
+			// depend on the answer. Prepended so this branch continues ahead of
+			// anything queued from a parallel branch.
+			succs, serr := graph.successors(pausedNode, channels)
 			if serr != nil {
 				return r.failRun(ctx, cmd.RunID, epoch, serr.Error())
 			}
 			frontier = append(succs, frontier...)
 		}
+
 		// A pause taken AFTER the node ran needs no resumedPast entry (the node
 		// is already in completedSet), but recording it is harmless and keeps
 		// the two phases symmetric.
-		resumedPast[interrupted] = true
+		resumedPast[pausedNode] = true
 		interrupted = ""
 		pausedAfter = false
 	}


### PR DESCRIPTION
Completes `graph-engine.d2` §5 `on_resume`. **Stacked on #231** (base is `feat/interrupt-triggers`) — #231 did the pause side of §5, this is the resume side.

`[spec-skip]` impl-only: contract is `graph-engine.d2` §5 + the OpenAPI `Command` schema, both already written. No schema, migration, or generated-code change (codegen verified idempotent).

## The bug

`command.resume` and `command.goto` were carried the whole way to the worker — `runs_resume.go:81` → `run_processor.go` → `GraphCommand.Resume` — and then **silently discarded**: `runner.go` read only `.update`. A LangGraph client POSTing the canonical `{"command":{"resume":"approved"}}` got a `200` and a run that resumed with unchanged state. Silent wrong behavior on the field the API documents as *"A value to pass to an interrupted node."*

## Two contract reconciliations

Both recorded in `command.go` rather than decided silently:

1. **`send` folds into `goto`.** `graph-engine.d2` §5 lists `command.resume/update/goto/send`, but OpenAPI `Command` has only `update`/`resume`/`goto` — a `Send` is one of the four shapes `goto` may take. OpenAPI wins on wire shape, per the #228 precedent.
2. **Where the resume value lands.** §5 says it merges `→ channel_values`; `hitl.d2` `resume_behavior` #5 says *"inject as input to that node"*. Both are satisfied by landing it in `channel_values` under the reserved `resume` key — the field's own name, the least inventive binding available, since the spec names no key for it.

## Behavior

`goto` decodes all four shapes (`string`, `[]string`, `Send`, `[]Send`). A `Send`'s object input merges into channels; a bare scalar input has no channel name to bind to, so it takes the same reserved `resume` key — both mean "the input this node resumes with".

Merge order is **update → resume → goto**: the more specific statements about *this* pause beat the general state patch.

`goto` redirects **this branch**, replacing whatever the pause would have run next — the paused node itself for a pause-before, or the successors #231 defers for a pause-after. Parallel-branch frontier entries stay queued behind the targets.

A `goto` naming an unknown node, or a malformed `goto`, is a deterministic client error → `run.failed` + ack. Never a redelivery loop, and never a silent "route normally" — a client typo must not quietly become a no-op.

## Tests

4 unit + 5 integration (real Postgres, real resume endpoint). Every integration test **routes on the field's effect**, so a dropped field fails the assertion rather than passing vacuously.

Verified `TestResumeValueReachesChannels` actually bites — stubbing the merge out:
```
execution_history[node_id=B]: want 1, got 0
channels.resume: want "approved", got <nil>
```

`TestResumeGotoOverridesDeferredRouting` covers the interaction with #231: `goto` must override the deferred successor expansion, not append alongside it.

## Still open after this

- Run-level `interrupt_before`/`interrupt_after` from the OpenAPI axis (`RunCreate`), accepted and silently discarded — PR-C. Home is the unused `kwargs` column (`postgres.d2:120`), so no migration.
- `command.checkpoint` / `RunCreate.command` (command-on-create).
- Pre-existing, unchanged: `runs.output` never written (`graph-engine.d2` §3 `end_ex`); no `interrupt.created`/`interrupt.resolved` publishes despite the declared `INTERRUPTS` stream; worker never sends `execution.node_started`/`node_failed`.