### PR TITLE
feat: honor RunCreate.command (command-on-create)

### DIFF
--- a/controlplane/endpoints/runs_batch.go
+++ b/controlplane/endpoints/runs_batch.go
@@ -40,7 +40,7 @@ func (s *Server) RunsBatchCreate(c echo.Context) error {
 			return assistantRefHTTPError(err)
 		}
 		assistantIDs[i] = aid
-		kw, err := buildRunKwargs(r.InterruptBefore, r.InterruptAfter)
+		kw, err := buildRunKwargs(r.InterruptBefore, r.InterruptAfter, r.Command)
 		if err != nil {
 			return interruptSpecHTTPError(err)
 		}

--- a/controlplane/endpoints/runs_create.go
+++ b/controlplane/endpoints/runs_create.go
@@ -94,7 +94,7 @@ func (s *Server) RunsCreateOnThread(c echo.Context) error {
 	}
 	// Validate the run-level interrupt spec BEFORE the write, so a malformed
 	// one 422s without appending an event that would have to be rolled back.
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}
@@ -132,7 +132,7 @@ func (s *Server) RunsCreateStateless(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}

--- a/controlplane/endpoints/runs_kwargs.go
+++ b/controlplane/endpoints/runs_kwargs.go
@@ -35,8 +35,49 @@ var errInterruptSpecInvalid = errors.New("invalid interrupt spec")
 // runKwargs is the persisted shape of runs.kwargs. Fields are omitted when
 // absent so a run created without them stores {} rather than a bag of nulls.
 type runKwargs struct {
-	InterruptBefore any `json:"interrupt_before,omitempty"`
-	InterruptAfter  any `json:"interrupt_after,omitempty"`
+	InterruptBefore any             `json:"interrupt_before,omitempty"`
+	InterruptAfter  any             `json:"interrupt_after,omitempty"`
+	Command         json.RawMessage `json:"command,omitempty"`
+}
+
+// normalizeCommand validates RunCreate.command — a LangGraph Command supplied
+// at CREATE time rather than at resume. The schema is `anyOf: [Command, null]`,
+// so the only structural requirement is that it be a JSON object; its fields
+// (update / resume / goto) are the worker's contract and are decoded there
+// (worker/command.go), which is also where an unknown goto target is caught
+// against the actual graph.
+//
+// Validating shape here rather than semantics keeps the split honest: the
+// server knows the wire schema, only the worker knows the graph.
+func normalizeCommand(v any) (json.RawMessage, error) {
+	if v == nil {
+		return nil, nil
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: command: want an object, got %T", errInterruptSpecInvalid, v)
+	}
+	if len(obj) == 0 {
+		// An empty command is inert; store nothing rather than an empty object
+		// so the run looks identical to one created without a command.
+		return nil, nil
+	}
+	// Unknown fields are deliberately ACCEPTED and stored, not rejected. The
+	// Command schema does not set additionalProperties: false, and in OpenAPI an
+	// absent additionalProperties means extra properties are permitted — so
+	// 422ing them would be stricter than the contract and would break a client
+	// written against a later Command with a field we do not know yet. They are
+	// inert: the worker decodes only update/resume/goto (worker/command.go).
+	//
+	// The cost is that a typo such as {"resmue": ...} is silently ineffective.
+	// That is the contract's tradeoff to make, not this handler's — contrast
+	// interrupt_before, where rejection IS schema-mandated because its string
+	// branch is an explicit single-value enum.
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("%w: command: %s", errInterruptSpecInvalid, err)
+	}
+	return b, nil
 }
 
 // normalizeInterruptSpec validates one run-level interrupt field and returns
@@ -75,11 +116,11 @@ func normalizeInterruptSpec(field string, v any) (any, error) {
 	}
 }
 
-// buildRunKwargs validates the run-level interrupt fields and renders the
-// runs.kwargs jsonb. Absent on both sides yields "{}" — the column default —
-// so a run that sets neither is indistinguishable from one created before this
-// slice existed.
-func buildRunKwargs(interruptBefore, interruptAfter any) ([]byte, error) {
+// buildRunKwargs validates the run-level LangGraph fields and renders the
+// runs.kwargs jsonb. All absent yields "{}" — the column default — so a run
+// that sets none is indistinguishable from one created before these fields
+// were honored.
+func buildRunKwargs(interruptBefore, interruptAfter, command any) ([]byte, error) {
 	before, err := normalizeInterruptSpec("interrupt_before", interruptBefore)
 	if err != nil {
 		return nil, err
@@ -88,10 +129,14 @@ func buildRunKwargs(interruptBefore, interruptAfter any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if before == nil && after == nil {
+	cmd, err := normalizeCommand(command)
+	if err != nil {
+		return nil, err
+	}
+	if before == nil && after == nil && cmd == nil {
 		return []byte("{}"), nil
 	}
-	b, err := json.Marshal(runKwargs{InterruptBefore: before, InterruptAfter: after})
+	b, err := json.Marshal(runKwargs{InterruptBefore: before, InterruptAfter: after, Command: cmd})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", errInterruptSpecInvalid, err)
 	}

--- a/controlplane/endpoints/runs_kwargs_integration_test.go
+++ b/controlplane/endpoints/runs_kwargs_integration_test.go
@@ -114,6 +114,89 @@ func TestRunCreatePersistsInterruptSpec(t *testing.T) {
 	}
 }
 
+// TestRunCreatePersistsCommand proves RunCreate.command survives create. It is
+// declared on RunCreateStateful/RunCreateStateless and was in the generated
+// types all along, but no handler read it, so it vanished behind a 201.
+func TestRunCreatePersistsCommand(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistantGraph(t, ctx, "agent", "a", "2020-01-01T00:00:00Z")
+
+	post := func(body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/runs", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	rec := post(fmt.Sprintf(
+		`{"assistant_id":%q,"command":{"goto":"b","update":{"x":1}}}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create with command: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var run Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var raw []byte
+	if err := testPool.QueryRow(ctx, `SELECT kwargs FROM runs WHERE id=$1`, run.RunId).Scan(&raw); err != nil {
+		t.Fatalf("select kwargs: %v", err)
+	}
+	var kw struct {
+		Command map[string]any `json:"command"`
+	}
+	if err := json.Unmarshal(raw, &kw); err != nil {
+		t.Fatalf("decode kwargs: %v", err)
+	}
+	if kw.Command["goto"] != "b" {
+		t.Errorf("kwargs.command.goto: want b, got %v", kw.Command["goto"])
+	}
+	if upd, _ := kw.Command["update"].(map[string]any); upd["x"] != float64(1) {
+		t.Errorf("kwargs.command.update: want {x:1}, got %v", kw.Command["update"])
+	}
+
+	// An empty command stores nothing, so the run is indistinguishable from one
+	// created without the field at all.
+	rec = post(fmt.Sprintf(`{"assistant_id":%q,"command":{}}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("empty command: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `SELECT kwargs FROM runs WHERE id=$1`, run.RunId).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "{}" {
+		t.Errorf("empty command must store nothing, got kwargs %s", raw)
+	}
+
+	// A value that is not an object violates the schema (Command is
+	// type: object) and is rejected.
+	for _, bad := range []string{
+		`{"assistant_id":%q,"command":"not-an-object"}`,
+		`{"assistant_id":%q,"command":[1,2]}`,
+		`{"assistant_id":%q,"command":7}`,
+	} {
+		if rec := post(fmt.Sprintf(bad, aid)); rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("%s: want 422, got %d: %s", bad, rec.Code, rec.Body.String())
+		}
+	}
+
+	// An UNKNOWN field is accepted, not rejected: the Command schema does not
+	// set additionalProperties: false, so refusing it would be stricter than the
+	// contract and would break a client using a newer Command field. It is
+	// stored verbatim and is inert at execution.
+	rec = post(fmt.Sprintf(`{"assistant_id":%q,"command":{"future_field":true}}`, aid))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("unknown command field: want 201 (additionalProperties permitted), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestRunCreateRejectsBadInterruptSpec pins that a value which parses as JSON
 // but violates the schema's anyOf is 422 (unprocessable), not a 500 and not a
 // silent drop — and that the rejection happens BEFORE any write, so no run and

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -296,7 +296,7 @@ func (s *Server) RunsCreateAndStream(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}
@@ -322,7 +322,7 @@ func (s *Server) RunsStatelessStream(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}
@@ -439,7 +439,7 @@ func (s *Server) RunsStatelessWait(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}

--- a/controlplane/worker/create_command_integration_test.go
+++ b/controlplane/worker/create_command_integration_test.go
@@ -1,0 +1,160 @@
+// Integration coverage for RunCreate.command — a LangGraph Command supplied at
+// CREATE time rather than at resume. Declared on RunCreateStateful and
+// RunCreateStateless and present in the generated types all along, but read by
+// no handler, so it was accepted with a 201 and silently dropped.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// TestCreateCommandGotoOverridesEntry proves command.goto on create starts the
+// walk at a named node instead of the graph's entry nodes. A alone would run
+// first; the command sends the run straight to C, so A never executes.
+func TestCreateCommandGotoOverridesEntry(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "create-goto",
+		`[{"id":"A","type":"tool","config":{"set":{"went":"a"}}},
+		  {"id":"C","type":"tool","config":{"set":{"went":"c"}}}]`,
+		`[]`)
+	runner, _ := newLiveRunner(t, ctx, "create-goto")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "create-goto",
+		Kwargs: json.RawMessage(`{"command":{"goto":"C"}}`),
+	}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 0) // entry node skipped
+	assertNodeCount(t, ctx, pool, rid, "C", 1)
+}
+
+// TestCreateCommandUpdateBeatsInput pins the precedence between the two ways a
+// fresh run can seed state: input is the general seed, command.update is the
+// explicit instruction, so update wins on a shared key. The B edge routes on
+// that key, so B running proves which value survived.
+func TestCreateCommandUpdateBeatsInput(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "create-update",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"}}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B","condition":"mode == fast"}]`)
+	runner, _ := newLiveRunner(t, ctx, "create-update")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "create-update",
+		Input:  json.RawMessage(`{"mode":"slow"}`),
+		Kwargs: json.RawMessage(`{"command":{"update":{"mode":"fast"}}}`),
+	}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	// B only runs if command.update overwrote the input's mode=slow.
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+}
+
+// TestCreateCommandNotReappliedOnRedelivery is the durability guard: the create
+// command seeds a FRESH walk only. A redelivery that restores a checkpoint must
+// not re-apply it, or a goto would rewind the frontier and an update would
+// clobber state the walk has since moved past.
+//
+// The runner crashes after node A (StopAfterNode), then a second delivery of
+// the same command resumes from the checkpoint. If the create command were
+// re-applied, its goto would send the walk back to A — so A running exactly
+// once is the proof it was not.
+func TestCreateCommandNotReappliedOnRedelivery(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "create-redeliver",
+		`[{"id":"A","type":"tool","config":{"set":{"n":1}}},
+		  {"id":"B","type":"tool","config":{"set":{"n":2}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	cmd := worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "create-redeliver",
+		Kwargs: json.RawMessage(`{"command":{"goto":"A"}}`),
+	}
+
+	runner1, _ := newLiveRunner(t, ctx, "create-redeliver")
+	runner1.StopAfterNode = 0 // die after A completes, before B
+	if acked, _, err := runner1.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("first ProcessOne: %v", err)
+	} else if acked {
+		t.Fatal("first ProcessOne: want acked=false (simulated crash)")
+	}
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	// Redelivery to a fresh runner: resumes from the checkpoint.
+	runner2, _ := newLiveRunner(t, ctx, "create-redeliver")
+	if _, _, err := runner2.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("second ProcessOne: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1) // THE PROOF: goto did not rewind
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+}
+
+// TestCreateCommandUnknownGotoFailsRun pins that a create-time goto naming a
+// node the graph lacks is a deterministic client error — run.failed and acked,
+// not a redelivery loop and not a silent fall back to the entry nodes.
+func TestCreateCommandUnknownGotoFailsRun(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "create-bad",
+		`[{"id":"A","type":"tool","config":{"set":{"went":"a"}}}]`, `[]`)
+	runner, _ := newLiveRunner(t, ctx, "create-bad")
+
+	acked, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "create-bad",
+		Kwargs: json.RawMessage(`{"command":{"goto":"NOPE"}}`),
+	})
+	if err != nil {
+		t.Fatalf("ProcessOne: unexpected transport error: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (poison, no redelivery), got false")
+	}
+
+	assertRunStatus(t, ctx, pool, rid, "failed")
+	assertNodeCount(t, ctx, pool, rid, "A", 0) // did NOT silently fall back to entry
+}
+
+// TestNoCreateCommandIsInert pins that a run with no command behaves exactly as
+// before this field was honored: entry nodes, input-seeded channels.
+func TestNoCreateCommandIsInert(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+	runner, _ := newLiveRunner(t, ctx, "counter")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter",
+		Kwargs: json.RawMessage(`{"interrupt_before":[]}`), // kwargs present, no command
+	}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+}

--- a/controlplane/worker/graph.go
+++ b/controlplane/worker/graph.go
@@ -126,6 +126,27 @@ func contains(list []string, s string) bool {
 	return false
 }
 
+// decodeCreateCommand reads RunCreate.command out of the run-kwargs bag — a
+// LangGraph Command supplied at CREATE time rather than at resume. Returns nil
+// when the run carried none. The server validated its shape at create
+// (endpoints normalizeCommand); its fields are decoded by resumeCommand, the
+// same type the resume path uses, so create and resume cannot drift.
+func decodeCreateCommand(kwargs json.RawMessage) json.RawMessage {
+	if len(kwargs) == 0 {
+		return nil
+	}
+	var bag struct {
+		Command json.RawMessage `json:"command,omitempty"`
+	}
+	if err := json.Unmarshal(kwargs, &bag); err != nil {
+		return nil
+	}
+	if len(bag.Command) == 0 || string(bag.Command) == "null" {
+		return nil
+	}
+	return bag.Command
+}
+
 // decodeInterruptPolicy reads the run-kwargs bag into an interruptPolicy. A
 // malformed bag is NOT an error: the server validated the spec at create time,
 // so anything unreadable here is a corrupt or hand-edited row, and dropping a

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -367,6 +367,34 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 			}
 		}
 		frontier = graph.entryNodes()
+
+		// RunCreate.command: a LangGraph Command supplied at CREATE time. It is
+		// applied ONLY on a fresh walk — inside this branch, so a redelivery
+		// that restores a checkpoint cannot re-apply it and re-seed state the
+		// walk has since moved past.
+		//
+		// Applied AFTER input seeding so an explicit command.update wins over
+		// the same key in input, and its goto replaces the graph's entry nodes
+		// (start this run at a named node instead of the beginning) rather than
+		// adding to them.
+		if raw := decodeCreateCommand(cmd.Kwargs); raw != nil {
+			var create resumeCommand
+			if uerr := json.Unmarshal(raw, &create); uerr != nil {
+				return false, epoch, fmt.Errorf("runner: decode create command: %w", uerr)
+			}
+			targets, aerr := create.apply(channels)
+			if aerr != nil {
+				return r.failRun(ctx, cmd.RunID, epoch, aerr.Error())
+			}
+			if len(targets.Nodes) > 0 {
+				for _, n := range targets.Nodes {
+					if _, ok := graph.node(n); !ok {
+						return r.failRun(ctx, cmd.RunID, epoch, fmt.Sprintf("command.goto names unknown node %q", n))
+					}
+				}
+				frontier = targets.Nodes
+			}
+		}
 	}
 
 	// HITL resume: a run.resumed dispatch carries cmd.Resume, the LangGraph


### PR DESCRIPTION
Closes the last of the silently-dropped `RunCreate` contract fields. Same class as #231 (node triggers), #234 (resume/goto) and #235 (run-level interrupts).

`[spec-skip]` impl-only: field already in OpenAPI and the generated types, column already in `postgres.d2`. No schema, migration, or generated-code change (codegen idempotent).

## The gap

`RunCreate.command` is declared on `RunCreateStateful` and `RunCreateStateless`, and was in `types_gen.go` (`:1309`/`:1385`, typed `interface{}` because of `anyOf[Command,null]`) — **referenced by zero handlers**. A client's `{"command":{"goto":"b"}}` got a `201` and vanished.

## Reuse, not new machinery

- **Storage**: the `runs.kwargs` bag from #235, so no migration and no new dispatch plumbing — `run_processor` already forwards kwargs.
- **Execution**: #234's `resumeCommand`, wholesale. Create and resume decode the **same type**, so the two paths cannot drift in what a `Command` means.

## Semantics

Applied **only on a fresh walk** (inside the no-checkpoint branch), so a redelivery restoring a checkpoint cannot re-apply it and rewind the frontier or clobber state the walk has moved past.

Applied **after** input seeding, so `command.update` wins over the same key in `input` — the explicit instruction beats the general seed — and `command.goto` **replaces** the graph's entry nodes rather than adding to them, starting the run at a named node. An unknown `goto` target is a deterministic client error → `run.failed` + ack, never a silent fall back to the entry nodes.

## Validation is deliberately shape-only

A non-object `command` violates the schema (`Command` is `type: object`) and 422s.

An unknown **field** does not. The `Command` schema does **not** set `additionalProperties: false`, and in OpenAPI that means extra properties are permitted — so rejecting them would be stricter than the contract and would break a client written against a later `Command`. They are stored verbatim and inert at execution (the worker decodes only `update`/`resume`/`goto`).

This is the **opposite** call from `interrupt_before`, where rejecting a non-`"*"` string *is* schema-mandated because that branch is an explicit single-value enum. The difference is in the schema, not in taste. I'd initially written this the strict way and corrected it on review.

## Tests

5 worker integration + server-side persistence/validation. The two worth reading:

- **`TestCreateCommandUpdateBeatsInput`** routes the contested key through a conditional edge, so which value survived is *observable* rather than asserted on internals.
- **`TestCreateCommandNotReappliedOnRedelivery`** uses `StopAfterNode` plus a `goto` that would rewind to `A`; `A` running exactly once is the proof the create command wasn't re-applied.

## Still open after this

`CronCreate.interrupt_*` and `CronCreate.command` (crons has no `kwargs` column — needs a migration plus the scheduler engine). `RunCreate.checkpoint`.

Pre-existing, unchanged: lost `execution_history` row when `WriteCheckpoint` commits then `NodeCompleted` fails; no `interrupt.created`/`interrupt.resolved` publishes despite the declared `INTERRUPTS` stream; worker never sends `execution.node_started`/`node_failed` though the server handles both.

Note: `runs.output` (`graph-engine.d2` §3 `end_ex` "freeze output channel → run.output") is **lower value than previously flagged** — I checked, and `output` is absent from the OpenAPI `Run` schema entirely, so writing it would populate a column nothing exposes. A run's result already surfaces via the thread-state/checkpoint path.