### PR TITLE
feat: honor run-level interrupt_before/interrupt_after from RunCreate

### DIFF
--- a/controlplane/endpoints/rows.go
+++ b/controlplane/endpoints/rows.go
@@ -191,8 +191,13 @@ func (r runRow) toAPI() Run {
 	if r.ThreadID != nil {
 		run.ThreadId = *r.ThreadID
 	}
+	// Target is run.Kwargs, NOT r.Kwargs: unmarshalling into the source []byte
+	// both discards the result and cannot succeed (encoding/json decodes into a
+	// []byte from a base64 STRING, not from an object), so this silently
+	// returned kwargs {} for every run. Latent until runs.kwargs was actually
+	// populated — see runs_kwargs.go.
 	if len(r.Kwargs) > 0 {
-		_ = json.Unmarshal(r.Kwargs, &r.Kwargs)
+		_ = json.Unmarshal(r.Kwargs, &run.Kwargs)
 	}
 	if len(r.Metadata) > 0 {
 		_ = json.Unmarshal(r.Metadata, &run.Metadata)

--- a/controlplane/endpoints/runs_batch.go
+++ b/controlplane/endpoints/runs_batch.go
@@ -29,13 +29,22 @@ func (s *Server) RunsBatchCreate(c echo.Context) error {
 
 	// Resolve every assistant reference (UUID or graph name) up front so an
 	// unknown graph fails the whole batch before any event is appended.
+	// Run-level interrupt specs are validated in the same up-front pass, so one
+	// malformed member rejects the whole batch atomically — matching how an
+	// unknown graph already behaves — rather than half-writing it.
 	assistantIDs := make([]uuid.UUID, len(req))
+	kwargs := make([][]byte, len(req))
 	for i, r := range req {
 		aid, err := s.resolveAssistantRef(ctx, r.AssistantId)
 		if err != nil {
 			return assistantRefHTTPError(err)
 		}
 		assistantIDs[i] = aid
+		kw, err := buildRunKwargs(r.InterruptBefore, r.InterruptAfter)
+		if err != nil {
+			return interruptSpecHTTPError(err)
+		}
+		kwargs[i] = kw
 	}
 
 	// Pre-mint an id per run so the run.created events (built before the TX
@@ -55,9 +64,9 @@ func (s *Server) RunsBatchCreate(c echo.Context) error {
 	out := make([]Run, 0, len(req))
 	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
 		for i, r := range req {
-			rows, err := tx.Query(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata)
-VALUES ($1, $2, 'queued', $3, $4)
-RETURNING `+runReturningColumns, ids[i], assistantIDs[i], mustJSON(r.Input), mustJSON(r.Metadata))
+			rows, err := tx.Query(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata, kwargs)
+VALUES ($1, $2, 'queued', $3, $4, $5)
+RETURNING `+runReturningColumns, ids[i], assistantIDs[i], mustJSON(r.Input), mustJSON(r.Metadata), kwargs[i])
 			if err != nil {
 				return err
 			}

--- a/controlplane/endpoints/runs_create.go
+++ b/controlplane/endpoints/runs_create.go
@@ -92,6 +92,12 @@ func (s *Server) RunsCreateOnThread(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
+	// Validate the run-level interrupt spec BEFORE the write, so a malformed
+	// one 422s without appending an event that would have to be rolled back.
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
 
 	aggID := uuid.New()
 	events := []Event{
@@ -99,10 +105,10 @@ func (s *Server) RunsCreateOnThread(c echo.Context) error {
 	}
 	var row runRow
 	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `INSERT INTO runs (id, thread_id, assistant_id, status, input, metadata)
-VALUES ($1, $2, $3, 'queued', $4, $5)
+		rows, err := tx.Query(ctx, `INSERT INTO runs (id, thread_id, assistant_id, status, input, metadata, kwargs)
+VALUES ($1, $2, $3, 'queued', $4, $5, $6)
 RETURNING `+runReturningColumns,
-			aggID, pathID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata))
+			aggID, pathID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata), kwargs)
 		if err != nil {
 			return err
 		}
@@ -126,6 +132,10 @@ func (s *Server) RunsCreateStateless(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
 
 	aggID := uuid.New()
 	events := []Event{
@@ -133,10 +143,10 @@ func (s *Server) RunsCreateStateless(c echo.Context) error {
 	}
 	var row runRow
 	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata)
-VALUES ($1, $2, 'queued', $3, $4)
+		rows, err := tx.Query(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata, kwargs)
+VALUES ($1, $2, 'queued', $3, $4, $5)
 RETURNING `+runReturningColumns,
-			aggID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata))
+			aggID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata), kwargs)
 		if err != nil {
 			return err
 		}

--- a/controlplane/endpoints/runs_kwargs.go
+++ b/controlplane/endpoints/runs_kwargs.go
@@ -1,0 +1,109 @@
+// Run-level LangGraph kwargs — the RunCreate fields that configure HOW a run
+// executes rather than what it contains. They are persisted to runs.kwargs,
+// which postgres.d2:120 declares for exactly this ("jsonb — run kwargs
+// (LangGraph)") and which nothing populated before.
+//
+// This slice carries interrupt_before / interrupt_after, the run-level half of
+// HITL. They are a DIFFERENT axis from the graph's own node config: the graph
+// author marks a node config.interrupt_before, while a CALLER names nodes to
+// interrupt at for this run only. Both are real, and the worker takes their
+// union — see worker/graph.go interruptPolicy.
+//
+// Contract: OpenAPI RunCreateStateful / RunCreateStateless / CronCreate, each
+// declaring `anyOf: [string enum "*", array of string]`. Both fields were
+// already in the generated types (types_gen.go InterruptBefore/InterruptAfter,
+// typed interface{} because of that anyOf) and were referenced by no handler,
+// so a caller's interrupt_before was accepted with a 201 and silently dropped.
+package endpoints
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// interruptAll is the wildcard form: interrupt at every node in the graph.
+const interruptAll = "*"
+
+// errInterruptSpecInvalid marks a malformed interrupt_before/interrupt_after so
+// the caller gets 422 (semantically invalid) rather than a 500.
+var errInterruptSpecInvalid = errors.New("invalid interrupt spec")
+
+// runKwargs is the persisted shape of runs.kwargs. Fields are omitted when
+// absent so a run created without them stores {} rather than a bag of nulls.
+type runKwargs struct {
+	InterruptBefore any `json:"interrupt_before,omitempty"`
+	InterruptAfter  any `json:"interrupt_after,omitempty"`
+}
+
+// normalizeInterruptSpec validates one run-level interrupt field and returns
+// the value to persist: nil (absent), the "*" wildcard, or a []string of node
+// names. Values arrive as interface{} because the OpenAPI anyOf makes the
+// generated field untyped, so this is where the schema is actually enforced —
+// without it a caller could store arbitrary JSON in kwargs and the worker would
+// have to defend against it at execution time.
+func normalizeInterruptSpec(field string, v any) (any, error) {
+	switch t := v.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		// The schema's string branch is an enum of exactly one value; a bare
+		// node name is NOT valid here (a single node must be a one-element
+		// list), so accepting it would invent contract.
+		if t != interruptAll {
+			return nil, fmt.Errorf("%w: %s: the only allowed string is %q; name a single node as a one-element list", errInterruptSpecInvalid, field, interruptAll)
+		}
+		return interruptAll, nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for i, e := range t {
+			s, ok := e.(string)
+			if !ok {
+				return nil, fmt.Errorf("%w: %s[%d]: node names must be strings, got %T", errInterruptSpecInvalid, field, i, e)
+			}
+			if s == "" {
+				return nil, fmt.Errorf("%w: %s[%d]: node name must not be empty", errInterruptSpecInvalid, field, i)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("%w: %s: want %q or a list of node names, got %T", errInterruptSpecInvalid, field, interruptAll, v)
+	}
+}
+
+// buildRunKwargs validates the run-level interrupt fields and renders the
+// runs.kwargs jsonb. Absent on both sides yields "{}" — the column default —
+// so a run that sets neither is indistinguishable from one created before this
+// slice existed.
+func buildRunKwargs(interruptBefore, interruptAfter any) ([]byte, error) {
+	before, err := normalizeInterruptSpec("interrupt_before", interruptBefore)
+	if err != nil {
+		return nil, err
+	}
+	after, err := normalizeInterruptSpec("interrupt_after", interruptAfter)
+	if err != nil {
+		return nil, err
+	}
+	if before == nil && after == nil {
+		return []byte("{}"), nil
+	}
+	b, err := json.Marshal(runKwargs{InterruptBefore: before, InterruptAfter: after})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errInterruptSpecInvalid, err)
+	}
+	return b, nil
+}
+
+// interruptSpecHTTPError maps a buildRunKwargs failure to 422. The value parsed
+// as JSON (Bind succeeded) but does not satisfy the schema, which is
+// Unprocessable Entity rather than Bad Request.
+func interruptSpecHTTPError(err error) error {
+	if errors.Is(err, errInterruptSpecInvalid) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+}

--- a/controlplane/endpoints/runs_kwargs_integration_test.go
+++ b/controlplane/endpoints/runs_kwargs_integration_test.go
@@ -1,0 +1,157 @@
+package endpoints
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRunCreatePersistsInterruptSpec proves the run-level interrupt fields
+// survive create instead of being dropped. They are declared on
+// RunCreateStateful/RunCreateStateless and were present in the generated types
+// all along, but no handler read them: runs.kwargs stayed '{}' and the caller's
+// interrupt_before vanished behind a 201.
+func TestRunCreatePersistsInterruptSpec(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistantGraph(t, ctx, "agent", "a", "2020-01-01T00:00:00Z")
+
+	post := func(path, body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+	kwargsOf := func(t *testing.T, runID string) map[string]any {
+		t.Helper()
+		var raw []byte
+		if err := testPool.QueryRow(ctx, `SELECT kwargs FROM runs WHERE id=$1`, runID).Scan(&raw); err != nil {
+			t.Fatalf("select kwargs: %v", err)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("decode kwargs: %v", err)
+		}
+		return out
+	}
+
+	// --- node list round-trips ---
+	rec := post("/api/v1/runs", fmt.Sprintf(
+		`{"assistant_id":%q,"interrupt_before":["gate"],"interrupt_after":["a","b"]}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create with interrupt spec: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var run Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	kw := kwargsOf(t, run.RunId.String())
+	before, _ := kw["interrupt_before"].([]any)
+	if len(before) != 1 || before[0] != "gate" {
+		t.Errorf("kwargs.interrupt_before: want [gate], got %v", kw["interrupt_before"])
+	}
+	after, _ := kw["interrupt_after"].([]any)
+	if len(after) != 2 || after[0] != "a" || after[1] != "b" {
+		t.Errorf("kwargs.interrupt_after: want [a b], got %v", kw["interrupt_after"])
+	}
+
+	// The RESPONSE must echo kwargs too. This is what catches the toAPI bug
+	// where the jsonb was unmarshalled into the source []byte instead of the
+	// API map, so every run reported kwargs {} regardless of the column.
+	respBefore, _ := run.Kwargs["interrupt_before"].([]any)
+	if len(respBefore) != 1 || respBefore[0] != "gate" {
+		t.Errorf("Run.kwargs.interrupt_before in the response: want [gate], got %v", run.Kwargs)
+	}
+
+	// --- wildcard round-trips as the string, not a list ---
+	rec = post("/api/v1/runs", fmt.Sprintf(`{"assistant_id":%q,"interrupt_before":"*"}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("wildcard: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := kwargsOf(t, run.RunId.String())["interrupt_before"]; got != "*" {
+		t.Errorf("kwargs.interrupt_before: want \"*\", got %v", got)
+	}
+
+	// --- omitting both leaves the column at its default, indistinguishable
+	// from a run created before this field existed ---
+	rec = post("/api/v1/runs", fmt.Sprintf(`{"assistant_id":%q}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("no spec: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if kw := kwargsOf(t, run.RunId.String()); len(kw) != 0 {
+		t.Errorf("kwargs with no spec: want {}, got %v", kw)
+	}
+
+	// --- stateful path honours it too ---
+	var threadID string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatal(err)
+	}
+	rec = post("/api/v1/threads/"+threadID+"/runs", fmt.Sprintf(
+		`{"assistant_id":%q,"interrupt_after":["x"]}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("stateful create: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := kwargsOf(t, run.RunId.String())["interrupt_after"].([]any); len(got) != 1 || got[0] != "x" {
+		t.Errorf("stateful kwargs.interrupt_after: want [x], got %v", got)
+	}
+}
+
+// TestRunCreateRejectsBadInterruptSpec pins that a value which parses as JSON
+// but violates the schema's anyOf is 422 (unprocessable), not a 500 and not a
+// silent drop — and that the rejection happens BEFORE any write, so no run and
+// no run.created event survive it.
+func TestRunCreateRejectsBadInterruptSpec(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistantGraph(t, ctx, "agent", "a", "2020-01-01T00:00:00Z")
+
+	for _, body := range []string{
+		`{"assistant_id":%q,"interrupt_before":"all"}`,      // string that is not the "*" enum
+		`{"assistant_id":%q,"interrupt_before":["a",5]}`,    // non-string member
+		`{"assistant_id":%q,"interrupt_before":["a",""]}`,   // empty node name
+		`{"assistant_id":%q,"interrupt_before":{"a":true}}`, // object is not an allowed shape
+		`{"assistant_id":%q,"interrupt_after":7}`,           // number is not an allowed shape
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/runs",
+			bytes.NewReader([]byte(fmt.Sprintf(body, aid))))
+		req.Header.Set("Content-Type", "application/json")
+		e.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("%s: want 422, got %d: %s", body, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Nothing was written by any of the rejected creates.
+	var runs, events int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM runs`).Scan(&runs); err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM events WHERE event_type='run.created'`).Scan(&events); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 0 || events != 0 {
+		t.Errorf("a rejected create must write nothing: got %d runs, %d run.created events", runs, events)
+	}
+}

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -246,7 +246,10 @@ func (s *Server) RunsStreamThread(c echo.Context) error {
 // writeTx) but is parameterized on threadID so both variants can share it —
 // the generated handlers keep their own inline copy so this stays a small,
 // additive helper rather than a generator change. Returns the new run's id.
-func (s *Server) createRun(ctx context.Context, threadID *uuid.UUID, assistantID uuid.UUID, input, metadata []byte) (uuid.UUID, error) {
+// kwargs carries the run-level LangGraph kwargs (interrupt_before /
+// interrupt_after) already validated by the caller via buildRunKwargs; pass
+// nil for none and the column default '{}' applies.
+func (s *Server) createRun(ctx context.Context, threadID *uuid.UUID, assistantID uuid.UUID, input, metadata, kwargs []byte) (uuid.UUID, error) {
 	aggID := uuid.New()
 	payload := mustJSON(struct {
 		AssistantID uuid.UUID       `json:"assistant_id"`
@@ -259,11 +262,11 @@ func (s *Server) createRun(ctx context.Context, threadID *uuid.UUID, assistantID
 	err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
 		var execErr error
 		if threadID != nil {
-			_, execErr = tx.Exec(ctx, `INSERT INTO runs (id, thread_id, assistant_id, status, input, metadata)
-VALUES ($1, $2, $3, 'queued', $4, $5)`, aggID, *threadID, assistantID, input, metadata)
+			_, execErr = tx.Exec(ctx, `INSERT INTO runs (id, thread_id, assistant_id, status, input, metadata, kwargs)
+VALUES ($1, $2, $3, 'queued', $4, $5, $6)`, aggID, *threadID, assistantID, input, metadata, jsonOrEmpty(kwargs))
 		} else {
-			_, execErr = tx.Exec(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata)
-VALUES ($1, $2, 'queued', $3, $4)`, aggID, assistantID, input, metadata)
+			_, execErr = tx.Exec(ctx, `INSERT INTO runs (id, assistant_id, status, input, metadata, kwargs)
+VALUES ($1, $2, 'queued', $3, $4, $5)`, aggID, assistantID, input, metadata, jsonOrEmpty(kwargs))
 		}
 		return execErr
 	})
@@ -293,7 +296,11 @@ func (s *Server) RunsCreateAndStream(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	rid, err := s.createRun(ctx, &threadID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata))
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
+	rid, err := s.createRun(ctx, &threadID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata), kwargs)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -315,7 +322,11 @@ func (s *Server) RunsStatelessStream(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	rid, err := s.createRun(ctx, nil, assistantID, mustJSON(req.Input), mustJSON(req.Metadata))
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
+	rid, err := s.createRun(ctx, nil, assistantID, mustJSON(req.Input), mustJSON(req.Metadata), kwargs)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -428,7 +439,11 @@ func (s *Server) RunsStatelessWait(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	rid, err := s.createRun(ctx, nil, assistantID, mustJSON(req.Input), mustJSON(req.Metadata))
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
+	rid, err := s.createRun(ctx, nil, assistantID, mustJSON(req.Input), mustJSON(req.Metadata), kwargs)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/controlplane/nats/run_processor.go
+++ b/controlplane/nats/run_processor.go
@@ -144,13 +144,18 @@ func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
 	// runs not yet bound to a graph); assistant_id is NOT NULL. input is the
 	// run's initial channel seed (NOT NULL DEFAULT '{}'), forwarded so the
 	// worker's entry (start) node can seed channels from it.
+	// kwargs carries the run-level LangGraph knobs the CALLER set on create —
+	// currently interrupt_before / interrupt_after, which the worker unions with
+	// each node's own interrupt config. Forwarded on the command so the worker
+	// needs no extra round trip to learn them.
 	var threadID *uuid.UUID
 	var assistantID uuid.UUID
 	var graphID *string
 	var input []byte
+	var kwargs []byte
 	err = rp.pool.QueryRow(ctx,
-		`SELECT thread_id, assistant_id, graph_id, input FROM runs WHERE id = $1`, runID,
-	).Scan(&threadID, &assistantID, &graphID, &input)
+		`SELECT thread_id, assistant_id, graph_id, input, kwargs FROM runs WHERE id = $1`, runID,
+	).Scan(&threadID, &assistantID, &graphID, &input, &kwargs)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Run no longer exists (e.g. deleted) — nothing to dispatch.
@@ -171,6 +176,11 @@ func (rp *RunProcessor) dispatch(ctx context.Context, msg jetstream.Msg) error {
 	}
 	if len(input) > 0 {
 		cmd["input"] = json.RawMessage(input)
+	}
+	// Omit an empty bag so a run with no run-level knobs sends the same command
+	// shape it did before this field existed.
+	if len(kwargs) > 0 && string(kwargs) != "{}" {
+		cmd["kwargs"] = json.RawMessage(kwargs)
 	}
 
 	// Dedup key for the worker.graph.execute command:

--- a/controlplane/worker/graph.go
+++ b/controlplane/worker/graph.go
@@ -18,6 +18,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -84,6 +85,87 @@ func (n Node) interruptsAfter() bool {
 	v, _ := n.Config["interrupt_after"].(bool)
 	return v
 }
+
+// interruptPolicy is the RUN-LEVEL interrupt spec, from the caller's
+// RunCreate.interrupt_before / interrupt_after (persisted to runs.kwargs and
+// forwarded on GraphCommand.Kwargs). It is a second, independent axis from the
+// per-node config above: the graph author marks nodes in the definition, while
+// a caller names nodes for one run only. Neither overrides the other — a node
+// pauses if EITHER says so, because both are affirmative statements that a
+// human should see this node, and honouring only one would silently discard the
+// other party's intent.
+//
+// Each field is nil (unset), the "*" wildcard, or an explicit node list, per the
+// OpenAPI anyOf. Validation happens server-side at create (endpoints
+// normalizeInterruptSpec), so anything arriving here has already been checked.
+type interruptPolicy struct {
+	Before []string
+	After  []string
+	// AllBefore/AllAfter record the "*" wildcard, which matches every node —
+	// distinct from an empty list, which matches none.
+	AllBefore bool
+	AllAfter  bool
+}
+
+// interruptsBefore reports whether the run-level spec names this node.
+func (p interruptPolicy) interruptsBefore(nodeID string) bool {
+	return p.AllBefore || contains(p.Before, nodeID)
+}
+
+// interruptsAfter reports whether the run-level spec names this node.
+func (p interruptPolicy) interruptsAfter(nodeID string) bool {
+	return p.AllAfter || contains(p.After, nodeID)
+}
+
+func contains(list []string, s string) bool {
+	for _, e := range list {
+		if e == s {
+			return true
+		}
+	}
+	return false
+}
+
+// decodeInterruptPolicy reads the run-kwargs bag into an interruptPolicy. A
+// malformed bag is NOT an error: the server validated the spec at create time,
+// so anything unreadable here is a corrupt or hand-edited row, and dropping a
+// run on it would be worse than executing with no run-level interrupts.
+func decodeInterruptPolicy(kwargs json.RawMessage) interruptPolicy {
+	var p interruptPolicy
+	if len(kwargs) == 0 {
+		return p
+	}
+	var bag struct {
+		Before json.RawMessage `json:"interrupt_before,omitempty"`
+		After  json.RawMessage `json:"interrupt_after,omitempty"`
+	}
+	if err := json.Unmarshal(kwargs, &bag); err != nil {
+		return p
+	}
+	p.AllBefore, p.Before = decodeNodeSelector(bag.Before)
+	p.AllAfter, p.After = decodeNodeSelector(bag.After)
+	return p
+}
+
+// decodeNodeSelector collapses one interrupt_before/interrupt_after value into
+// (wildcard, node list) — the two shapes the OpenAPI anyOf allows.
+func decodeNodeSelector(raw json.RawMessage) (all bool, nodes []string) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	var names []string
+	if err := json.Unmarshal(raw, &names); err == nil {
+		return false, names
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil && s == interruptAllNodes {
+		return true, nil
+	}
+	return false, nil
+}
+
+// interruptAllNodes is the wildcard form of a run-level interrupt spec.
+const interruptAllNodes = "*"
 
 // pausesAfter reports whether the walk must suspend AFTER this node has run,
 // and with which interrupts.reason. It folds the two post-execution triggers

--- a/controlplane/worker/interrupt_policy_test.go
+++ b/controlplane/worker/interrupt_policy_test.go
@@ -1,0 +1,113 @@
+package worker
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDecodeInterruptPolicy covers the run-level interrupt spec as it arrives
+// on GraphCommand.Kwargs: the two shapes the OpenAPI anyOf allows (wildcard
+// string, node list), the absent cases, and the corrupt-row case that must
+// degrade to "no run-level interrupts" rather than dropping the run.
+func TestDecodeInterruptPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		kwargs                string
+		wantBefore, wantAfter []string
+		wantAllB, wantAllA    bool
+	}{
+		{name: "absent", kwargs: ``},
+		{name: "empty bag", kwargs: `{}`},
+		{name: "unrelated kwargs ignored", kwargs: `{"webhook":"https://x"}`},
+		{
+			name:       "before list",
+			kwargs:     `{"interrupt_before":["a","b"]}`,
+			wantBefore: []string{"a", "b"},
+		},
+		{
+			name:      "after list",
+			kwargs:    `{"interrupt_after":["c"]}`,
+			wantAfter: []string{"c"},
+		},
+		{
+			name:     "before wildcard",
+			kwargs:   `{"interrupt_before":"*"}`,
+			wantAllB: true,
+		},
+		{
+			name:     "both wildcards",
+			kwargs:   `{"interrupt_before":"*","interrupt_after":"*"}`,
+			wantAllB: true, wantAllA: true,
+		},
+		{
+			name:       "mixed shapes",
+			kwargs:     `{"interrupt_before":["a"],"interrupt_after":"*"}`,
+			wantBefore: []string{"a"}, wantAllA: true,
+		},
+		// A corrupt or hand-edited row must not take the run down: the server
+		// validated this at create time, so anything unreadable here is an
+		// anomaly, and executing with no run-level interrupts beats failing.
+		{name: "corrupt bag", kwargs: `not json`},
+		{name: "wrong inner type", kwargs: `{"interrupt_before":42}`},
+		{name: "unknown wildcard string", kwargs: `{"interrupt_before":"all"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := decodeInterruptPolicy(json.RawMessage(tc.kwargs))
+			if p.AllBefore != tc.wantAllB {
+				t.Errorf("AllBefore: want %v, got %v", tc.wantAllB, p.AllBefore)
+			}
+			if p.AllAfter != tc.wantAllA {
+				t.Errorf("AllAfter: want %v, got %v", tc.wantAllA, p.AllAfter)
+			}
+			if len(p.Before) != len(tc.wantBefore) {
+				t.Fatalf("Before: want %v, got %v", tc.wantBefore, p.Before)
+			}
+			for i, n := range tc.wantBefore {
+				if p.Before[i] != n {
+					t.Errorf("Before[%d]: want %q, got %q", i, n, p.Before[i])
+				}
+			}
+			if len(p.After) != len(tc.wantAfter) {
+				t.Fatalf("After: want %v, got %v", tc.wantAfter, p.After)
+			}
+		})
+	}
+}
+
+// TestInterruptPolicyMatching pins the two lookups, including the distinction
+// that makes the wildcard meaningful: an EMPTY list matches nothing, while "*"
+// matches everything.
+func TestInterruptPolicyMatching(t *testing.T) {
+	empty := decodeInterruptPolicy(json.RawMessage(`{"interrupt_before":[]}`))
+	if empty.interruptsBefore("anything") {
+		t.Error("an empty list must match no node")
+	}
+
+	star := decodeInterruptPolicy(json.RawMessage(`{"interrupt_before":"*"}`))
+	if !star.interruptsBefore("anything") {
+		t.Error(`"*" must match every node`)
+	}
+	if star.interruptsAfter("anything") {
+		t.Error("interrupt_before wildcard must not leak into interrupt_after")
+	}
+
+	named := decodeInterruptPolicy(json.RawMessage(`{"interrupt_after":["b"]}`))
+	if !named.interruptsAfter("b") {
+		t.Error("a named node must match")
+	}
+	if named.interruptsAfter("a") {
+		t.Error("an unnamed node must not match")
+	}
+	if named.interruptsBefore("b") {
+		t.Error("interrupt_after must not leak into interrupt_before")
+	}
+}
+
+// TestZeroPolicyIsInert pins that a run with no kwargs behaves exactly as it
+// did before this field existed — nothing pauses on the run-level axis.
+func TestZeroPolicyIsInert(t *testing.T) {
+	var p interruptPolicy
+	if p.interruptsBefore("a") || p.interruptsAfter("a") {
+		t.Error("the zero policy must never trigger an interrupt")
+	}
+}

--- a/controlplane/worker/interrupt_triggers_integration_test.go
+++ b/controlplane/worker/interrupt_triggers_integration_test.go
@@ -409,6 +409,105 @@ func TestInterruptBeforeAndAfterOnSameNode(t *testing.T) {
 	assertNodeCount(t, ctx, pool, rid, "B", 1)
 }
 
+// TestRunLevelInterruptSpec covers the second interrupt axis: nodes named by
+// the CALLER on the run (RunCreate.interrupt_before / interrupt_after,
+// persisted to runs.kwargs and forwarded on GraphCommand.Kwargs), on a graph
+// whose nodes carry NO interrupt config at all. Before this slice the field was
+// accepted with a 201 and silently discarded, so the run just ran to
+// completion.
+func TestRunLevelInterruptSpec(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		kwargs       string
+		wantPaused   string // node the run must park at
+		wantACount   int    // execution_history rows for A at the pause
+		wantPauseSet bool
+	}{
+		{
+			name: "interrupt_before names a node", kwargs: `{"interrupt_before":["B"]}`,
+			wantPaused: "B", wantACount: 1, wantPauseSet: true,
+		},
+		{
+			name: "interrupt_after names a node", kwargs: `{"interrupt_after":["A"]}`,
+			wantPaused: "A", wantACount: 1, wantPauseSet: true,
+		},
+		{
+			name: "wildcard before parks at the very first node", kwargs: `{"interrupt_before":"*"}`,
+			wantPaused: "A", wantACount: 0, wantPauseSet: true,
+		},
+		{
+			name: "empty list parks nowhere", kwargs: `{"interrupt_before":[]}`,
+			wantACount: 1,
+		},
+		{
+			name: "unnamed node parks nowhere", kwargs: `{"interrupt_before":["nope"]}`,
+			wantACount: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			pool := newPool(t)
+
+			tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+			// Neither node carries any interrupt config — every pause below is
+			// attributable to the run-level spec alone.
+			seedGraph(t, ctx, pool, aid, "runlevel",
+				`[{"id":"A","type":"tool","config":{"set":{"stage":"a"}}},
+				  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+				`[{"source":"A","target":"B"}]`)
+			runner, _ := newLiveRunner(t, ctx, "runlevel")
+
+			if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+				RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "runlevel",
+				Kwargs: json.RawMessage(tc.kwargs),
+			}); err != nil {
+				t.Fatalf("ProcessOne: %v", err)
+			}
+
+			assertNodeCount(t, ctx, pool, rid, "A", tc.wantACount)
+			if !tc.wantPauseSet {
+				assertRunStatus(t, ctx, pool, rid, "completed")
+				assertNodeCount(t, ctx, pool, rid, "B", 1)
+				return
+			}
+			assertRunStatus(t, ctx, pool, rid, "requires_action")
+			if in := soleInterrupt(t, ctx, pool, rid); in.NodeID != tc.wantPaused {
+				t.Errorf("interrupt node_id: want %q, got %q", tc.wantPaused, in.NodeID)
+			}
+		})
+	}
+}
+
+// TestRunLevelUnionsWithNodeConfig pins that the two interrupt axes are a
+// UNION, not an override: a node the graph author marked still pauses even
+// though the caller's run-level spec names a different node. Honouring only one
+// side would silently discard the other party's intent.
+func TestRunLevelUnionsWithNodeConfig(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "union",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"},"interrupt_before":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "union")
+
+	// The run-level spec names only B; A's own config must still park the walk.
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "union",
+		Kwargs: json.RawMessage(`{"interrupt_before":["B"]}`),
+	}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "A", 0)
+	if in := soleInterrupt(t, ctx, pool, rid); in.NodeID != "A" {
+		t.Errorf("interrupt node_id: want A (node config still honoured), got %q", in.NodeID)
+	}
+}
+
 // postResume drives the real HITL resume endpoint.
 func postResume(t *testing.T, tid, rid uuid.UUID, body string) {
 	t.Helper()

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -139,6 +139,13 @@ type GraphCommand struct {
 	GraphID     string          `json:"graph_id,omitempty"`
 	Input       json.RawMessage `json:"input,omitempty"`
 
+	// Kwargs is the run's LangGraph run-kwargs bag (runs.kwargs), carrying the
+	// knobs the CALLER set at create time rather than the ones the graph author
+	// baked into the node config — currently interrupt_before / interrupt_after.
+	// Absent when the run set none. See interruptPolicy (graph.go) for how the
+	// two axes combine.
+	Kwargs json.RawMessage `json:"kwargs,omitempty"`
+
 	// Resume is the LangGraph-style resume command carried by a run.resumed
 	// dispatch (nats.RunProcessor sets it from the run.resumed event payload's
 	// `command`). Present only when continuing a run that was paused at an
@@ -306,6 +313,10 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		// to run.failed via ackDecision.
 		return false, epoch, gerr
 	}
+
+	// Run-level interrupt spec from the caller's RunCreate, unioned with each
+	// node's own config during the walk (see graph.go interruptPolicy).
+	policy := decodeInterruptPolicy(cmd.Kwargs)
 
 	// Restore the walk state from the latest checkpoint, or start fresh.
 	channels := map[string]any{}
@@ -480,7 +491,7 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		// run to requires_action (+ record the interrupt), then park (ack). The
 		// run continues when a run.resumed redelivers this command with
 		// cmd.Resume set (handled before the loop).
-		if node.interruptsBefore() && !resumedPast[nodeID] {
+		if (node.interruptsBefore() || policy.interruptsBefore(nodeID)) && !resumedPast[nodeID] {
 			pauseFrontier := append([]string{nodeID}, frontier...)
 			// Node is the boundary node — the one that last completed, NOT the
 			// node we are pausing before. Interrupted != Node is exactly what
@@ -539,6 +550,11 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		// writes anyway, so the pause is ONE atomic write rather than two.
 		// Interrupted == Node marks it a pause-AFTER on restore.
 		pauseAfter, pauseReason := node.pausesAfter(writes)
+		if !pauseAfter && policy.interruptsAfter(nodeID) {
+			// The caller named this node on the run, even though the graph
+			// definition did not mark it.
+			pauseAfter, pauseReason = true, node.interruptReason()
+		}
 		markInterrupted := ""
 
 		if pauseAfter {
@@ -658,6 +674,9 @@ func (r *Runner) pauseAnnouncement(graph GraphDefinition, nodeID string, pausedA
 	}
 	_, reason = node.pausesAfter(channels)
 	if reason == "" {
+		// Either the trigger was the run-level spec (which carries no reason of
+		// its own) or the recomputation came up empty; the node's configured
+		// reason is the right fallback for both.
 		reason = node.interruptReason()
 	}
 	if calls := node.toolCalls(channels); len(calls) > 0 {


### PR DESCRIPTION
Replaces #233 (base branch was consumed by the stacked-merge sequence). **Identical tree** — #233's commit replayed onto the post-#234 main, verified with `git diff origin/feat/run-level-interrupts HEAD` (empty).

The second HITL axis. #231/#234 implemented interrupts as **graph node config**; this adds the one the API actually exposes: a **caller** naming nodes to interrupt at, for a single run.

`[spec-skip]` impl-only: fields already in OpenAPI and the generated types, column already in `postgres.d2`. No schema, migration, or generated-code change (codegen idempotent).

## The gap

`interrupt_before`/`interrupt_after` are declared on `RunCreateStateful` (`:3237`/`:3247`), `RunCreateStateless` (`:3422`/`:3432`) and `CronCreate` (`:2849`/`:2859`), and were already in `types_gen.go` (typed `interface{}` because of the `anyOf`) — **referenced by zero handlers**. `runs_create.go` inserted six columns and dropped the rest, so `{"interrupt_before":["gate"]}` got a `201` and vanished.

## No migration

`postgres.d2:120` declares `runs.kwargs` as *"jsonb — run kwargs (LangGraph)"*, and the column existed unused. These fields **are** LangGraph run kwargs.

## Design

Persisted at all **five** production create paths (stateful, stateless, batch, and the shared `createRun` behind both stream endpoints and wait).

`normalizeInterruptSpec` enforces the `anyOf` the generated `interface{}` erases: `"*"` or a list of non-empty node names, else **422 before any write** — a rejected create leaves no run and no `run.created` event. In batch it joins the existing up-front resolution pass, so one bad member rejects the whole batch atomically.

`run_processor` forwards `kwargs` on dispatch. The same enrich path serves `run.created` and `run.resumed`, so a resumed run still knows its spec — load-bearing for `"*"`, where the *next* node must pause too.

The worker decodes it into an `interruptPolicy` and **unions** it with node config: a node pauses if **either** says so. Neither overrides the other — both are affirmative statements that a human should see this node, and honouring one would silently discard the other party's intent. Empty list matches nothing; `"*"` matches everything.

Corrupt `kwargs` degrades to an empty policy rather than failing the run: the server validated at create, so anything unreadable at execution is an anomaly, and running without run-level interrupts beats dropping the run.

## Latent bug this makes reachable

`rows.go` `toAPI` unmarshalled kwargs into the **source `[]byte`** instead of the API map (`&r.Kwargs`, not `&run.Kwargs` — compare the `Metadata` line below it). It could not succeed regardless, since `encoding/json` decodes `[]byte` from a base64 *string*, and the error was discarded. **Every `Run` response reported `kwargs {}`** regardless of the column.

Invisible while nothing populated `kwargs`; this slice is what populates it. Pinned by asserting the create *response* echoes the spec, verified failing without the fix.

## Tests

3 unit + 4 integration. Run-level tests use a graph whose nodes carry **no** interrupt config, so every pause is attributable to the run-level spec alone.

## Not in this PR

`CronCreate.interrupt_*` stays deferred for a verified reason: the `crons` table has no `kwargs` column, so it needs a migration *plus* the scheduler engine. Also open: `RunCreate.command`, `RunCreate.checkpoint`.