### PR TITLE
feat(worker): emit execution.node_started and node_failed

### DIFF
--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -150,24 +150,70 @@ func (s *Server) leaseRun(ctx context.Context, rid, wid string) (int, error) {
 // so a stale worker's event is never committed.
 var errStaleLease = errors.New("stale lease_epoch")
 
-// nodeEvent records a node execution row + emits the execution.node_* event.
-// The epoch guard is ATOMIC (conditional INSERT), not a separate read.
+// nodeEvent records a node execution + emits the execution.node_* event.
+//
+// execution_history is "one row per node execution" (003_run.up.sql), and its
+// columns say the same: started_at NOT NULL, completed_at and duration_ms
+// nullable. So a node's lifecycle TRANSITIONS one row rather than appending
+// several — execution.node_started INSERTs it, and node_completed/node_failed
+// UPDATE that row in place. Appending on every event would give two rows per
+// node and turn "how many times did N run" into a question about event counts.
+//
+// The completing UPDATE targets the newest still-'started' row for (run_id,
+// node_id), so a node that runs more than once (a cycle) closes its own
+// attempt rather than an earlier one. If no started row exists the write falls
+// back to an INSERT: a worker that reports only completion — as every worker
+// did before node_started was emitted — still records its execution.
+//
+// The epoch guard is ATOMIC in both paths (a conditional INSERT, and a join to
+// runs in the UPDATE), never a separate read.
 func (s *Server) nodeEvent(ctx context.Context, rid string, ev WorkerEvent) error {
 	return s.writeTxOrHTTP(ctx, rid, ev.Type, ev, func(tx pgx.Tx) error {
+		if ev.NodeStatus == "started" {
+			return insertNodeExecution(ctx, tx, rid, ev)
+		}
 		ct, err := tx.Exec(ctx, `
-			INSERT INTO execution_history (run_id, node_id, node_type, status, input, output, error, duration_ms, completed_at)
-			SELECT $1,$2,$3,$4::varchar,$5,$6,$7,$8, CASE WHEN $4::varchar <> 'started' THEN now() END
-			WHERE EXISTS (SELECT 1 FROM runs WHERE id=$1 AND lease_epoch=$9)`,
-			rid, ev.NodeID, ev.NodeType, ev.NodeStatus,
-			jsonOrEmpty(ev.Input), jsonOrEmpty(ev.Output), ev.Error, ev.DurationMs, ev.LeaseEpoch)
+			UPDATE execution_history h
+			SET status = $3::varchar, output = $4, error = $5,
+			    duration_ms = COALESCE($6, (EXTRACT(EPOCH FROM (now() - h.started_at)) * 1000)::integer),
+			    completed_at = now()
+			WHERE h.id = (
+			    SELECT id FROM execution_history
+			    WHERE run_id = $1 AND node_id = $2 AND status = 'started'
+			    ORDER BY id DESC LIMIT 1)
+			  AND EXISTS (SELECT 1 FROM runs WHERE id = $1 AND lease_epoch = $7)`,
+			rid, ev.NodeID, ev.NodeStatus,
+			jsonOrEmpty(ev.Output), ev.Error, ev.DurationMs, ev.LeaseEpoch)
 		if err != nil {
 			return err
 		}
-		if ct.RowsAffected() == 0 {
-			return errStaleLease
+		if ct.RowsAffected() > 0 {
+			return nil
 		}
-		return nil
+		// No open attempt to close. Either the run is fenced, or the worker
+		// never announced a start — insert so the execution is still recorded,
+		// and let the epoch guard inside decide which of the two it was.
+		return insertNodeExecution(ctx, tx, rid, ev)
 	})
+}
+
+// insertNodeExecution writes a new execution_history row, epoch-fenced.
+// completed_at is set for any terminal status so a fallback insert (a worker
+// reporting only completion) is not left looking perpetually in-flight.
+func insertNodeExecution(ctx context.Context, tx pgx.Tx, rid string, ev WorkerEvent) error {
+	ct, err := tx.Exec(ctx, `
+		INSERT INTO execution_history (run_id, node_id, node_type, status, input, output, error, duration_ms, completed_at)
+		SELECT $1,$2,$3,$4::varchar,$5,$6,$7,$8, CASE WHEN $4::varchar <> 'started' THEN now() END
+		WHERE EXISTS (SELECT 1 FROM runs WHERE id=$1 AND lease_epoch=$9)`,
+		rid, ev.NodeID, ev.NodeType, ev.NodeStatus,
+		jsonOrEmpty(ev.Input), jsonOrEmpty(ev.Output), ev.Error, ev.DurationMs, ev.LeaseEpoch)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return errStaleLease
+	}
+	return nil
 }
 
 // terminalRun marks the run completed/failed + emits the event. Epoch guarded

--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -81,14 +81,56 @@ func (c *Client) RunStarted(ctx context.Context, runID uuid.UUID) (int, error) {
 	return resp.LeaseEpoch, nil
 }
 
-// NodeCompleted records a completed node execution, fenced on epoch.
-func (c *Client) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
+// NodeStarted opens a node's execution_history row before the node runs, fenced
+// on epoch. The completing call (NodeCompleted / NodeFailed) transitions that
+// same row rather than adding another — see the server's nodeEvent.
+//
+// Announcing the start is what makes an in-flight node visible: without it a
+// node that is slow, wedged, or killed mid-execution leaves no trace at all, so
+// "where is this run" is unanswerable from execution_history.
+func (c *Client) NodeStarted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
+	body := eventsRequest{Events: []workerEvent{{
+		Type:       "execution.node_started",
+		LeaseEpoch: epoch,
+		NodeID:     nodeID,
+		NodeType:   nodeType,
+		NodeStatus: "started",
+	}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
+// NodeCompleted closes a node's execution_history row as succeeded, fenced on
+// epoch. durationMs is the worker's own measurement of the node's execution;
+// the server falls back to now()-started_at when it is nil.
+func (c *Client) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string, durationMs *int) error {
 	body := eventsRequest{Events: []workerEvent{{
 		Type:       "execution.node_completed",
 		LeaseEpoch: epoch,
 		NodeID:     nodeID,
 		NodeType:   nodeType,
 		NodeStatus: "completed",
+		DurationMs: durationMs,
+	}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
+// NodeFailed closes a node's execution_history row as failed, recording which
+// node died and why, fenced on epoch.
+//
+// Without it a poison node produced run.failed and nothing else: the error text
+// landed on runs.error and execution_history held no row naming the node, so the
+// run's own audit trail could not say where it died.
+func (c *Client) NodeFailed(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType, reason string, durationMs *int) error {
+	body := eventsRequest{Events: []workerEvent{{
+		Type:       "execution.node_failed",
+		LeaseEpoch: epoch,
+		NodeID:     nodeID,
+		NodeType:   nodeType,
+		NodeStatus: "failed",
+		Error:      &reason,
+		DurationMs: durationMs,
 	}}}
 	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
 	return err

--- a/controlplane/worker/client_test.go
+++ b/controlplane/worker/client_test.go
@@ -45,14 +45,14 @@ func TestClientLifecycleAndCheckpoints(t *testing.T) {
 	if cp.ID != ckptID {
 		t.Errorf("LatestCheckpoint id: want %d (the row WriteCheckpoint created), got %d", ckptID, cp.ID)
 	}
-	if err := cl.NodeCompleted(ctx, rid, epoch, "A", "tool"); err != nil {
+	if err := cl.NodeCompleted(ctx, rid, epoch, "A", "tool", nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := cl.RunCompleted(ctx, rid, epoch); err != nil {
 		t.Fatal(err)
 	}
 	// stale lease surfaces as ErrStaleLease
-	if err := cl.NodeCompleted(ctx, rid, 999, "B", "tool"); err != worker.ErrStaleLease {
+	if err := cl.NodeCompleted(ctx, rid, 999, "B", "tool", nil); err != worker.ErrStaleLease {
 		t.Fatalf("stale lease: want ErrStaleLease, got %v", err)
 	}
 }

--- a/controlplane/worker/execution_integration_test.go
+++ b/controlplane/worker/execution_integration_test.go
@@ -152,7 +152,7 @@ func TestDurableResume(t *testing.T) {
 
 	// The dead worker (still holding epoch 1) can no longer write: the live
 	// lease is now epoch 2, so its event is fenced off as stale.
-	if err := cl1.NodeCompleted(ctx, rid, 1, "B", "tool"); !errors.Is(err, worker.ErrStaleLease) {
+	if err := cl1.NodeCompleted(ctx, rid, 1, "B", "tool", nil); !errors.Is(err, worker.ErrStaleLease) {
 		t.Errorf("dead worker's replayed write: want ErrStaleLease, got %v", err)
 	}
 }
@@ -191,7 +191,25 @@ func TestGraphErrorMarksRunFailed(t *testing.T) {
 
 	assertRunStatus(t, ctx, pool, rid, "failed")
 	assertNodeCount(t, ctx, pool, rid, "A", 1)
-	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	// B is the poison node. It used to leave NO execution_history row, so the
+	// run's audit trail could not say where it died — only runs.error carried
+	// the text. It now leaves exactly ONE row (started, then transitioned in
+	// place to failed) naming the node and carrying the reason.
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+	var status string
+	var errText *string
+	if err := pool.QueryRow(ctx,
+		`SELECT status, error FROM execution_history WHERE run_id=$1 AND node_id='B'`,
+		rid).Scan(&status, &errText); err != nil {
+		t.Fatalf("select execution_history[B]: %v", err)
+	}
+	if status != "failed" {
+		t.Errorf("execution_history[B].status: want failed, got %q", status)
+	}
+	if errText == nil || *errText == "" {
+		t.Error("execution_history[B].error: want the failure reason recorded, got empty")
+	}
 
 	var nOutbox int
 	if err := pool.QueryRow(ctx,

--- a/controlplane/worker/node_events_integration_test.go
+++ b/controlplane/worker/node_events_integration_test.go
@@ -1,0 +1,199 @@
+package worker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// TestNodeLifecycleTransitionsOneRow pins the shape of execution_history under
+// the start/complete event pair.
+//
+// execution_history is "one row per node execution" (003_run.up.sql), and its
+// columns agree: started_at NOT NULL, completed_at and duration_ms nullable. So
+// a node's start and completion must TRANSITION a single row, not append two.
+// The naive implementation — INSERT on every event — would double every count
+// and quietly redefine "how many times did N run" as an event count.
+func TestNodeLifecycleTransitionsOneRow(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool
+
+	tid, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+	cmd := worker.GraphCommand{RunID: rid, ThreadID: tid, AssistantID: aid, GraphID: "counter"}
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(nil, cl, dnats.GraphExecutorMaxDeliver)
+
+	if _, _, err := runner.ProcessOne(ctx, cmd); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	assertRunStatus(t, ctx, pool, rid, "completed")
+
+	// One row per node, despite two events each.
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+
+	// And that row is the COMPLETED one — a lingering 'started' row would mean
+	// the completion inserted alongside the start instead of closing it.
+	for _, nodeID := range []string{"A", "B"} {
+		var status string
+		var completedAt *string
+		var durationMs *int
+		if err := pool.QueryRow(ctx,
+			`SELECT status, completed_at::text, duration_ms FROM execution_history
+			 WHERE run_id=$1 AND node_id=$2`, rid, nodeID).Scan(&status, &completedAt, &durationMs); err != nil {
+			t.Fatalf("select execution_history[%s]: %v", nodeID, err)
+		}
+		if status != "completed" {
+			t.Errorf("execution_history[%s].status: want completed, got %q", nodeID, status)
+		}
+		if completedAt == nil {
+			t.Errorf("execution_history[%s].completed_at: want set, got NULL", nodeID)
+		}
+		// duration_ms is declared on the event and was never populated by any
+		// worker; a fast node legitimately measures 0ms, so assert presence and
+		// sanity, not a lower bound.
+		if durationMs == nil {
+			t.Errorf("execution_history[%s].duration_ms: want populated, got NULL", nodeID)
+		} else if *durationMs < 0 {
+			t.Errorf("execution_history[%s].duration_ms: want >= 0, got %d", nodeID, *durationMs)
+		}
+	}
+}
+
+// TestNodeStartedIsVisibleBeforeCompletion is the point of emitting a start at
+// all: a node that is in-flight — slow, wedged, or killed mid-execution — must
+// be observable. Before this, execution_history gained a row only once a node
+// FINISHED, so a run stuck inside a node was indistinguishable from one that
+// had not reached it.
+//
+// Driven through the client directly rather than a runner, because a runner
+// never leaves a node open long enough to observe.
+func TestNodeStartedIsVisibleBeforeCompletion(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool
+
+	_, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	// Lease the run so the epoch guard on the event write is satisfied.
+	if _, err := cl.RunStarted(ctx, rid); err != nil {
+		t.Fatalf("RunStarted: %v", err)
+	}
+
+	if err := cl.NodeStarted(ctx, rid, 1, "A", "tool"); err != nil {
+		t.Fatalf("NodeStarted: %v", err)
+	}
+
+	var status string
+	var completedAt *string
+	if err := pool.QueryRow(ctx,
+		`SELECT status, completed_at::text FROM execution_history WHERE run_id=$1 AND node_id='A'`,
+		rid).Scan(&status, &completedAt); err != nil {
+		t.Fatalf("an in-flight node must be visible in execution_history: %v", err)
+	}
+	if status != "started" {
+		t.Errorf("in-flight node status: want started, got %q", status)
+	}
+	if completedAt != nil {
+		t.Errorf("in-flight node completed_at: want NULL, got %v", *completedAt)
+	}
+
+	// Completing closes THAT row rather than adding a second.
+	if err := cl.NodeCompleted(ctx, rid, 1, "A", "tool", nil); err != nil {
+		t.Fatalf("NodeCompleted: %v", err)
+	}
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+
+	// duration_ms was not supplied, so the server derives it from started_at
+	// rather than leaving the column NULL.
+	var durationMs *int
+	if err := pool.QueryRow(ctx,
+		`SELECT duration_ms FROM execution_history WHERE run_id=$1 AND node_id='A'`,
+		rid).Scan(&durationMs); err != nil {
+		t.Fatalf("select duration_ms: %v", err)
+	}
+	if durationMs == nil {
+		t.Error("duration_ms: want server-derived value when the worker sends none, got NULL")
+	}
+}
+
+// TestNodeCompletionWithoutStartStillRecords covers the compatibility path.
+// Every worker before this change reported ONLY completion, and an in-flight
+// upgrade means both kinds run at once. A completion with no open row must
+// still record the execution rather than being silently dropped.
+func TestNodeCompletionWithoutStartStillRecords(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool
+
+	_, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := cl.RunStarted(ctx, rid); err != nil {
+		t.Fatalf("RunStarted: %v", err)
+	}
+
+	// No NodeStarted — straight to completion, as an old worker would.
+	if err := cl.NodeCompleted(ctx, rid, 1, "A", "tool", nil); err != nil {
+		t.Fatalf("NodeCompleted without a prior start: %v", err)
+	}
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+
+	var status string
+	var completedAt *string
+	if err := pool.QueryRow(ctx,
+		`SELECT status, completed_at::text FROM execution_history WHERE run_id=$1 AND node_id='A'`,
+		rid).Scan(&status, &completedAt); err != nil {
+		t.Fatalf("select execution_history[A]: %v", err)
+	}
+	if status != "completed" {
+		t.Errorf("status: want completed, got %q", status)
+	}
+	// The fallback insert must not look perpetually in-flight.
+	if completedAt == nil {
+		t.Error("completed_at: want set on a fallback insert, got NULL")
+	}
+}
+
+// TestNodeEventsAreEpochFenced keeps the new events under the same fencing as
+// every other worker write: a superseded worker must not be able to write node
+// history into a run it no longer owns.
+func TestNodeEventsAreEpochFenced(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool
+
+	_, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := cl.RunStarted(ctx, rid); err != nil {
+		t.Fatalf("RunStarted: %v", err)
+	}
+
+	if err := cl.NodeStarted(ctx, rid, 999, "A", "tool"); err != worker.ErrStaleLease {
+		t.Errorf("NodeStarted with a stale epoch: want ErrStaleLease, got %v", err)
+	}
+	if err := cl.NodeFailed(ctx, rid, 999, "A", "tool", "boom", nil); err != worker.ErrStaleLease {
+		t.Errorf("NodeFailed with a stale epoch: want ErrStaleLease, got %v", err)
+	}
+	assertNodeCount(t, ctx, pool, rid, "A", 0)
+}

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -51,6 +51,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go/jetstream"
@@ -90,7 +91,9 @@ type runClient interface {
 	LatestCheckpoint(ctx context.Context, threadID, runID uuid.UUID) (Checkpoint, bool, error)
 	CheckpointByID(ctx context.Context, threadID uuid.UUID, checkpointID int64) (Checkpoint, bool, error)
 	WriteCheckpoint(ctx context.Context, threadID, runID uuid.UUID, epoch, version int, state []byte) (int64, error)
-	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
+	NodeStarted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
+	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string, durationMs *int) error
+	NodeFailed(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType, reason string, durationMs *int) error
 	RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error
 	RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error
 	RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error
@@ -613,9 +616,29 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 			return r.failRun(ctx, cmd.RunID, epoch, fmt.Sprintf("no executor for node type %q", node.Type))
 		}
 
+		// Announce the start before executing, so a node that is slow or dies
+		// mid-execution is still visible in execution_history. A stale lease
+		// here means a newer worker owns the run — stop and ack.
+		if serr := r.cl.NodeStarted(ctx, cmd.RunID, epoch, node.ID, node.Type); serr != nil {
+			if errors.Is(serr, ErrStaleLease) {
+				return true, epoch, nil
+			}
+			return false, epoch, serr // transient — Nak, redeliver
+		}
+
+		startedAt := time.Now()
 		writes, xerr := exec.Execute(ctx, node, channels)
+		elapsed := msSince(startedAt)
 		if xerr != nil {
 			// Poison node — deterministic failure, redelivery cannot help.
+			// Record WHICH node died before failing the run, so the audit trail
+			// names it rather than leaving only the error text on runs.error.
+			if nerr := r.cl.NodeFailed(ctx, cmd.RunID, epoch, node.ID, node.Type, xerr.Error(), elapsed); nerr != nil {
+				if errors.Is(nerr, ErrStaleLease) {
+					return true, epoch, nil
+				}
+				return false, epoch, nerr // transient — Nak so the record is retried
+			}
 			return r.failRun(ctx, cmd.RunID, epoch, xerr.Error())
 		}
 		for k, v := range writes {
@@ -677,7 +700,7 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 			return false, epoch, werr // transient — Nak, redeliver
 		}
 		parentCheckpointID = ckptID
-		if nerr := r.cl.NodeCompleted(ctx, cmd.RunID, epoch, node.ID, node.Type); nerr != nil {
+		if nerr := r.cl.NodeCompleted(ctx, cmd.RunID, epoch, node.ID, node.Type, elapsed); nerr != nil {
 			if errors.Is(nerr, ErrStaleLease) {
 				return true, epoch, nil
 			}
@@ -714,6 +737,19 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		return false, epoch, cerr
 	}
 	return true, epoch, nil
+}
+
+// msSince renders a node's wall-clock execution time for execution_history's
+// duration_ms (an INTEGER). Measured by the worker rather than derived from
+// now()-started_at server-side so it reflects the node itself, not the node plus
+// two round trips. Clamped at zero: a backwards clock must not write a negative
+// duration.
+func msSince(start time.Time) *int {
+	ms := int(time.Since(start).Milliseconds())
+	if ms < 0 {
+		ms = 0
+	}
+	return &ms
 }
 
 // lastNode returns the most recently completed node id, or "" when nothing has

--- a/controlplane/worker/runner_escalation_test.go
+++ b/controlplane/worker/runner_escalation_test.go
@@ -42,7 +42,15 @@ func (c *stubEscalationClient) WriteCheckpoint(ctx context.Context, threadID, ru
 	return 0, errors.New("transient: write checkpoint boom")
 }
 
-func (c *stubEscalationClient) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
+func (c *stubEscalationClient) NodeStarted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error {
+	return nil
+}
+
+func (c *stubEscalationClient) NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string, durationMs *int) error {
+	return nil
+}
+
+func (c *stubEscalationClient) NodeFailed(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType, reason string, durationMs *int) error {
 	return nil
 }
 

--- a/controlplane/worker/stream_e2e_test.go
+++ b/controlplane/worker/stream_e2e_test.go
@@ -183,10 +183,17 @@ func TestStreamEndToEnd(t *testing.T) {
 
 	url := sseSrv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/stream"
 	done := make(chan []sseFrame, 1)
-	go func() { done <- readSSE(t, url, 4, 15*time.Second) }()
+	// Each node now streams a start AND a completion, so a consumer can see a
+	// node enter execution rather than only learning it finished.
+	go func() { done <- readSSE(t, url, 6, 15*time.Second) }()
 
 	frames := <-done
-	want := []string{"run.started", "execution.node_completed", "execution.node_completed", "run.completed"}
+	want := []string{
+		"run.started",
+		"execution.node_started", "execution.node_completed", // A
+		"execution.node_started", "execution.node_completed", // B
+		"run.completed",
+	}
 	if len(frames) != len(want) {
 		t.Fatalf("want %d frames, got %d: %+v", len(want), len(frames), frames)
 	}


### PR DESCRIPTION
The server has always handled all three `execution.node_*` events (`workers.go` dispatch), but the worker only ever sent `node_completed`. Two consequences, both from `graph-engine.d2` §7:

- **A node was invisible until it finished.** A run wedged inside a slow or hung node looked identical to one that hadn't reached it — `execution_history` couldn't answer "where is this run".
- **A poison node left no row naming it.** The error text landed on `runs.error`; the audit trail said the run failed but not where.

`TestGraphErrorMarksRunFailed` asserted exactly that second hole (`node B: want 0 rows`). That assertion is **inverted** here into a positive one: the row exists, is `status='failed'`, and carries the reason.

`duration_ms` is declared on `WorkerEvent` and populated by nobody. It's now measured by the worker around `Execute`, so it reflects the node itself rather than the node plus two round trips.

## This is a server change, not just two client methods

`execution_history` is *"one row per node execution"* (`003_run.up.sql`), and its columns agree: `started_at NOT NULL`, `completed_at` and `duration_ms` nullable. So a node's lifecycle **transitions one row** — `node_started` INSERTs, `node_completed`/`node_failed` UPDATE in place.

`nodeEvent` INSERTed unconditionally. Simply sending the new events would have written **two rows per node** and silently redefined "how many times did N run" as an event count. Verified: with the old INSERT the new tests report `want 1, got 2` on every node.

## Details that aren't obvious

- The completing UPDATE closes the **newest still-`started`** row for `(run_id, node_id)`, so a node that runs twice in a cycle closes its own attempt rather than an earlier one.
- **A completion with no open row falls back to INSERT.** Every worker before this change reported only completion, and an in-flight upgrade runs both kinds at once — that execution must still be recorded. The fallback sets `completed_at` so it isn't left looking perpetually in-flight.
- `duration_ms` falls back to `now()-started_at` when the worker sends none.
- Both paths stay **atomically** epoch-fenced (conditional INSERT; a join to `runs` in the UPDATE) — never a separate read.
- `NodeStarted` failing on a stale lease **acks** rather than Naks: a newer worker owns the run, so redelivery can't help.

## Tests

One row per node despite two events, with `completed_at` and `duration_ms` populated; an in-flight node observable as `started` with `completed_at` NULL *before* it finishes; completion-without-start still recorded; both new events epoch-fenced. All verified failing against the old always-INSERT server.

The SSE end-to-end expectation grows from 4 frames to 6 — a consumer now sees each node enter execution instead of only learning it finished.

`[spec-skip]` impl-only — `graph-engine.d2` §7 already lists all three events and the OpenAPI `WorkerEvent` schema already carries `node_status`, `error` and `duration_ms`. No API, schema or generated-code change; codegen verified idempotent.