### PR TITLE
feat: honor RunCreate.checkpoint (resume a new run from a prior checkpoint)

### DIFF
--- a/controlplane/endpoints/path_params.go
+++ b/controlplane/endpoints/path_params.go
@@ -1,0 +1,62 @@
+// Path-parameter parsing at the API boundary.
+//
+// Postgres, not Go, was validating these. A handler that interpolated a raw
+// path parameter into a query let the DRIVER reject it, which surfaced as a 500
+// carrying the raw SQLSTATE text:
+//
+//	GET /threads/{tid}/state/not-a-bigint
+//	  500 {"message":"ERROR: invalid input syntax for type bigint: \"not-a-bigint\" (SQLSTATE 22P02)"}
+//	GET /threads/not-a-uuid/state
+//	  500 {"message":"ERROR: invalid input syntax for type uuid: \"not-a-uuid\" (SQLSTATE 22P02)"}
+//
+// Three things are wrong with that: a client error is reported as a server
+// error, the internal schema (column names and types) leaks to the caller, and
+// 500 is not in the endpoint's declared response set.
+//
+// STATUS CHOICE: 422, not 400 and not 404. The thread state/history/checkpoint
+// paths declare exactly two responses in the OpenAPI —
+// "200" Success and "422" Validation Error (duragraph-latest.yaml, the
+// /threads/{thread_id}/state, /state/{checkpoint_id}, /state/checkpoint and
+// /history paths). A malformed identifier IS a validation error, and returning
+// an undeclared 400 would violate the contract the same way an undeclared 404
+// would — the precedent set when assistants get_versions was made to return an
+// empty 200 rather than a 404 the schema did not declare.
+package endpoints
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// pathUUID parses a UUID-typed path parameter, 422ing a malformed one before it
+// can reach a uuid column. The message names the parameter but never the
+// column or the driver error.
+func pathUUID(c echo.Context, name string) (uuid.UUID, error) {
+	raw := c.Param(name)
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.UUID{}, echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid "+name+": must be a UUID")
+	}
+	return id, nil
+}
+
+// parseCheckpointID parses a checkpoint identifier. The OpenAPI types
+// checkpoint_id as a STRING (CheckpointConfig.checkpoint_id), but a checkpoint
+// is a snapshots row and snapshots.id is BIGSERIAL — so the string must denote
+// a bigint. Anything else, including a value too large for int64, is a
+// validation error rather than a lookup that happens to miss.
+//
+// Kept separate from pathUUID because the id travels two ways: as a path
+// parameter (GET /threads/{id}/state/{checkpoint_id}) and inside a request body
+// (POST /threads/{id}/state/checkpoint carries a CheckpointConfig), and the
+// body form has no echo.Context to read from.
+func parseCheckpointID(raw string) (int64, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid checkpoint_id: must be a checkpoint identifier")
+	}
+	return id, nil
+}

--- a/controlplane/endpoints/path_params_integration_test.go
+++ b/controlplane/endpoints/path_params_integration_test.go
@@ -1,0 +1,96 @@
+package endpoints
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMalformedIdentifiersAreValidationErrors pins the API boundary for the
+// thread state/checkpoint/history reads.
+//
+// These handlers used to interpolate raw path parameters straight into SQL and
+// let Postgres do the validating, so every malformed identifier came back as a
+// 500 carrying the raw driver text — e.g.
+//
+//	{"message":"ERROR: invalid input syntax for type bigint: \"not-a-bigint\" (SQLSTATE 22P02)"}
+//
+// which reports a client error as a server error AND leaks the column type.
+//
+// 422 is the contract-declared answer: these paths declare exactly "200" and
+// "422" in the OpenAPI, so a 400 would be as undeclared as the 500 it replaces.
+func TestMalformedIdentifiersAreValidationErrors(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	var tid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, method, path, body string }{
+		{"bad checkpoint id in path", "GET", "/api/v1/threads/" + tid + "/state/not-a-bigint", ""},
+		{"checkpoint id out of int64 range", "GET", "/api/v1/threads/" + tid + "/state/99999999999999999999", ""},
+		{"bad thread id on get_state", "GET", "/api/v1/threads/not-a-uuid/state", ""},
+		{"bad thread id on get_history", "GET", "/api/v1/threads/not-a-uuid/history", ""},
+		{"bad thread id on get_checkpoint_state", "GET", "/api/v1/threads/not-a-uuid/state/1", ""},
+		{"bad checkpoint id in body", "POST", "/api/v1/threads/" + tid + "/state/checkpoint", `{"checkpoint":{"checkpoint_id":"abc"}}`},
+		{"bad thread id on create_checkpoint", "POST", "/api/v1/threads/not-a-uuid/state/checkpoint", `{"checkpoint":{}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Errorf("want 422, got %d: %s", rec.Code, rec.Body.String())
+			}
+			// The response must not leak the schema or the driver.
+			for _, leak := range []string{"SQLSTATE", "invalid input syntax", "bigint", "uuid:", "snapshots"} {
+				if strings.Contains(rec.Body.String(), leak) {
+					t.Errorf("response leaks internals (%q): %s", leak, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestWellFormedIdentifiersStillResolve is the companion guard: tightening the
+// boundary must not turn a legitimate miss into a validation error. A
+// well-formed id that simply matches nothing keeps its existing behavior.
+func TestWellFormedIdentifiersStillResolve(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	var tid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name, method, path, body string
+		want                     int
+	}{
+		{"unknown but valid checkpoint id", "GET", "/api/v1/threads/" + tid + "/state/424242", "", http.StatusNotFound},
+		{"unknown but valid thread id", "GET", "/api/v1/threads/11111111-1111-1111-1111-111111111111/state", "", http.StatusNotFound},
+		{"history on a thread with no snapshots", "GET", "/api/v1/threads/" + tid + "/history", "", http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			e.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Errorf("want %d, got %d: %s", tc.want, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/controlplane/endpoints/runs_batch.go
+++ b/controlplane/endpoints/runs_batch.go
@@ -40,7 +40,7 @@ func (s *Server) RunsBatchCreate(c echo.Context) error {
 			return assistantRefHTTPError(err)
 		}
 		assistantIDs[i] = aid
-		kw, err := buildRunKwargs(r.InterruptBefore, r.InterruptAfter, r.Command)
+		kw, err := buildRunKwargs(r.InterruptBefore, r.InterruptAfter, r.Command, nil)
 		if err != nil {
 			return interruptSpecHTTPError(err)
 		}

--- a/controlplane/endpoints/runs_create.go
+++ b/controlplane/endpoints/runs_create.go
@@ -92,11 +92,21 @@ func (s *Server) RunsCreateOnThread(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	// Validate the run-level interrupt spec BEFORE the write, so a malformed
-	// one 422s without appending an event that would have to be rolled back.
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
+	// Validate the run-level knobs BEFORE the write, so a malformed one 422s
+	// without appending an event that would have to be rolled back.
+	checkpoint, err := normalizeCheckpoint(req.Checkpoint, pathID)
 	if err != nil {
 		return interruptSpecHTTPError(err)
+	}
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command, checkpoint)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
+	// Resolve the checkpoint against this thread up front: an unusable
+	// reference must 404 here rather than become a queued run its worker can
+	// only fail.
+	if err := s.verifyCheckpointOwned(ctx, checkpoint, pathID); err != nil {
+		return checkpointHTTPError(err)
 	}
 
 	aggID := uuid.New()
@@ -132,7 +142,7 @@ func (s *Server) RunsCreateStateless(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command, nil)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}

--- a/controlplane/endpoints/runs_kwargs.go
+++ b/controlplane/endpoints/runs_kwargs.go
@@ -17,11 +17,14 @@
 package endpoints
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -37,6 +40,7 @@ var errInterruptSpecInvalid = errors.New("invalid interrupt spec")
 type runKwargs struct {
 	InterruptBefore any             `json:"interrupt_before,omitempty"`
 	InterruptAfter  any             `json:"interrupt_after,omitempty"`
+	Checkpoint      json.RawMessage `json:"checkpoint_id,omitempty"`
 	Command         json.RawMessage `json:"command,omitempty"`
 }
 
@@ -116,11 +120,58 @@ func normalizeInterruptSpec(field string, v any) (any, error) {
 	}
 }
 
+// normalizeCheckpoint validates RunCreate.checkpoint — the checkpoint a new run
+// resumes from, which was written by a PREVIOUS run on the same thread
+// (snapshots.aggregate_id is a run id, so a checkpoint belongs to a run, and the
+// thread is reached by joining through runs).
+//
+// Two of CheckpointConfig's four fields are REJECTED rather than ignored:
+//
+//   - checkpoint_ns is LangGraph's subgraph namespacing, and this engine has no
+//     subgraph concept at all — GraphDefinition does not nest, and sub-worker
+//     delegation is still TARGET in graph-engine.d2 §8. Storing a namespace we
+//     cannot honor would be the silent-drop bug this whole line of work exists
+//     to remove; adding a column for it would bake in a field with no defined
+//     semantics. An explicit 422 says what is true: not supported yet.
+//   - checkpoint_map ("checkpoint-specific data") likewise has no defined
+//     meaning here.
+//
+// checkpoint_id is REQUIRED when a checkpoint config is supplied. The schema
+// marks it optional, but the field means "the checkpoint to resume from" — with
+// no id there is no checkpoint, and quietly treating the config as absent would
+// again be a silent drop. This is a judgment call in favour of an explicit
+// error over an inert request.
+//
+// thread_id, if supplied, must agree with the run's own thread; a contradiction
+// is rejected rather than silently resolved in favour of one of them.
+func normalizeCheckpoint(cfg *CheckpointConfig, threadID uuid.UUID) (json.RawMessage, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	if cfg.CheckpointNs != nil && *cfg.CheckpointNs != "" {
+		return nil, fmt.Errorf("%w: checkpoint.checkpoint_ns is not supported: this engine has no subgraphs", errInterruptSpecInvalid)
+	}
+	if cfg.CheckpointMap != nil && len(*cfg.CheckpointMap) > 0 {
+		return nil, fmt.Errorf("%w: checkpoint.checkpoint_map is not supported", errInterruptSpecInvalid)
+	}
+	if cfg.ThreadId != nil && *cfg.ThreadId != "" && *cfg.ThreadId != threadID.String() {
+		return nil, fmt.Errorf("%w: checkpoint.thread_id %q does not match the run's thread %s", errInterruptSpecInvalid, *cfg.ThreadId, threadID)
+	}
+	if cfg.CheckpointId == nil || *cfg.CheckpointId == "" {
+		return nil, fmt.Errorf("%w: checkpoint.checkpoint_id is required to resume from a checkpoint", errInterruptSpecInvalid)
+	}
+	id, err := parseCheckpointID(*cfg.CheckpointId)
+	if err != nil {
+		return nil, fmt.Errorf("%w: checkpoint.checkpoint_id must be a checkpoint identifier", errInterruptSpecInvalid)
+	}
+	return json.RawMessage(strconv.FormatInt(id, 10)), nil
+}
+
 // buildRunKwargs validates the run-level LangGraph fields and renders the
 // runs.kwargs jsonb. All absent yields "{}" — the column default — so a run
 // that sets none is indistinguishable from one created before these fields
 // were honored.
-func buildRunKwargs(interruptBefore, interruptAfter, command any) ([]byte, error) {
+func buildRunKwargs(interruptBefore, interruptAfter, command any, checkpoint json.RawMessage) ([]byte, error) {
 	before, err := normalizeInterruptSpec("interrupt_before", interruptBefore)
 	if err != nil {
 		return nil, err
@@ -133,14 +184,54 @@ func buildRunKwargs(interruptBefore, interruptAfter, command any) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	if before == nil && after == nil && cmd == nil {
+	if before == nil && after == nil && cmd == nil && len(checkpoint) == 0 {
 		return []byte("{}"), nil
 	}
-	b, err := json.Marshal(runKwargs{InterruptBefore: before, InterruptAfter: after, Command: cmd})
+	b, err := json.Marshal(runKwargs{InterruptBefore: before, InterruptAfter: after, Command: cmd, Checkpoint: checkpoint})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", errInterruptSpecInvalid, err)
 	}
 	return b, nil
+}
+
+// errCheckpointNotFound marks a checkpoint that does not exist, or exists but
+// belongs to another thread's run — the two collapse deliberately, so probing
+// ids cannot distinguish "no such checkpoint" from "not yours".
+var errCheckpointNotFound = errors.New("checkpoint not found")
+
+// verifyCheckpointOwned resolves the checkpoint against the run's thread BEFORE
+// the run is written, so an unusable reference fails as a clean 404 instead of
+// producing a queued run that its worker can only fail. Scoping mirrors
+// WorkersReadCheckpoint and threads_state.go: a snapshot is reachable only
+// through the thread's own runs.
+func (s *Server) verifyCheckpointOwned(ctx context.Context, checkpoint json.RawMessage, threadID uuid.UUID) error {
+	if len(checkpoint) == 0 {
+		return nil
+	}
+	id, err := strconv.ParseInt(string(checkpoint), 10, 64)
+	if err != nil {
+		return errCheckpointNotFound
+	}
+	var exists bool
+	if err := s.Tenant.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM snapshots
+			WHERE id = $1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = $2))`,
+		id, threadID).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return errCheckpointNotFound
+	}
+	return nil
+}
+
+// checkpointHTTPError maps a verifyCheckpointOwned failure to 404.
+func checkpointHTTPError(err error) error {
+	if errors.Is(err, errCheckpointNotFound) {
+		return echo.NewHTTPError(http.StatusNotFound, "no such checkpoint for this thread")
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 }
 
 // interruptSpecHTTPError maps a buildRunKwargs failure to 422. The value parsed

--- a/controlplane/endpoints/runs_kwargs_integration_test.go
+++ b/controlplane/endpoints/runs_kwargs_integration_test.go
@@ -197,6 +197,135 @@ func TestRunCreatePersistsCommand(t *testing.T) {
 	}
 }
 
+// TestRunCreateCheckpointValidation covers RunCreate.checkpoint at the create
+// boundary: what is honored, what is explicitly refused, and what 404s.
+//
+// checkpoint_ns and checkpoint_map are REFUSED rather than ignored. Both are
+// LangGraph concepts this engine has no representation for (ns is subgraph
+// namespacing; there are no subgraphs), and storing a field we cannot honor is
+// exactly the silent-drop behavior this line of work removes.
+func TestRunCreateCheckpointValidation(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, "TRUNCATE threads, runs, snapshots, assistants, events, outbox, event_streams CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+	e := newTestServerWithTenantWrites()
+	aid := seedAssistantGraph(t, ctx, "agent", "a", "2020-01-01T00:00:00Z")
+
+	var tid string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+	// A checkpoint belonging to a run on THIS thread.
+	var srcRun string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'completed') RETURNING id`,
+		tid, aid).Scan(&srcRun); err != nil {
+		t.Fatal(err)
+	}
+	var streamID string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
+		 VALUES (gen_random_uuid(),'Run',$1,1) RETURNING stream_id`, srcRun).Scan(&streamID); err != nil {
+		t.Fatal(err)
+	}
+	var ckpt int64
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+		 VALUES ($1,'Run',$2,1,'{"channels":{}}'::jsonb) RETURNING id`, streamID, srcRun).Scan(&ckpt); err != nil {
+		t.Fatal(err)
+	}
+	// And one belonging to another thread entirely.
+	var otherThread, otherRun string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&otherThread); err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'completed') RETURNING id`,
+		otherThread, aid).Scan(&otherRun); err != nil {
+		t.Fatal(err)
+	}
+	var otherStream string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO event_streams (stream_id, aggregate_type, aggregate_id, version)
+		 VALUES (gen_random_uuid(),'Run',$1,1) RETURNING stream_id`, otherRun).Scan(&otherStream); err != nil {
+		t.Fatal(err)
+	}
+	var foreignCkpt int64
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO snapshots (stream_id, aggregate_type, aggregate_id, version, state)
+		 VALUES ($1,'Run',$2,1,'{}'::jsonb) RETURNING id`, otherStream, otherRun).Scan(&foreignCkpt); err != nil {
+		t.Fatal(err)
+	}
+
+	post := func(body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/threads/"+tid+"/runs", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Honored: a checkpoint on this thread round-trips into kwargs.
+	rec := post(fmt.Sprintf(`{"assistant_id":%q,"checkpoint":{"checkpoint_id":"%d"}}`, aid, ckpt))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("valid checkpoint: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var run Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatal(err)
+	}
+	var raw []byte
+	if err := testPool.QueryRow(ctx, `SELECT kwargs FROM runs WHERE id=$1`, run.RunId).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	var kw struct {
+		CheckpointID int64 `json:"checkpoint_id"`
+	}
+	if err := json.Unmarshal(raw, &kw); err != nil {
+		t.Fatal(err)
+	}
+	if kw.CheckpointID != ckpt {
+		t.Errorf("kwargs.checkpoint_id: want %d, got %d", ckpt, kw.CheckpointID)
+	}
+
+	// Refused (422) — unsupported fields, contradictions, and malformed ids.
+	for name, body := range map[string]string{
+		"checkpoint_ns unsupported":  `{"assistant_id":%q,"checkpoint":{"checkpoint_id":"1","checkpoint_ns":"sub"}}`,
+		"checkpoint_map unsupported": `{"assistant_id":%q,"checkpoint":{"checkpoint_id":"1","checkpoint_map":{"a":1}}}`,
+		"checkpoint_id required":     `{"assistant_id":%q,"checkpoint":{}}`,
+		"checkpoint_id malformed":    `{"assistant_id":%q,"checkpoint":{"checkpoint_id":"not-a-number"}}`,
+		"thread_id contradiction":    `{"assistant_id":%q,"checkpoint":{"checkpoint_id":"1","thread_id":"11111111-1111-1111-1111-111111111111"}}`,
+	} {
+		if rec := post(fmt.Sprintf(body, aid)); rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("%s: want 422, got %d: %s", name, rec.Code, rec.Body.String())
+		}
+	}
+
+	// 404 — resolvable shape, but not a checkpoint this thread owns. A
+	// checkpoint from ANOTHER thread must be indistinguishable from one that
+	// does not exist, so ids cannot be probed for existence.
+	for name, id := range map[string]int64{
+		"unknown checkpoint": 987654321,
+		"another thread's":   foreignCkpt,
+	} {
+		rec := post(fmt.Sprintf(`{"assistant_id":%q,"checkpoint":{"checkpoint_id":"%d"}}`, aid, id))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: want 404, got %d: %s", name, rec.Code, rec.Body.String())
+		}
+	}
+
+	// A rejected create writes nothing: only the one honored run above exists.
+	var runs int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM runs WHERE thread_id=$1 AND status='queued'`, tid).Scan(&runs); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 1 {
+		t.Errorf("rejected creates must write nothing: want 1 queued run, got %d", runs)
+	}
+}
+
 // TestRunCreateRejectsBadInterruptSpec pins that a value which parses as JSON
 // but violates the schema's anyOf is 422 (unprocessable), not a 500 and not a
 // silent drop — and that the rejection happens BEFORE any write, so no run and

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -296,9 +296,16 @@ func (s *Server) RunsCreateAndStream(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
+	checkpoint, err := normalizeCheckpoint(req.Checkpoint, threadID)
 	if err != nil {
 		return interruptSpecHTTPError(err)
+	}
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command, checkpoint)
+	if err != nil {
+		return interruptSpecHTTPError(err)
+	}
+	if err := s.verifyCheckpointOwned(ctx, checkpoint, threadID); err != nil {
+		return checkpointHTTPError(err)
 	}
 	rid, err := s.createRun(ctx, &threadID, assistantID, mustJSON(req.Input), mustJSON(req.Metadata), kwargs)
 	if err != nil {
@@ -322,7 +329,7 @@ func (s *Server) RunsStatelessStream(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command, nil)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}
@@ -439,7 +446,7 @@ func (s *Server) RunsStatelessWait(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command)
+	kwargs, err := buildRunKwargs(req.InterruptBefore, req.InterruptAfter, req.Command, nil)
 	if err != nil {
 		return interruptSpecHTTPError(err)
 	}

--- a/controlplane/endpoints/threads_state.go
+++ b/controlplane/endpoints/threads_state.go
@@ -23,7 +23,10 @@ import (
 // chronological key. GET /threads/{id}/state -> 200 ThreadState / 404.
 func (s *Server) ThreadsGetState(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots
@@ -48,8 +51,14 @@ func (s *Server) ThreadsGetState(c echo.Context) error {
 // GET /threads/{id}/state/{checkpoint_id} -> 200 ThreadState / 404.
 func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
-	ckpt := c.Param("checkpoint_id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
+	ckpt, err := parseCheckpointID(c.Param("checkpoint_id"))
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots
@@ -79,22 +88,29 @@ func (s *Server) ThreadsGetCheckpointState(c echo.Context) error {
 // POST /threads/{id}/state/checkpoint -> 200 ThreadState / 404.
 func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
 	var req ThreadStateCheckpointRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	var (
-		rows pgx.Rows
-		err  error
-	)
+	var rows pgx.Rows
 	if req.Checkpoint.CheckpointId != nil && *req.Checkpoint.CheckpointId != "" {
+		// Body-carried twin of the path param, so it needs the same guard: a
+		// CheckpointConfig.checkpoint_id that is not a checkpoint identifier is
+		// a validation error, not a 500 from the driver.
+		ckpt, perr := parseCheckpointID(*req.Checkpoint.CheckpointId)
+		if perr != nil {
+			return perr
+		}
 		rows, err = s.Tenant.Query(ctx, `
 			SELECT id, stream_id, aggregate_id, version, state, created_at
 			FROM snapshots
 			WHERE id = $1 AND aggregate_id IN (SELECT id FROM runs WHERE thread_id = $2)`,
-			*req.Checkpoint.CheckpointId, tid)
+			ckpt, tid)
 	} else {
 		rows, err = s.Tenant.Query(ctx, `
 			SELECT id, stream_id, aggregate_id, version, state, created_at
@@ -121,7 +137,10 @@ func (s *Server) ThreadsCreateCheckpoint(c echo.Context) error {
 // per-stream). GET /threads/{id}/history -> 200 []ThreadState.
 func (s *Server) ThreadsGetHistory(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("id")
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots

--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/google/uuid"
 )
@@ -158,6 +159,25 @@ type Checkpoint struct {
 // (no checkpoint yet) is not an error: found is false, err is nil.
 func (c *Client) LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (cp Checkpoint, found bool, err error) {
 	path := "/api/v1/threads/" + threadID.String() + "/checkpoints/latest?run_id=" + runID.String()
+	var resp checkpointResponse
+	status, err := c.doJSON(ctx, http.MethodGet, path, nil, &resp)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return Checkpoint{}, false, nil
+		}
+		return Checkpoint{}, false, err
+	}
+	return Checkpoint{ID: resp.CheckpointID, Version: resp.Version, State: []byte(resp.State)}, true, nil
+}
+
+// CheckpointByID fetches one checkpoint by its id, scoped to threadID. Used
+// when a run was created with RunCreate.checkpoint — the checkpoint it resumes
+// from belongs to a PREVIOUS run on the same thread, so it cannot be found by
+// this run's own id. GET /api/v1/threads/{tid}/checkpoints/{ckpt}. A 404 (no
+// such checkpoint, or one belonging to another thread — the server collapses
+// the two) is not an error: found is false, err is nil.
+func (c *Client) CheckpointByID(ctx context.Context, threadID uuid.UUID, checkpointID int64) (cp Checkpoint, found bool, err error) {
+	path := "/api/v1/threads/" + threadID.String() + "/checkpoints/" + strconv.FormatInt(checkpointID, 10)
 	var resp checkpointResponse
 	status, err := c.doJSON(ctx, http.MethodGet, path, nil, &resp)
 	if err != nil {

--- a/controlplane/worker/graph.go
+++ b/controlplane/worker/graph.go
@@ -147,6 +147,24 @@ func decodeCreateCommand(kwargs json.RawMessage) json.RawMessage {
 	return bag.Command
 }
 
+// decodeSeedCheckpointID reads RunCreate.checkpoint out of the run-kwargs bag:
+// the id of a checkpoint, written by a PREVIOUS run on the same thread, that
+// this run resumes from. Returns 0 when the run carried none. The server
+// validated the id and proved the thread owns it at create time
+// (endpoints normalizeCheckpoint + verifyCheckpointOwned).
+func decodeSeedCheckpointID(kwargs json.RawMessage) int64 {
+	if len(kwargs) == 0 {
+		return 0
+	}
+	var bag struct {
+		CheckpointID int64 `json:"checkpoint_id,omitempty"`
+	}
+	if err := json.Unmarshal(kwargs, &bag); err != nil {
+		return 0
+	}
+	return bag.CheckpointID
+}
+
 // decodeInterruptPolicy reads the run-kwargs bag into an interruptPolicy. A
 // malformed bag is NOT an error: the server validated the spec at create time,
 // so anything unreadable here is a corrupt or hand-edited row, and dropping a

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -88,6 +88,7 @@ type runClient interface {
 	RunStarted(ctx context.Context, runID uuid.UUID) (int, error)
 	LoadGraph(ctx context.Context, runID uuid.UUID) (GraphDefinition, error)
 	LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (Checkpoint, bool, error)
+	CheckpointByID(ctx context.Context, threadID uuid.UUID, checkpointID int64) (Checkpoint, bool, error)
 	WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) (int64, error)
 	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
 	RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error
@@ -355,6 +356,59 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		interrupted = cp.Interrupted
 		pausedAfter = cp.pausedAfter()
 		parentCheckpointID = restored.ID
+	} else if seedID := decodeSeedCheckpointID(cmd.Kwargs); seedID != 0 {
+		// RunCreate.checkpoint: this run resumes from a checkpoint written by a
+		// PREVIOUS run on the same thread, so it cannot be found by this run's
+		// own id (snapshots.aggregate_id is a run id). Fetch it by id; the
+		// server proved the thread owns it at create time.
+		seed, found, serr := r.cl.CheckpointByID(ctx, cmd.ThreadID, seedID)
+		if serr != nil {
+			return false, epoch, serr // transient — Nak, redeliver
+		}
+		if !found {
+			// It existed at create and does not now (the source run was
+			// deleted). Deterministic — redelivery cannot help.
+			return r.failRun(ctx, cmd.RunID, epoch, fmt.Sprintf("checkpoint %d no longer exists", seedID))
+		}
+		var cp checkpointState
+		if uerr := json.Unmarshal(seed.State, &cp); uerr != nil {
+			return false, epoch, fmt.Errorf("runner: decode seed checkpoint state: %w", uerr)
+		}
+		if cp.Channels != nil {
+			channels = cp.Channels
+		}
+		// completed_nodes is inherited: the nodes the source run already
+		// executed are not re-run, which is what "resume from" means. This run's
+		// execution_history therefore records only what IT ran; the full picture
+		// is reconstructed across runs through parent_checkpoint_id, which the
+		// first checkpoint below sets to the seed.
+		completed = cp.CompletedNodes
+		for _, id := range completed {
+			completedSet[id] = true
+		}
+		frontier = cp.Frontier
+		parentCheckpointID = seed.ID
+
+		// The pause marker is deliberately NOT inherited. Carrying it would park
+		// this run against an interrupts row owned by the SOURCE run, and the
+		// resume endpoint requires an unresolved interrupt for THIS run — so the
+		// run would be permanently unresumable. Clearing it does not skip the
+		// gate either: the walk re-evaluates it, and any node whose config (or
+		// this run's own interrupt policy) still calls for a pause parks again
+		// with an interrupt row of its own.
+		//
+		// A source checkpoint taken AFTER its node ran is the one case that
+		// needs help: that node is already in completedSet and its successors
+		// were never expanded (routing is deferred across a pause-after), so the
+		// frontier is empty and the walk would finish immediately. Expand them
+		// now, exactly as a resume with an empty command would.
+		if cp.pausedAfter() {
+			succs, serr := graph.successors(cp.Node, channels)
+			if serr != nil {
+				return r.failRun(ctx, cmd.RunID, epoch, serr.Error())
+			}
+			frontier = append(succs, frontier...)
+		}
 	} else {
 		// Fresh run: seed channels from the command input, frontier from the
 		// graph's entry nodes.

--- a/controlplane/worker/runner_escalation_test.go
+++ b/controlplane/worker/runner_escalation_test.go
@@ -34,6 +34,10 @@ func (c *stubEscalationClient) LatestCheckpoint(ctx context.Context, threadID, r
 	return Checkpoint{}, false, nil
 }
 
+func (c *stubEscalationClient) CheckpointByID(ctx context.Context, threadID uuid.UUID, checkpointID int64) (Checkpoint, bool, error) {
+	return Checkpoint{}, false, nil
+}
+
 func (c *stubEscalationClient) WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) (int64, error) {
 	return 0, errors.New("transient: write checkpoint boom")
 }

--- a/controlplane/worker/seed_checkpoint_integration_test.go
+++ b/controlplane/worker/seed_checkpoint_integration_test.go
@@ -1,0 +1,240 @@
+// Integration coverage for RunCreate.checkpoint — a NEW run resuming from a
+// checkpoint written by a PREVIOUS run on the same thread. snapshots.aggregate_id
+// is a run id, so the seed checkpoint is never findable by the new run's own id;
+// it is fetched by id and thread-scoped.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// seedRunOnThread adds a second run to an existing thread/assistant, so a
+// checkpoint written by the first can be handed to the second.
+func seedRunOnThread(t *testing.T, ctx context.Context, pool *pgxpool.Pool, threadID, assistantID uuid.UUID) uuid.UUID {
+	t.Helper()
+	var rid uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'queued') RETURNING id`,
+		threadID, assistantID).Scan(&rid); err != nil {
+		t.Fatal(err)
+	}
+	return rid
+}
+
+// latestCheckpointID returns the newest snapshot id for a run.
+func latestCheckpointID(t *testing.T, ctx context.Context, pool *pgxpool.Pool, rid uuid.UUID) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM snapshots WHERE aggregate_id=$1 ORDER BY id DESC LIMIT 1`, rid).Scan(&id); err != nil {
+		t.Fatalf("select latest checkpoint id: %v", err)
+	}
+	return id
+}
+
+// TestSeedCheckpointResumesFromAnotherRun is the core case: run 1 crashes after
+// node A, run 2 is created pointing at run 1's checkpoint, and run 2 must
+// continue at B rather than re-running A.
+//
+// A's execution_history staying attached to run 1 — and run 2 recording only B —
+// is the point: completed_nodes is inherited so the work is not repeated, and
+// each run's history honestly reflects what IT executed.
+func TestSeedCheckpointResumesFromAnotherRun(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid1 := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false) // A → B
+	runner1, _ := newLiveRunner(t, ctx, "counter")
+	runner1.StopAfterNode = 0 // stop after A checkpoints, before B
+
+	if _, _, err := runner1.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid1, ThreadID: tid, AssistantID: aid, GraphID: "counter",
+	}); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	assertNodeCount(t, ctx, pool, rid1, "A", 1)
+	assertNodeCount(t, ctx, pool, rid1, "B", 0)
+	seedID := latestCheckpointID(t, ctx, pool, rid1)
+
+	// Run 2 forks from run 1's checkpoint.
+	rid2 := seedRunOnThread(t, ctx, pool, tid, aid)
+	runner2, _ := newLiveRunner(t, ctx, "counter")
+	if _, _, err := runner2.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid2, ThreadID: tid, AssistantID: aid, GraphID: "counter",
+		Kwargs: json.RawMessage(fmt.Sprintf(`{"checkpoint_id":%d}`, seedID)),
+	}); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+
+	assertRunStatus(t, ctx, pool, rid2, "completed")
+	assertNodeCount(t, ctx, pool, rid2, "A", 0) // inherited as already done
+	assertNodeCount(t, ctx, pool, rid2, "B", 1) // continued from the frontier
+	assertNodeCount(t, ctx, pool, rid1, "A", 1) // run 1's history unchanged
+
+	// Run 2's first checkpoint chains back to the seed, so the full walk is
+	// reconstructable across the two runs.
+	var parent int64
+	var raw []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT state FROM snapshots WHERE aggregate_id=$1 ORDER BY id ASC LIMIT 1`, rid2).Scan(&raw); err != nil {
+		t.Fatalf("select run 2 checkpoint: %v", err)
+	}
+	var cp struct {
+		Parent int64 `json:"parent_checkpoint_id"`
+	}
+	if err := json.Unmarshal(raw, &cp); err != nil {
+		t.Fatal(err)
+	}
+	parent = cp.Parent
+	if parent != seedID {
+		t.Errorf("run 2's first checkpoint parent: want the seed %d, got %d", seedID, parent)
+	}
+}
+
+// TestSeedCheckpointDoesNotInheritPause is the decision this slice turns on.
+// Run 1 parks at an interrupt_before gate. Run 2 forks from that pause
+// checkpoint. It must NOT inherit the marker — doing so would park run 2 against
+// an interrupts row owned by RUN 1, and the resume endpoint requires an
+// unresolved interrupt for THIS run, leaving run 2 permanently unresumable.
+//
+// Nor may it silently walk past the gate. The correct behavior is re-evaluation:
+// run 2 reaches GATE, pauses on its own account, and owns its own interrupt row.
+func TestSeedCheckpointDoesNotInheritPause(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid1 := seedThreadAssistantRun(t, ctx, pool)
+	seedInterruptGraph(t, ctx, pool, aid) // A → GATE(interrupt_before) → B
+	runner1, _ := newLiveRunner(t, ctx, "hitl")
+	if _, _, err := runner1.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid1, ThreadID: tid, AssistantID: aid, GraphID: "hitl",
+	}); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid1, "requires_action")
+	in1 := soleInterrupt(t, ctx, pool, rid1)
+	seedID := latestCheckpointID(t, ctx, pool, rid1)
+
+	rid2 := seedRunOnThread(t, ctx, pool, tid, aid)
+	runner2, _ := newLiveRunner(t, ctx, "hitl")
+	if _, _, err := runner2.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid2, ThreadID: tid, AssistantID: aid, GraphID: "hitl",
+		Kwargs: json.RawMessage(fmt.Sprintf(`{"checkpoint_id":%d}`, seedID)),
+	}); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+
+	// Run 2 parked at the gate on its OWN account, and did not slip past it.
+	assertRunStatus(t, ctx, pool, rid2, "requires_action")
+	assertNodeCount(t, ctx, pool, rid2, "GATE", 0)
+	assertNodeCount(t, ctx, pool, rid2, "B", 0)
+
+	in2 := soleInterrupt(t, ctx, pool, rid2)
+	if in2.ID == in1.ID {
+		t.Fatal("run 2 must own a NEW interrupt row, not the source run's")
+	}
+	if in2.NodeID != "GATE" {
+		t.Errorf("run 2 interrupt node: want GATE, got %q", in2.NodeID)
+	}
+
+	// And it is genuinely resumable — the deadlock this decision avoids.
+	postResume(t, tid, rid2, `{"command":{"update":{"approved":true}}}`)
+	assertRunStatus(t, ctx, pool, rid2, "in_progress")
+}
+
+// TestSeedCheckpointFromPauseAfterExpandsSuccessors covers the one case that
+// needs help. Routing is deferred across a pause-AFTER, so that checkpoint's
+// frontier is empty and its node is already completed — a run seeded from it
+// would have nothing to walk and would finish instantly. The successors must be
+// expanded on restore, exactly as an empty resume would.
+func TestSeedCheckpointFromPauseAfterExpandsSuccessors(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid1 := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "after",
+		`[{"id":"A","type":"tool","config":{"set":{"stage":"a"},"interrupt_after":true}},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"A","target":"B"}]`)
+	runner1, _ := newLiveRunner(t, ctx, "after")
+	if _, _, err := runner1.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid1, ThreadID: tid, AssistantID: aid, GraphID: "after",
+	}); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid1, "requires_action")
+	seedID := latestCheckpointID(t, ctx, pool, rid1)
+
+	rid2 := seedRunOnThread(t, ctx, pool, tid, aid)
+	runner2, _ := newLiveRunner(t, ctx, "after")
+	if _, _, err := runner2.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid2, ThreadID: tid, AssistantID: aid, GraphID: "after",
+		Kwargs: json.RawMessage(fmt.Sprintf(`{"checkpoint_id":%d}`, seedID)),
+	}); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+
+	// THE PROOF: B ran. Without expanding A's deferred successors the frontier
+	// would be empty and run 2 would have completed having executed nothing.
+	assertRunStatus(t, ctx, pool, rid2, "completed")
+	assertNodeCount(t, ctx, pool, rid2, "A", 0) // inherited as done
+	assertNodeCount(t, ctx, pool, rid2, "B", 1)
+}
+
+// TestSeedCheckpointVanishedFailsRun pins the race where the checkpoint existed
+// at create (the server verified it) but is gone by dispatch, e.g. the source
+// run was deleted and CASCADE took its snapshots. Deterministic: redelivery
+// cannot help, so record run.failed and ack rather than loop.
+func TestSeedCheckpointVanishedFailsRun(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+	runner, _ := newLiveRunner(t, ctx, "counter")
+
+	acked, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter",
+		Kwargs: json.RawMessage(`{"checkpoint_id":987654321}`),
+	})
+	if err != nil {
+		t.Fatalf("ProcessOne: unexpected transport error: %v", err)
+	}
+	if !acked {
+		t.Fatal("ProcessOne: want acked=true (deterministic, no redelivery), got false")
+	}
+	assertRunStatus(t, ctx, pool, rid, "failed")
+	assertNodeCount(t, ctx, pool, rid, "A", 0)
+}
+
+// TestNoSeedCheckpointIsInert pins that a run without the field behaves exactly
+// as before: entry nodes, input-seeded channels.
+func TestNoSeedCheckpointIsInert(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+	runner, _ := newLiveRunner(t, ctx, "counter")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter",
+		Kwargs: json.RawMessage(`{"interrupt_before":[]}`),
+	}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+	_ = dnats.GraphExecutorMaxDeliver
+}


### PR DESCRIPTION
**Step 3 of 3.** Stacked on #237 (step 1) — merge that first.

Step 1 fixed the boundary 500s; step 2 settled the inheritance semantics you confirmed; this implements it.

`[spec-skip]` impl-only: field already in OpenAPI and the generated types, column already in `postgres.d2`. No schema, migration, or generated-code change.

## Scope is smaller than expected

`RunCreate.checkpoint` is **stateful only** — `RunCreateStateless` carries `checkpoint_during` but *not* `checkpoint`. So this touches **two** create paths, not the five the earlier kwargs slices did.

No new endpoint either: `WorkersReadCheckpoint` (`GET /threads/{tid}/checkpoints/{ckpt}`) already existed and is already thread-scoped.

## Inheritance semantics

`snapshots.aggregate_id` is a **run** id, so the seed checkpoint belongs to a *previous* run and is not findable by the new run's own id.

| Field | Decision |
|---|---|
| `channels` | inherited — the point of the feature |
| `completed_nodes` | inherited, so the source run's work isn't repeated |
| `interrupted` | **not** inherited |

**On `completed_nodes`:** each run's `execution_history` then honestly records only what *it* ran, and the full walk is reconstructed across runs via `parent_checkpoint_id`. I'd originally objected that this makes the new run's history misleading — that was backwards, and I withdrew it: the misleading option is the opposite, claiming a run executed nodes it didn't.

**On `interrupted`:** carrying it would park the new run against an `interrupts` row owned by the **source** run, while `runs_resume.go` requires an unresolved interrupt for *this* run — leaving it **permanently unresumable**. Clearing it doesn't skip the gate either: the walk re-evaluates it and parks again with an interrupt row of its own.

Cost accepted: an approval granted on the source run does not carry forward, because nothing in the model lets an approval outlive a run.

**One case needs help.** Routing is deferred across a pause-after (#231), so such a checkpoint has its node already completed and its successors never expanded — the frontier is empty and a seeded run would finish having executed nothing. Successors are expanded on restore, exactly as an empty resume does. Verified: disabling it makes `TestSeedCheckpointFromPauseAfterExpandsSuccessors` fail with `B: want 1, got 0`.

## Validation

`checkpoint_ns` and `checkpoint_map` are **refused with 422, not ignored**. `ns` is LangGraph subgraph namespacing and this engine has no subgraph concept — `GraphDefinition` doesn't nest, and sub-worker delegation is still TARGET in `graph-engine.d2` §8. Storing a field we can't honor is the silent-drop behavior this whole line of work removes, and a column for it would bake in undefined semantics.

`checkpoint_id` is **required** when a checkpoint config is supplied — a judgment call for an explicit error over an inert request, since "the checkpoint to resume from" has no meaning without one. Flagging it because the schema marks it optional.

A `thread_id` contradicting the run's thread is rejected rather than silently resolved.

Ownership is proved at **create**, not at execution, so an unusable reference 404s there instead of becoming a queued run its worker can only fail. A checkpoint from another thread is indistinguishable from one that doesn't exist, so ids can't be probed. A checkpoint that vanishes between create and dispatch is deterministic — `run.failed` and ack, not a redelivery loop.

## Tests

5 worker integration + 1 server. The two that carry the argument:

- **`TestSeedCheckpointDoesNotInheritPause`** — the new run owns a *new* interrupt row and is genuinely resumable, which is the deadlock this decision avoids.
- **`TestSeedCheckpointFromPauseAfterExpandsSuccessors`** — verified failing when the expansion is disabled.