### PR TITLE
fix(endpoints): validate thread/checkpoint identifiers at the API boundary

### DIFF
--- a/controlplane/endpoints/path_params.go
+++ b/controlplane/endpoints/path_params.go
@@ -1,0 +1,62 @@
+// Path-parameter parsing at the API boundary.
+//
+// Postgres, not Go, was validating these. A handler that interpolated a raw
+// path parameter into a query let the DRIVER reject it, which surfaced as a 500
+// carrying the raw SQLSTATE text:
+//
+//	GET /threads/{tid}/state/not-a-bigint
+//	  500 {"message":"ERROR: invalid input syntax for type bigint: \"not-a-bigint\" (SQLSTATE 22P02)"}
+//	GET /threads/not-a-uuid/state
+//	  500 {"message":"ERROR: invalid input syntax for type uuid: \"not-a-uuid\" (SQLSTATE 22P02)"}
+//
+// Three things are wrong with that: a client error is reported as a server
+// error, the internal schema (column names and types) leaks to the caller, and
+// 500 is not in the endpoint's declared response set.
+//
+// STATUS CHOICE: 422, not 400 and not 404. The thread state/history/checkpoint
+// paths declare exactly two responses in the OpenAPI —
+// "200" Success and "422" Validation Error (duragraph-latest.yaml, the
+// /threads/{thread_id}/state, /state/{checkpoint_id}, /state/checkpoint and
+// /history paths). A malformed identifier IS a validation error, and returning
+// an undeclared 400 would violate the contract the same way an undeclared 404
+// would — the precedent set when assistants get_versions was made to return an
+// empty 200 rather than a 404 the schema did not declare.
+package endpoints
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// pathUUID parses a UUID-typed path parameter, 422ing a malformed one before it
+// can reach a uuid column. The message names the parameter but never the
+// column or the driver error.
+func pathUUID(c echo.Context, name string) (uuid.UUID, error) {
+	raw := c.Param(name)
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.UUID{}, echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid "+name+": must be a UUID")
+	}
+	return id, nil
+}
+
+// parseCheckpointID parses a checkpoint identifier. The OpenAPI types
+// checkpoint_id as a STRING (CheckpointConfig.checkpoint_id), but a checkpoint
+// is a snapshots row and snapshots.id is BIGSERIAL — so the string must denote
+// a bigint. Anything else, including a value too large for int64, is a
+// validation error rather than a lookup that happens to miss.
+//
+// Kept separate from pathUUID because the id travels two ways: as a path
+// parameter (GET /threads/{id}/state/{checkpoint_id}) and inside a request body
+// (POST /threads/{id}/state/checkpoint carries a CheckpointConfig), and the
+// body form has no echo.Context to read from.
+func parseCheckpointID(raw string) (int64, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid checkpoint_id: must be a checkpoint identifier")
+	}
+	return id, nil
+}

--- a/controlplane/endpoints/path_params_integration_test.go
+++ b/controlplane/endpoints/path_params_integration_test.go
@@ -1,0 +1,96 @@
+package endpoints
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMalformedIdentifiersAreValidationErrors pins the API boundary for the
+// thread state/checkpoint/history reads.
+//
+// These handlers used to interpolate raw path parameters straight into SQL and
+// let Postgres do the validating, so every malformed identifier came back as a
+// 500 carrying the raw driver text — e.g.
+//
+//	{"message":"ERROR: invalid input syntax for type bigint: \"not-a-bigint\" (SQLSTATE 22P02)"}
+//
+// which reports a client error as a server error AND leaks the column type.
+//
+// 422 is the contract-declared answer: these paths declare exactly "200" and
+// "422" in the OpenAPI, so a 400 would be as undeclared as the 500 it replaces.
+func TestMalformedIdentifiersAreValidationErrors(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	var tid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, method, path, body string }{
+		{"bad checkpoint id in path", "GET", "/api/v1/threads/" + tid + "/state/not-a-bigint", ""},
+		{"checkpoint id out of int64 range", "GET", "/api/v1/threads/" + tid + "/state/99999999999999999999", ""},
+		{"bad thread id on get_state", "GET", "/api/v1/threads/not-a-uuid/state", ""},
+		{"bad thread id on get_history", "GET", "/api/v1/threads/not-a-uuid/history", ""},
+		{"bad thread id on get_checkpoint_state", "GET", "/api/v1/threads/not-a-uuid/state/1", ""},
+		{"bad checkpoint id in body", "POST", "/api/v1/threads/" + tid + "/state/checkpoint", `{"checkpoint":{"checkpoint_id":"abc"}}`},
+		{"bad thread id on create_checkpoint", "POST", "/api/v1/threads/not-a-uuid/state/checkpoint", `{"checkpoint":{}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Errorf("want 422, got %d: %s", rec.Code, rec.Body.String())
+			}
+			// The response must not leak the schema or the driver.
+			for _, leak := range []string{"SQLSTATE", "invalid input syntax", "bigint", "uuid:", "snapshots"} {
+				if strings.Contains(rec.Body.String(), leak) {
+					t.Errorf("response leaks internals (%q): %s", leak, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestWellFormedIdentifiersStillResolve is the companion guard: tightening the
+// boundary must not turn a legitimate miss into a validation error. A
+// well-formed id that simply matches nothing keeps its existing behavior.
+func TestWellFormedIdentifiersStillResolve(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	var tid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name, method, path, body string
+		want                     int
+	}{
+		{"unknown but valid checkpoint id", "GET", "/api/v1/threads/" + tid + "/state/424242", "", http.StatusNotFound},
+		{"unknown but valid thread id", "GET", "/api/v1/threads/11111111-1111-1111-1111-111111111111/state", "", http.StatusNotFound},
+		{"history on a thread with no snapshots", "GET", "/api/v1/threads/" + tid + "/history", "", http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			e.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Errorf("want %d, got %d: %s", tc.want, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/controlplane/endpoints/threads_state.go
+++ b/controlplane/endpoints/threads_state.go
@@ -23,7 +23,10 @@ import (
 // chronological key. GET /threads/{id}/state -> 200 ThreadState / 404.
 func (s *Server) ThreadsGetState(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots
@@ -48,8 +51,14 @@ func (s *Server) ThreadsGetState(c echo.Context) error {
 // GET /threads/{id}/state/{checkpoint_id} -> 200 ThreadState / 404.
 func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
-	ckpt := c.Param("checkpoint_id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
+	ckpt, err := parseCheckpointID(c.Param("checkpoint_id"))
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots
@@ -79,22 +88,29 @@ func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
 // POST /threads/{id}/state/checkpoint -> 200 ThreadState / 404.
 func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
 	var req ThreadStateCheckpointRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	var (
-		rows pgx.Rows
-		err  error
-	)
+	var rows pgx.Rows
 	if req.Checkpoint.CheckpointId != nil && *req.Checkpoint.CheckpointId != "" {
+		// Body-carried twin of the path param, so it needs the same guard: a
+		// CheckpointConfig.checkpoint_id that is not a checkpoint identifier is
+		// a validation error, not a 500 from the driver.
+		ckpt, perr := parseCheckpointID(*req.Checkpoint.CheckpointId)
+		if perr != nil {
+			return perr
+		}
 		rows, err = s.Tenant.Query(ctx, `
 			SELECT id, stream_id, aggregate_id, version, state, created_at
 			FROM snapshots
 			WHERE id = $1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = $2)`,
-			*req.Checkpoint.CheckpointId, tid)
+			ckpt, tid)
 	} else {
 		rows, err = s.Tenant.Query(ctx, `
 			SELECT id, stream_id, aggregate_id, version, state, created_at
@@ -121,7 +137,10 @@ func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
 // per-stream). GET /threads/{id}/history -> 200 []ThreadState.
 func (s *Server) ThreadsGetHistory(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots


### PR DESCRIPTION
**Step 1 of 3** toward `RunCreate.checkpoint`. Standalone — no dependency on the rest.

## The bug

The thread state/checkpoint/history reads interpolated raw path parameters straight into SQL and let **Postgres** do the validating:

```
GET /threads/{tid}/state/not-a-bigint
  500 {"message":"ERROR: invalid input syntax for type bigint: \"not-a-bigint\" (SQLSTATE 22P02)"}
GET /threads/not-a-uuid/state
  500 {"message":"ERROR: invalid input syntax for type uuid: \"not-a-uuid\" (SQLSTATE 22P02)"}
```

Three things wrong: a client error reported as a server error, the internal schema (column names and types) leaked to the caller, and `500` is not in these endpoints' declared response set.

## Blast radius was wider than the case that surfaced it

I found this while scoping `RunCreate.checkpoint` and initially thought it was one endpoint. Probing found **all seven** malformed-identifier paths across the four handlers returning 500, on two axes — `checkpoint_id` (bigint, including values out of `int64` range) and `thread_id` (uuid). `threads_state.go` did **no parsing at all**, unlike the rest of the package, which already parses via `uuid.Parse`.

## Why 422, not 400 or 404

`/threads/{thread_id}/state`, `/state/{checkpoint_id}`, `/state/checkpoint` and `/history` each declare exactly two responses in the OpenAPI: `"200"` Success and `"422"` Validation Error.

A malformed identifier **is** a validation error, and an undeclared 400 would violate the contract the same way the 500 does. Precedent is #228, where `get_versions` returns an empty 200 rather than a 404 the schema doesn't declare.

## Note on the underlying mismatch

The OpenAPI types `checkpoint_id` as a **string**, but a checkpoint is a `snapshots` row and `snapshots.id` is `BIGSERIAL` — so the string must denote a bigint. That mismatch is *why* this class of 500 existed, and it's the same one step 3 will have to handle deliberately.

`parseCheckpointID` is separate from `pathUUID` because the id travels two ways: as a path parameter, and inside a request body (`POST /state/checkpoint` carries a `CheckpointConfig`), where there's no `echo.Context`. Both forms are now guarded.

## Tests

7 malformed cases asserting **422** *and* that the body leaks no `SQLSTATE`, driver text, column type or table name. Plus a companion guard that tightening the boundary didn't turn a legitimate miss into a validation error — unknown-but-valid ids keep their existing 404/200.

## Deliberately not changed

- These handlers return **404 on no-rows**, which is *also* undeclared by the schema. Left alone: changing it is a behavior change for existing clients, not a bug fix.
- The same raw-parameter pattern exists in `assistants_graph.go` and `workers.go` (the internal worker protocol). Untouched to keep this standalone — worth a follow-up.

`[spec-skip]` impl-only; codegen idempotent.