### PR TITLE
fix(db): allow 'human' in execution_history.node_type

### DIFF
--- a/controlplane/db/migrations/tenant/008_execution_history_human_node.down.sql
+++ b/controlplane/db/migrations/tenant/008_execution_history_human_node.down.sql
@@ -1,0 +1,13 @@
+-- Reverse 008_execution_history_human_node.up.sql.
+--
+-- NOT a pure inverse, and deliberately so: narrowing the CHECK fails outright if
+-- any execution_history row already records a 'human' node, because Postgres
+-- validates an added CHECK against existing rows. Those rows are real execution
+-- history, so the migration refuses rather than deleting them — resolve by
+-- removing or re-typing them first if this must be rolled back.
+ALTER TABLE execution_history
+    DROP CONSTRAINT execution_history_node_type_check;
+
+ALTER TABLE execution_history
+    ADD CONSTRAINT execution_history_node_type_check
+        CHECK (node_type IN ('start', 'end', 'llm', 'tool', 'conditional'));

--- a/controlplane/db/migrations/tenant/008_execution_history_human_node.up.sql
+++ b/controlplane/db/migrations/tenant/008_execution_history_human_node.up.sql
@@ -1,0 +1,25 @@
+-- Allow 'human' in execution_history.node_type.
+--
+-- The graph engine gained the `human` node type (graph-engine.d2 §3 human_ex,
+-- "always interrupt — requires_human") but this CHECK was written before it
+-- existed and still lists only start|end|llm|tool|conditional. The gap is not
+-- reachable while the node is merely PAUSED — the pause writes an interrupts
+-- row, not an execution_history row — so it only bites on the delivery that
+-- resumes past the node and reports it completed:
+--
+--   POST /workers/{id}/runs/{rid}/events -> 500
+--   new row for relation "execution_history" violates check constraint
+--   "execution_history_node_type_check" (SQLSTATE 23514)
+--
+-- The worker treats that 500 as transient and Naks, so the run stalls
+-- in_progress and burns every redelivery before dead-lettering to run.failed.
+-- A human node is therefore unusable end to end until this lands.
+--
+-- The set is kept in sync with the worker's defaultExecutors (worker/graph.go):
+-- start, end, conditional, human, llm, tool.
+ALTER TABLE execution_history
+    DROP CONSTRAINT execution_history_node_type_check;
+
+ALTER TABLE execution_history
+    ADD CONSTRAINT execution_history_node_type_check
+        CHECK (node_type IN ('start', 'end', 'llm', 'tool', 'conditional', 'human'));

--- a/controlplane/endpoints/migration008_test.go
+++ b/controlplane/endpoints/migration008_test.go
@@ -1,0 +1,48 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+)
+
+// TestExecutionHistoryAcceptsHumanNodeType pins migration 008 at the schema
+// level, alongside the worker-level end-to-end proof.
+//
+// execution_history.node_type's CHECK predated the `human` node type and listed
+// only start|end|llm|tool|conditional, so a human node's completion write was
+// rejected with SQLSTATE 23514. The worker reads that 500 as transient and Naks,
+// which stalled the run rather than failing it visibly — the reason this went
+// unnoticed until a run actually resumed past a human node.
+func TestExecutionHistoryAcceptsHumanNodeType(t *testing.T) {
+	ctx := context.Background()
+
+	var threadID, assistantID, runID string
+	if err := testPool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&threadID); err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (name) VALUES ('m008') RETURNING id`).Scan(&assistantID); err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (thread_id, assistant_id, status) VALUES ($1,$2,'in_progress') RETURNING id`,
+		threadID, assistantID).Scan(&runID); err != nil {
+		t.Fatal(err)
+	}
+
+	ins := `INSERT INTO execution_history (run_id, node_id, node_type, status) VALUES ($1, 'N', $2, 'completed')`
+
+	// Every type the engine's defaultExecutors can dispatch must be storable.
+	// If these drift apart again, that type fails only on the delivery where it
+	// completes — long after it appeared to work.
+	for _, nodeType := range []string{"start", "end", "llm", "tool", "conditional", "human"} {
+		if _, err := testPool.Exec(ctx, ins, runID, nodeType); err != nil {
+			t.Errorf("node_type %q must be accepted by execution_history: %v", nodeType, err)
+		}
+	}
+
+	// The constraint must still constrain — this is not a blanket widening.
+	if _, err := testPool.Exec(ctx, ins, runID, "not-a-node-type"); err == nil {
+		t.Error("an unknown node_type should still violate the CHECK, but the insert succeeded")
+	}
+}

--- a/controlplane/worker/human_node_integration_test.go
+++ b/controlplane/worker/human_node_integration_test.go
@@ -1,0 +1,108 @@
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// TestHumanNodeCompletesAfterResume closes the gap that made the `human` node
+// type unusable end to end.
+//
+// The type was added with the interrupt-trigger work, and its pause was covered
+// — but only the pause. A pause writes an interrupts row, not an
+// execution_history row, so nothing ever exercised the delivery that RESUMES
+// past a human node and reports it completed. That path hit
+// execution_history.node_type's CHECK, which predated the type and listed only
+// start|end|llm|tool|conditional:
+//
+//	500 new row for relation "execution_history" violates check constraint
+//	    "execution_history_node_type_check" (SQLSTATE 23514)
+//
+// The worker reads that 500 as transient and Naks, so the run stalled
+// in_progress and burned every redelivery before dead-lettering to run.failed.
+//
+// This test walks the whole loop — pause, resume through the real endpoint,
+// execute the human node, continue to its successor — so the node type is
+// exercised where it actually writes.
+func TestHumanNodeCompletesAfterResume(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedGraph(t, ctx, pool, aid, "human-e2e",
+		`[{"id":"H","type":"human"},
+		  {"id":"B","type":"tool","config":{"set":{"done":true}}}]`,
+		`[{"source":"H","target":"B"}]`)
+	runner, _ := newLiveRunner(t, ctx, "human-e2e")
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "human-e2e"}
+
+	// Phase 1: parks before the human node, which contributes no history row.
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("pause ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "requires_action")
+	assertNodeCount(t, ctx, pool, rid, "H", 0)
+
+	// Phase 2: resume so the human node actually EXECUTES and reports completed.
+	postResume(t, tid, rid, `{"command":{"update":{"answer":"yes"}}}`)
+	cmd.Resume = json.RawMessage(`{"update":{"answer":"yes"}}`)
+	acked, _, err := runner.ProcessOne(ctx, cmd)
+	if err != nil {
+		t.Fatalf("resume ProcessOne: %v", err)
+	}
+	if !acked {
+		t.Fatal("resume ProcessOne: want acked=true (run finished), got false")
+	}
+
+	// THE PROOF: the human node's completion was recorded, and the walk carried
+	// on past it. Before the CHECK was widened, H's write 500'd, so the run
+	// stayed in_progress with zero history rows.
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	assertNodeCount(t, ctx, pool, rid, "H", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+
+	var nodeType string
+	if err := pool.QueryRow(ctx,
+		`SELECT node_type FROM execution_history WHERE run_id=$1 AND node_id='H'`, rid).Scan(&nodeType); err != nil {
+		t.Fatalf("select human node history: %v", err)
+	}
+	if nodeType != "human" {
+		t.Errorf("execution_history.node_type: want human, got %q", nodeType)
+	}
+}
+
+// TestExecutorNodeTypesSatisfyCheck guards the coupling that caused this: every
+// type the engine can execute must be accepted by the execution_history CHECK,
+// or that type fails only on the delivery where it completes — long after it
+// looked like it worked.
+func TestExecutorNodeTypesSatisfyCheck(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	// One node per executor type the runner dispatches on. Only `human`
+	// interrupts, so it is covered by the test above; the rest run straight
+	// through and each writes a history row typed with its own node type.
+	seedGraph(t, ctx, pool, aid, "alltypes",
+		`[{"id":"S","type":"start"},
+		  {"id":"L","type":"llm","config":{"set":{"a":1}}},
+		  {"id":"T","type":"tool","config":{"set":{"b":2}}},
+		  {"id":"C","type":"conditional"},
+		  {"id":"E","type":"end"}]`,
+		`[{"source":"S","target":"L"},{"source":"L","target":"T"},
+		  {"source":"T","target":"C"},{"source":"C","target":"E"}]`)
+	runner, _ := newLiveRunner(t, ctx, "alltypes")
+
+	if _, _, err := runner.ProcessOne(ctx, worker.GraphCommand{
+		RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "alltypes",
+	}); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+	for _, n := range []string{"S", "L", "T", "C", "E"} {
+		assertNodeCount(t, ctx, pool, rid, n, 1)
+	}
+}


### PR DESCRIPTION
**The `human` node type is unusable end to end on main today.** Found while starting the node-execution-events work.

## The bug

#231 added the `human` node type (`graph-engine.d2` §3 `human_ex`, "always interrupt"), but `execution_history.node_type`'s CHECK predates it and still lists only `start|end|llm|tool|conditional`.

The gap is invisible while the node is merely **paused** — a pause writes an `interrupts` row, not an `execution_history` row. It only bites on the delivery that **resumes past** the node and reports it completed:

```
POST /workers/{id}/runs/{rid}/events -> 500
new row for relation "execution_history" violates check constraint
"execution_history_node_type_check" (SQLSTATE 23514)
```

And it fails *quietly*: the worker treats a 500 as transient and Naks, so the run doesn't fail loudly — it stalls `in_progress` and burns every redelivery before dead-lettering to `run.failed`.

## Why #231's tests didn't catch it

`TestHumanNodeAlwaysInterrupts` asserts the pause and stops there. It never resumes, so it never reaches the only code path that writes the row. That's my miss in #231 — the test proved the trigger fired but not that the node could actually run.

## The fix

Migration 008 widens the CHECK to the set the worker's `defaultExecutors` can actually dispatch: `start, end, conditional, human, llm, tool`.

The **down** migration is deliberately not a pure inverse: narrowing the CHECK fails if any row already records a `human` node, because Postgres validates an added CHECK against existing rows. Those rows are real execution history, so it refuses rather than silently deleting them.

## Tests, at both levels

- **Worker** — the full loop: pause, resume through the real endpoint, execute the human node, continue to its successor; asserts the history row exists and is typed `human`. **Verified failing without the migration**, with the exact 23514 above.
- **Schema** — every type `defaultExecutors` dispatches is insertable, **and** an unknown type is still rejected, so this isn't a blanket widening. This one guards the drift that caused the bug, since a mismatch only ever surfaces on the delivery where a node completes.

`[spec-skip]` impl-only — `postgres.d2`'s `execution_history` block documents `node_type` as a value set without enumerating it as a constraint; no API, generated-code, or contract change.

## Next

This was split out of the `execution.node_started` / `node_failed` slice so the production-blocking fix lands on its own. That work follows: the server already handles all three event types (`workers.go:112`), but the worker only ever sends `NodeCompleted`, so a poison node leaves no `execution_history` row saying where the run died — and `duration_ms` is declared on the event and never populated.