### PR TITLE
feat: make the control plane compile and work end-to-end for a single user

### DIFF
--- a/controlplane/cron/cron.go
+++ b/controlplane/cron/cron.go
@@ -1,0 +1,213 @@
+// Package cron fires due cron jobs. A crons row describes a schedule but
+// nothing ever acted on it: next_run_at was only ever SELECTed, never set and
+// never polled, so a created cron sat inert forever.
+//
+// Shape mirrors controlplane/reaper: a ticker in the control plane claiming
+// rows with FOR UPDATE SKIP LOCKED. Not pg_cron (a superuser extension that
+// would need enabling in every tenant database, and that would have to
+// hand-write the runs+events+outbox triple in SQL) and not JetStream (which has
+// no scheduled delivery). Firing here means a cron-created run takes the SAME
+// event-sourced path as an API-created one — run.created to the outbox, relayed
+// to NATS, dispatched to a worker — rather than a second route to the same
+// outcome.
+package cron
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	cronlib "github.com/robfig/cron/v3"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+)
+
+// Parser accepts standard 5-field cron expressions (minute hour dom month dow).
+var Parser = cronlib.NewParser(
+	cronlib.Minute | cronlib.Hour | cronlib.Dom | cronlib.Month | cronlib.Dow,
+)
+
+// NextRun returns the first firing of schedule strictly after from.
+//
+// Computing from NOW rather than from the previous due time is what makes a
+// missed window simply skip: if the control plane was down for three hours, a
+// five-minute cron fires once on recovery and is next due five minutes later,
+// instead of replaying thirty-six runs nobody wants.
+func NextRun(schedule string, from time.Time) (time.Time, error) {
+	s, err := Parser.Parse(schedule)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return s.Next(from).UTC(), nil
+}
+
+// Validate reports whether schedule is a usable cron expression.
+func Validate(schedule string) error {
+	_, err := Parser.Parse(schedule)
+	return err
+}
+
+type Config struct {
+	Interval time.Duration // tick period; default 30s
+	Batch    int           // max crons fired per tick; default 100
+}
+
+func (c *Config) defaults() {
+	if c.Interval == 0 {
+		c.Interval = 30 * time.Second
+	}
+	if c.Batch == 0 {
+		c.Batch = 100
+	}
+}
+
+type Scheduler struct {
+	pool   *pgxpool.Pool
+	cfg    Config
+	stopCh chan struct{}
+}
+
+func NewScheduler(pool *pgxpool.Pool, cfg Config) *Scheduler {
+	cfg.defaults()
+	return &Scheduler{pool: pool, cfg: cfg, stopCh: make(chan struct{})}
+}
+
+// Start ticks on Interval until ctx is canceled or Stop is called.
+func (s *Scheduler) Start(ctx context.Context) error {
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.stopCh:
+			return nil
+		case <-ticker.C:
+			if n, err := s.FireDue(ctx); err != nil {
+				slog.Error("cron: tick failed", "err", err)
+			} else if n > 0 {
+				slog.Info("cron: fired due jobs", "count", n)
+			}
+		}
+	}
+}
+
+// Stop signals Start to exit. Idempotent.
+func (s *Scheduler) Stop() {
+	select {
+	case <-s.stopCh:
+	default:
+		close(s.stopCh)
+	}
+}
+
+type dueCron struct {
+	id          uuid.UUID
+	threadID    *uuid.UUID
+	assistantID uuid.UUID
+	schedule    string
+	input       []byte
+}
+
+// FireDue creates a run for every cron currently due and advances its
+// next_run_at. Returns how many fired.
+//
+// One transaction per cron, not one for the batch: a single unparseable
+// schedule must not roll back the runs already created for the others.
+func (s *Scheduler) FireDue(ctx context.Context) (int, error) {
+	now := time.Now().UTC()
+	fired := 0
+	for i := 0; i < s.cfg.Batch; i++ {
+		ok, err := s.fireOne(ctx, now)
+		if err != nil {
+			return fired, err
+		}
+		if !ok {
+			break
+		}
+		fired++
+	}
+	return fired, nil
+}
+
+// fireOne claims a single due cron, creates its run, and advances the
+// schedule — all in one transaction. Reports whether one was found.
+//
+// The claim is FOR UPDATE SKIP LOCKED so that running more than one control
+// plane does not fire the same cron twice: the second replica's SELECT steps
+// over the row the first is holding, and by commit next_run_at has moved into
+// the future so it is no longer due.
+func (s *Scheduler) fireOne(ctx context.Context, now time.Time) (bool, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
+
+	var c dueCron
+	err = tx.QueryRow(ctx, `
+		SELECT id, thread_id, assistant_id, schedule, input
+		FROM crons
+		WHERE next_run_at IS NOT NULL
+		  AND next_run_at <= $1
+		  AND (end_time IS NULL OR end_time > $1)
+		ORDER BY next_run_at
+		FOR UPDATE SKIP LOCKED
+		LIMIT 1`, now).Scan(&c.id, &c.threadID, &c.assistantID, &c.schedule, &c.input)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	next, err := NextRun(c.schedule, now)
+	if err != nil {
+		// An unparseable schedule can never fire. Clearing next_run_at retires
+		// it instead of leaving it permanently due and re-selected on every
+		// tick — the row stays for the operator to see and fix.
+		slog.Error("cron: retiring job with an invalid schedule",
+			"cron_id", c.id, "schedule", c.schedule, "err", err)
+		if _, uerr := tx.Exec(ctx,
+			`UPDATE crons SET next_run_at = NULL WHERE id = $1`, c.id); uerr != nil {
+			return false, uerr
+		}
+		return true, tx.Commit(ctx)
+	}
+
+	runID := uuid.New()
+	if err := eventstore.Append(ctx, tx, eventstore.Event{
+		AggregateType: "Run",
+		AggregateID:   runID,
+		EventType:     "run.created",
+		Payload: mustJSON(map[string]any{
+			"run_id":       runID.String(),
+			"assistant_id": c.assistantID.String(),
+			"cron_id":      c.id.String(),
+		}),
+	}); err != nil {
+		return false, err
+	}
+	// metadata records the origin so a run that appears unprompted can be
+	// traced back to the cron that asked for it.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO runs (id, thread_id, assistant_id, status, input, metadata)
+		VALUES ($1, $2, $3, 'queued', $4, $5)`,
+		runID, c.threadID, c.assistantID, jsonOrEmpty(c.input),
+		mustJSON(map[string]any{"cron_id": c.id.String()})); err != nil {
+		return false, err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE crons SET next_run_at = $2 WHERE id = $1`, c.id, next); err != nil {
+		return false, err
+	}
+	// Same notify the API path fires, so the relay picks the run up immediately
+	// rather than on its next poll.
+	if _, err := tx.Exec(ctx, `SELECT pg_notify('outbox_new', '')`); err != nil {
+		return false, err
+	}
+	return true, tx.Commit(ctx)
+}

--- a/controlplane/cron/json.go
+++ b/controlplane/cron/json.go
@@ -1,0 +1,21 @@
+package cron
+
+import "encoding/json"
+
+// mustJSON marshals a value that cannot fail to marshal (maps of strings).
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}
+
+// jsonOrEmpty defaults an absent payload to an empty object, matching the
+// runs.input NOT NULL DEFAULT '{}' column.
+func jsonOrEmpty(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("{}")
+	}
+	return b
+}

--- a/controlplane/db/migrations/platform/002_event_sourcing.down.sql
+++ b/controlplane/db/migrations/platform/002_event_sourcing.down.sql
@@ -1,0 +1,10 @@
+-- Reverse of 002_event_sourcing (platform).
+--
+-- update_updated_at_column is deliberately NOT dropped: 001_platform defines
+-- the same function and its users/tenants triggers still depend on it.
+DROP TABLE IF EXISTS outbox;
+DROP TABLE IF EXISTS snapshots;
+DROP TABLE IF EXISTS events;
+DROP TRIGGER IF EXISTS trg_increment_version_on_event ON events;
+DROP FUNCTION IF EXISTS increment_version_on_event();
+DROP TABLE IF EXISTS event_streams;

--- a/controlplane/db/migrations/platform/002_event_sourcing.up.sql
+++ b/controlplane/db/migrations/platform/002_event_sourcing.up.sql
@@ -1,0 +1,113 @@
+-- Event-sourcing infrastructure for the PLATFORM database — built from
+-- spec/models/d2/postgres.d2 (eventsourcing context), mirroring
+-- tenant/001_event_sourcing so the same eventstore.Append + writeTx path works
+-- against s.Platform.
+--
+-- Without this the platform surface could not emit a single event: the auth
+-- callback and every admin transition write user.*/tenant.* through writeTx on
+-- the platform pool (endpoints.yaml: db: platform), and relay.d2 routes those to
+-- the system account's PLATFORM_USERS / PLATFORM_TENANTS streams. The tables
+-- only ever existed per-tenant, so those writes had nowhere to land.
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto; -- gen_random_uuid()
+
+-- Shared updated_at trigger function (platform DB scope) — CREATE OR REPLACE so
+-- it is harmless alongside 001_platform, which defines the same function.
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- event_streams: one row per aggregate instance. version is the current
+-- stream version, auto-advanced by the increment_version_on_event trigger.
+CREATE TABLE event_streams (
+    stream_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    aggregate_type VARCHAR(100) NOT NULL,
+    aggregate_id   UUID NOT NULL,
+    version        INTEGER NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (aggregate_type, aggregate_id)
+);
+
+CREATE INDEX idx_event_streams_aggregate ON event_streams (aggregate_type, aggregate_id);
+
+-- events: append-only domain log. event_id is app-generated (UUID), written
+-- in the same TX as the outbox row that mirrors it. Never UPDATE or DELETE.
+CREATE TABLE events (
+    id             BIGSERIAL PRIMARY KEY,
+    event_id       UUID UNIQUE NOT NULL DEFAULT gen_random_uuid(),
+    stream_id      UUID NOT NULL REFERENCES event_streams (stream_id) ON DELETE CASCADE,
+    aggregate_type VARCHAR(100) NOT NULL,
+    aggregate_id   UUID NOT NULL,
+    event_type     VARCHAR(100) NOT NULL,
+    event_version  INTEGER NOT NULL,
+    payload        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_events_stream ON events (stream_id, event_version);
+CREATE INDEX idx_events_aggregate ON events (aggregate_type, aggregate_id);
+CREATE INDEX idx_events_type ON events (event_type);
+CREATE INDEX idx_events_occurred_at ON events (occurred_at);
+
+-- Advance the owning stream's version on every appended event. This is the
+-- ONLY trigger in the event path — the outbox is written by application code
+-- (no auto_publish_to_outbox trigger; see transactional-outbox.yml).
+CREATE OR REPLACE FUNCTION increment_version_on_event()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE event_streams
+       SET version = NEW.event_version,
+           updated_at = now()
+     WHERE stream_id = NEW.stream_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_increment_version_on_event
+    AFTER INSERT ON events
+    FOR EACH ROW EXECUTE FUNCTION increment_version_on_event();
+
+-- snapshots: periodic serialized aggregate state to bound replay cost.
+CREATE TABLE snapshots (
+    id             BIGSERIAL PRIMARY KEY,
+    stream_id      UUID NOT NULL REFERENCES event_streams (stream_id) ON DELETE CASCADE,
+    aggregate_type VARCHAR(100) NOT NULL,
+    aggregate_id   UUID NOT NULL,
+    version        INTEGER NOT NULL,
+    state          JSONB NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_snapshots_stream ON snapshots (stream_id, version DESC);
+
+-- outbox: mirrors each event for reliable publish to NATS. event_id matches
+-- events.event_id (written same TX). The relay drains WHERE NOT published AND
+-- (next_retry_at IS NULL OR next_retry_at <= now()), publishes with
+-- Nats-Msg-Id = event_id, then marks published / failed (attempts++,
+-- next_retry_at = exponential backoff).
+CREATE TABLE outbox (
+    id             BIGSERIAL PRIMARY KEY,
+    event_id       UUID UNIQUE NOT NULL,
+    aggregate_type VARCHAR(100) NOT NULL,
+    aggregate_id   UUID NOT NULL,
+    event_type     VARCHAR(100) NOT NULL,
+    payload        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    published      BOOLEAN NOT NULL DEFAULT FALSE,
+    published_at   TIMESTAMPTZ,
+    attempts       INTEGER NOT NULL DEFAULT 0,
+    last_error     TEXT,
+    next_retry_at  TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Drain index: only unpublished rows, ordered by id for FIFO publish.
+CREATE INDEX idx_outbox_unpublished ON outbox (id)
+    WHERE NOT published;

--- a/controlplane/db/migrations/platform/003_bootstrap_lock.down.sql
+++ b/controlplane/db/migrations/platform/003_bootstrap_lock.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS bootstrap_lock;

--- a/controlplane/db/migrations/platform/003_bootstrap_lock.up.sql
+++ b/controlplane/db/migrations/platform/003_bootstrap_lock.up.sql
@@ -1,0 +1,16 @@
+-- bootstrap_lock — atomic election of the very first user as admin.
+--
+-- The auth callback promotes the first-ever user to admin (endpoints.yaml,
+-- auth.callback branch "bootstrap"). Deciding that on SELECT count(*) = 0 is a
+-- race: two simultaneous first logins can both read 0 and both become admin.
+--
+-- The primary key is a BOOLEAN pinned TRUE by CHECK, so the table can hold at
+-- most ONE row ever. The first INSERT wins; every later one gets a unique
+-- violation (SQLSTATE 23505), which the caller reads as "someone else
+-- bootstrapped" and falls through to the normal pending-user path. The row is
+-- never deleted — bootstrap is a once-per-installation event.
+CREATE TABLE bootstrap_lock (
+    id         BOOLEAN     PRIMARY KEY DEFAULT TRUE,
+    claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT bootstrap_lock_id_must_be_true CHECK (id IS TRUE)
+);

--- a/controlplane/endpoints/admin.go
+++ b/controlplane/endpoints/admin.go
@@ -1,0 +1,459 @@
+// Hand-written admin endpoints (the operator surface at /api/admin/*). Routes
+// generated into admin_gen.go; bodies live here. Targets the PLATFORM database
+// (endpoints.yaml: group admin, db: platform) — users/tenants, not the
+// per-tenant workflow schema.
+//
+// Every mutating handler here is a STATE MACHINE TRANSITION, not a patch. The
+// spec gives each one a required starting state ("SELECT users WHERE id=:id AND
+// status='pending'"), and that guard is load-bearing: approving an already
+// approved user would re-fire tenant.provisioning and make the provisioner
+// rebuild a live tenant's database. So a wrong-state transition is refused with
+// 409 rather than silently doing nothing (which would look like success) or
+// applying anyway (which would corrupt).
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+)
+
+// adminUser is a users row as the admin surface reports it. oauth_id and the
+// provider are deliberately omitted: they are credentials-adjacent identifiers
+// and the operator console has no use for them.
+type adminUser struct {
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	Role      string    `json:"role"`
+	Status    string    `json:"status"`
+	TenantID  *string   `json:"tenant_id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// AdminListUsersResponse pairs the page with the total under the SAME filter,
+// so a console can render "showing 50 of 1,284" without a second call and
+// without inferring the total from a short page.
+type AdminListUsersResponse struct {
+	Users []adminUser `json:"users"`
+	Total int         `json:"total"`
+}
+
+// maxAdminPageSize caps limit. An operator console asking for everything must
+// not be able to turn one request into an unbounded scan + serialization.
+const maxAdminPageSize = 200
+
+// requireAdminIfConfigured is the auth gate for this surface.
+//
+// FAIL-OPEN WHEN UNCONFIGURED, AND THAT IS A REAL RISK. With no JWTSecret set,
+// s.requireAdmin cannot verify anything, so rather than 500 on every call this
+// lets the request through. That is tolerable ONLY because the composition root
+// does not mount the platform surface without a secret, and because it keeps
+// these endpoints drivable in tests that have no auth. It is NOT defence in
+// depth: anyone who mounts these routes with an empty AuthConfig publishes an
+// unauthenticated user-administration API.
+//
+// MUST BE REVISITED — the right shape is for the server to refuse to start when
+// the platform surface is enabled without a secret, at which point this helper
+// collapses to a plain s.requireAdmin call.
+func (s *Server) requireAdminIfConfigured(c echo.Context) error {
+	if len(s.Auth.JWTSecret) == 0 {
+		return nil
+	}
+	_, err := s.requireAdmin(c)
+	return err
+}
+
+// AdminListUsers lists platform users, newest-registration-last.
+// GET /api/admin/users?status=&limit=&offset= -> 200 AdminListUsersResponse.
+func (s *Server) AdminListUsers(c echo.Context) error {
+	ctx := c.Request().Context()
+	if err := s.requireAdminIfConfigured(c); err != nil {
+		return err
+	}
+
+	// An unrecognised status would silently return zero rows and read as "no
+	// such users" rather than "you asked a question I don't understand".
+	status := c.QueryParam("status")
+	if status != "" && !validUserStatus(status) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity,
+			"invalid status: must be pending, approved or suspended")
+	}
+	limit, err := intQueryParam(c, "limit", 50)
+	if err != nil {
+		return err
+	}
+	if limit > maxAdminPageSize {
+		limit = maxAdminPageSize
+	}
+	offset, err := intQueryParam(c, "offset", 0)
+	if err != nil {
+		return err
+	}
+
+	// $1 = "" means unfiltered, so one query serves both cases and the count
+	// below is guaranteed to use the identical predicate. Two separately
+	// written predicates would be free to drift.
+	rows, err := s.Platform.Query(ctx, `
+		SELECT u.id, u.email, u.role, u.status, t.id AS tenant_id, u.created_at, u.updated_at
+		FROM users u
+		LEFT JOIN tenants t ON t.user_id = u.id
+		WHERE ($1 = '' OR u.status = $1)
+		ORDER BY u.created_at, u.id
+		LIMIT $2 OFFSET $3`, status, limit, offset)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer rows.Close()
+
+	out := []adminUser{} // never nil — an empty page must marshal as [], not null
+	for rows.Next() {
+		var u adminUser
+		if err := rows.Scan(&u.ID, &u.Email, &u.Role, &u.Status, &u.TenantID, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		out = append(out, u)
+	}
+	if err := rows.Err(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	var total int
+	if err := s.Platform.QueryRow(ctx,
+		`SELECT count(*) FROM users WHERE ($1 = '' OR status = $1)`, status).Scan(&total); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, AdminListUsersResponse{Users: out, Total: total})
+}
+
+// AdminApprove admits a pending user and starts tenant provisioning.
+// POST /api/admin/users/{id}/approve -> 200 adminUser / 404 / 409.
+//
+// tenant.provisioning is the event the platform-provisioner consumer acts on
+// (endpoints.yaml side_effect): CREATE DATABASE + migrate + NATS account. It is
+// therefore emitted in the SAME transaction as the status flips — if the commit
+// fails, no consumer ever sees a provisioning request for a user who is not
+// approved.
+func (s *Server) AdminApprove(c echo.Context) error {
+	return s.adminUserTransition(c, userTransition{
+		from:     "pending",
+		to:       "approved",
+		tenantTo: "provisioning",
+		events:   []string{"user.approved", "tenant.provisioning"},
+	})
+}
+
+// AdminReject refuses a pending user.
+// POST /api/admin/users/{id}/reject -> 200 adminUser / 404 / 409.
+//
+// Rejection lands the user in 'suspended', not a dedicated 'rejected' state:
+// the users CHECK admits only pending|approved|suspended (001_platform), and
+// the spec's step is explicit ("UPDATE users SET status='suspended'"). The
+// distinction between "rejected" and "suspended later" therefore lives in the
+// event log — user.rejected vs user.suspended — not in the row. The tenant is
+// left untouched: it never left 'pending', so there is nothing to unwind.
+func (s *Server) AdminReject(c echo.Context) error {
+	return s.adminUserTransition(c, userTransition{
+		from:   "pending",
+		to:     "suspended",
+		events: []string{"user.rejected"},
+	})
+}
+
+// AdminSuspend suspends an approved user and their tenant.
+// POST /api/admin/users/{id}/suspend -> 200 adminUser / 404 / 409.
+func (s *Server) AdminSuspend(c echo.Context) error {
+	return s.adminUserTransition(c, userTransition{
+		from:     "approved",
+		to:       "suspended",
+		tenantTo: "suspended",
+		events:   []string{"user.suspended", "tenant.suspended"},
+	})
+}
+
+// AdminResume restores a suspended user and their tenant.
+// POST /api/admin/users/{id}/resume -> 200 adminUser / 404 / 409.
+//
+// Emits NOTHING: endpoints.yaml marks this endpoint outbox:false and notes the
+// user.resumed event is "not yet in spec". So this is the one transition with
+// no audit trail in the event log — a real gap, but inventing an event here
+// would put a type on the wire that no consumer or schema knows about.
+func (s *Server) AdminResume(c echo.Context) error {
+	return s.adminUserTransition(c, userTransition{
+		from:     "suspended",
+		to:       "approved",
+		tenantTo: "approved",
+	})
+}
+
+// userTransition describes one admin state change: the required starting state,
+// the target, the optional tenant target, and the events to emit.
+type userTransition struct {
+	from     string
+	to       string
+	tenantTo string   // "" = leave the tenant alone
+	events   []string // empty = no events (see AdminResume)
+}
+
+// adminUserTransition runs a guarded user state change.
+//
+// The guard and the write are ONE statement (`UPDATE ... WHERE status = from`),
+// not a SELECT then an UPDATE. Two operators clicking approve simultaneously
+// would both pass a separate SELECT and both emit tenant.provisioning; here the
+// second UPDATE matches no row and is refused. The follow-up SELECT exists only
+// to tell 404 (no such user) from 409 (wrong state) for the error message.
+func (s *Server) adminUserTransition(c echo.Context, t userTransition) error {
+	ctx := c.Request().Context()
+	if err := s.requireAdminIfConfigured(c); err != nil {
+		return err
+	}
+	uid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
+
+	var out adminUser
+	var tenantID *uuid.UUID
+	err = s.writeTxDeferred(ctx, s.Platform, func(tx pgx.Tx) ([]eventstore.Event, error) {
+		var email, role string
+		cmdErr := tx.QueryRow(ctx, `
+			UPDATE users SET status = $2
+			WHERE id = $1 AND status = $3
+			RETURNING email, role`, uid, t.to, t.from).Scan(&email, &role)
+		if errors.Is(cmdErr, pgx.ErrNoRows) {
+			return nil, s.explainTransitionMiss(ctx, uid, t.from)
+		}
+		if cmdErr != nil {
+			return nil, cmdErr
+		}
+
+		// The tenant is optional: a user rejected before provisioning may have
+		// one in 'pending', and a bootstrap admin always does. Update it when
+		// present, and capture its id either way so the events and the response
+		// can name it.
+		if t.tenantTo != "" {
+			var tid uuid.UUID
+			terr := tx.QueryRow(ctx,
+				`UPDATE tenants SET status = $2, failure_reason = NULL WHERE user_id = $1 RETURNING id`,
+				uid, t.tenantTo).Scan(&tid)
+			if terr == nil {
+				tenantID = &tid
+			} else if !errors.Is(terr, pgx.ErrNoRows) {
+				return nil, terr
+			}
+		} else {
+			var tid uuid.UUID
+			terr := tx.QueryRow(ctx, `SELECT id FROM tenants WHERE user_id = $1`, uid).Scan(&tid)
+			if terr == nil {
+				tenantID = &tid
+			} else if !errors.Is(terr, pgx.ErrNoRows) {
+				return nil, terr
+			}
+		}
+
+		if err := tx.QueryRow(ctx, `
+			SELECT id, email, role, status, created_at, updated_at
+			FROM users WHERE id = $1`, uid).
+			Scan(&out.ID, &out.Email, &out.Role, &out.Status, &out.CreatedAt, &out.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if tenantID != nil {
+			s := tenantID.String()
+			out.TenantID = &s
+		}
+		return adminEvents(t.events, uid, tenantID, email, role, t.to, t.tenantTo), nil
+	})
+	if err != nil {
+		return httpFromWriteErr(err)
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+// explainTransitionMiss turns "the guarded UPDATE matched nothing" into the
+// right error: 404 when there is no such user, 409 naming the actual state when
+// there is. Without this split every wrong-state click would read as 404 and
+// look like the user had been deleted.
+func (s *Server) explainTransitionMiss(ctx context.Context, uid uuid.UUID, want string) error {
+	var current string
+	err := s.Platform.QueryRow(ctx, `SELECT status FROM users WHERE id = $1`, uid).Scan(&current)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return echo.NewHTTPError(http.StatusNotFound, "user not found")
+	}
+	if err != nil {
+		return err
+	}
+	return echo.NewHTTPError(http.StatusConflict,
+		"user is "+current+"; this action requires "+want)
+}
+
+// adminEvents builds the event set for a transition. AggregateID is the REAL
+// user or tenant uuid — an earlier stub emitted these against a fresh
+// uuid.New(), which produced events that could never be correlated with the
+// row they described.
+func adminEvents(types []string, uid uuid.UUID, tenantID *uuid.UUID, email, role, userStatus, tenantStatus string) []eventstore.Event {
+	out := make([]eventstore.Event, 0, len(types))
+	for _, et := range types {
+		switch {
+		case len(et) > 5 && et[:5] == "user.":
+			out = append(out, eventstore.Event{
+				AggregateType: "User",
+				AggregateID:   uid,
+				EventType:     et,
+				Payload: mustJSON(map[string]any{
+					"user_id": uid.String(),
+					"email":   email,
+					"role":    role,
+					"status":  userStatus,
+				}),
+			})
+		case tenantID != nil:
+			out = append(out, eventstore.Event{
+				AggregateType: "Tenant",
+				AggregateID:   *tenantID,
+				EventType:     et,
+				Payload: mustJSON(map[string]any{
+					"tenant_id": tenantID.String(),
+					"user_id":   uid.String(),
+					"status":    tenantStatus,
+				}),
+			})
+		}
+		// A tenant.* event with no tenant row is dropped rather than emitted
+		// against a placeholder id: there is genuinely nothing to provision.
+	}
+	return out
+}
+
+// AdminRetryMigration re-queues a tenant whose provisioning failed.
+// POST /api/admin/tenants/{id}/retry-migration -> 200 / 404 / 409.
+//
+// SPEC vs SCHEMA, resolved toward the schema. endpoints.yaml prescribes
+// "SELECT tenants WHERE id=:id AND status='provisioning_failed'", but the
+// tenants CHECK in 001_platform admits only
+// pending|provisioning|approved|failed|suspended — 'provisioning_failed' is not
+// a value the column can ever hold, so the spec's guard would match zero rows
+// forever and this endpoint could never do anything. The equivalent state in
+// the actual schema is 'failed' (tenants.failure_reason carries the detail),
+// and that is what is used here. The spec text should be corrected to match.
+func (s *Server) AdminRetryMigration(c echo.Context) error {
+	ctx := c.Request().Context()
+	if err := s.requireAdminIfConfigured(c); err != nil {
+		return err
+	}
+	tid, err := pathUUID(c, "id")
+	if err != nil {
+		return err
+	}
+
+	var userID uuid.UUID
+	err = s.writeTxDeferred(ctx, s.Platform, func(tx pgx.Tx) ([]eventstore.Event, error) {
+		cmdErr := tx.QueryRow(ctx, `
+			UPDATE tenants SET status = 'provisioning', failure_reason = NULL
+			WHERE id = $1 AND status = 'failed'
+			RETURNING user_id`, tid).Scan(&userID)
+		if errors.Is(cmdErr, pgx.ErrNoRows) {
+			var current string
+			qerr := s.Platform.QueryRow(ctx, `SELECT status FROM tenants WHERE id = $1`, tid).Scan(&current)
+			if errors.Is(qerr, pgx.ErrNoRows) {
+				return nil, echo.NewHTTPError(http.StatusNotFound, "tenant not found")
+			}
+			if qerr != nil {
+				return nil, qerr
+			}
+			return nil, echo.NewHTTPError(http.StatusConflict,
+				"tenant is "+current+"; retry requires a failed provisioning")
+		}
+		if cmdErr != nil {
+			return nil, cmdErr
+		}
+		return []eventstore.Event{{
+			AggregateType: "Tenant",
+			AggregateID:   tid,
+			EventType:     "tenant.provisioning",
+			Payload: mustJSON(map[string]any{
+				"tenant_id": tid.String(),
+				"user_id":   userID.String(),
+				"status":    "provisioning",
+				"retry":     true,
+			}),
+		}}, nil
+	})
+	if err != nil {
+		return httpFromWriteErr(err)
+	}
+	return c.JSON(http.StatusOK, map[string]any{
+		"tenant_id": tid.String(),
+		"status":    "provisioning",
+	})
+}
+
+// AdminMetrics and AdminMetricsTenant are declared against a Mimir PromQL
+// backend (endpoints.yaml: backend: mimir) that does not exist anywhere in this
+// repository — there is no Mimir client, no configuration for one, and
+// /metrics on the system surface only exposes the default Go/process
+// collectors.
+//
+// They therefore answer 501 and name the missing dependency. The alternative —
+// returning a plausible-looking zeroed or synthesised body, which is what the
+// previous stub's empty 200 amounted to — is worse than an honest refusal: a
+// dashboard cannot tell invented numbers from real ones, and "all tenants show
+// zero runs" reads as an outage rather than as an unimplemented endpoint.
+func (s *Server) AdminMetrics(c echo.Context) error {
+	if err := s.requireAdminIfConfigured(c); err != nil {
+		return err
+	}
+	return echo.NewHTTPError(http.StatusNotImplemented,
+		"cross-tenant metrics require a Mimir backend, which is not configured in this deployment")
+}
+
+// AdminMetricsTenant — see AdminMetrics.
+func (s *Server) AdminMetricsTenant(c echo.Context) error {
+	if err := s.requireAdminIfConfigured(c); err != nil {
+		return err
+	}
+	if _, err := pathUUID(c, "tenant_id"); err != nil {
+		return err
+	}
+	return echo.NewHTTPError(http.StatusNotImplemented,
+		"per-tenant metrics require a Mimir backend, which is not configured in this deployment")
+}
+
+// validUserStatus reports whether s is one of the users CHECK values.
+func validUserStatus(s string) bool {
+	return s == "pending" || s == "approved" || s == "suspended"
+}
+
+// intQueryParam reads an optional integer query parameter, 422ing a malformed
+// one rather than letting strconv's zero value silently become the answer.
+func intQueryParam(c echo.Context, name string, def int) (int, error) {
+	raw := c.QueryParam(name)
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, echo.NewHTTPError(http.StatusUnprocessableEntity,
+			"invalid "+name+": must be a non-negative integer")
+	}
+	return n, nil
+}
+
+// httpFromWriteErr passes an echo.HTTPError raised inside a transaction through
+// unchanged, and turns anything else into a 500. Without this every deliberate
+// 404/409 chosen inside the projection would be flattened into a 500 on the way
+// out.
+func httpFromWriteErr(err error) error {
+	var he *echo.HTTPError
+	if errors.As(err, &he) {
+		return he
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+}

--- a/controlplane/endpoints/admin_gen.go
+++ b/controlplane/endpoints/admin_gen.go
@@ -4,10 +4,6 @@
 package endpoints
 
 import (
-	"net/http"
-
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
 
@@ -23,184 +19,18 @@ func (s *Server) RegisterAdmin(g *echo.Group) {
 	g.GET("/api/admin/metrics/:tenant_id", s.AdminMetricsTenant)
 }
 
-// AdminListUsers — GET /api/admin/users  (kind: read)
-//   - SELECT * FROM users WHERE status = :filter ORDER BY created_at LIMIT :limit OFFSET :offset
-//   - SELECT count(*) FROM users WHERE status = :filter
-func (s *Server) AdminListUsers(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   SELECT * FROM users WHERE status = :filter ORDER BY created_at LIMIT :limit OFFSET :offset
-	//   SELECT count(*) FROM users WHERE status = :filter
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// AdminListUsers — GET /api/admin/users  (kind: read) — hand-written in admin.go
 
-// AdminApprove — POST /api/admin/users/{id}/approve  (kind: write)
-//   - SELECT users WHERE id=:id AND status='pending' (validate)
-//   - UPDATE users SET status='approved'
-//   - UPDATE tenants SET status='provisioning' WHERE user_id=:id
-//   - INSERT events: user.approved + tenant.provisioning
-//   - INSERT outbox (both events, same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) AdminApprove(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (AdminApprove request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "User", AggregateID: aggID, EventType: "user.approved"},
-		{AggregateType: "Tenant", AggregateID: aggID, EventType: "tenant.provisioning"},
-	}
-	if err := s.writeTx(ctx, s.Platform, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   SELECT users WHERE id=:id AND status='pending' (validate)
-		//   UPDATE users SET status='approved'
-		//   UPDATE tenants SET status='provisioning' WHERE user_id=:id
-		//   INSERT events: user.approved + tenant.provisioning
-		//   INSERT outbox (both events, same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// AdminApprove — POST /api/admin/users/{id}/approve  (kind: write) — hand-written in admin.go
 
-// AdminReject — POST /api/admin/users/{id}/reject  (kind: write)
-//   - SELECT users WHERE id=:id AND status='pending'
-//   - UPDATE users SET status='suspended'
-//   - INSERT events: user.rejected
-//   - INSERT outbox (same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) AdminReject(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (AdminReject request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "User", AggregateID: aggID, EventType: "user.rejected"},
-	}
-	if err := s.writeTx(ctx, s.Platform, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   SELECT users WHERE id=:id AND status='pending'
-		//   UPDATE users SET status='suspended'
-		//   INSERT events: user.rejected
-		//   INSERT outbox (same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// AdminReject — POST /api/admin/users/{id}/reject  (kind: write) — hand-written in admin.go
 
-// AdminSuspend — POST /api/admin/users/{id}/suspend  (kind: write)
-//   - SELECT users WHERE id=:id AND status='approved'
-//   - UPDATE users SET status='suspended'
-//   - UPDATE tenants SET status='suspended' WHERE user_id=:id
-//   - INSERT events: user.suspended + tenant.suspended
-//   - INSERT outbox (same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) AdminSuspend(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (AdminSuspend request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "User", AggregateID: aggID, EventType: "user.suspended"},
-		{AggregateType: "Tenant", AggregateID: aggID, EventType: "tenant.suspended"},
-	}
-	if err := s.writeTx(ctx, s.Platform, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   SELECT users WHERE id=:id AND status='approved'
-		//   UPDATE users SET status='suspended'
-		//   UPDATE tenants SET status='suspended' WHERE user_id=:id
-		//   INSERT events: user.suspended + tenant.suspended
-		//   INSERT outbox (same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// AdminSuspend — POST /api/admin/users/{id}/suspend  (kind: write) — hand-written in admin.go
 
-// AdminResume — POST /api/admin/users/{id}/resume  (kind: write)
-//   - SELECT users WHERE id=:id AND status='suspended'
-//   - UPDATE users SET status='approved'
-//   - UPDATE tenants SET status='approved' WHERE user_id=:id
-//   - # optional user.resumed event — not yet in spec
-func (s *Server) AdminResume(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (AdminResume request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	// projection-only write (not event-sourced — no outbox):
-	//   SELECT users WHERE id=:id AND status='suspended'
-	//   UPDATE users SET status='approved'
-	//   UPDATE tenants SET status='approved' WHERE user_id=:id
-	//   # optional user.resumed event — not yet in spec
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// AdminResume — POST /api/admin/users/{id}/resume  (kind: write) — hand-written in admin.go
 
-// AdminRetryMigration — POST /api/admin/tenants/{id}/retry-migration  (kind: write)
-//   - SELECT tenants WHERE id=:id AND status='provisioning_failed'
-//   - UPDATE tenants SET status='provisioning', failure_reason=NULL
-//   - INSERT events: tenant.provisioning
-//   - INSERT outbox (same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) AdminRetryMigration(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (AdminRetryMigration request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "Tenant", AggregateID: aggID, EventType: "tenant.provisioning"},
-	}
-	if err := s.writeTx(ctx, s.Platform, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   SELECT tenants WHERE id=:id AND status='provisioning_failed'
-		//   UPDATE tenants SET status='provisioning', failure_reason=NULL
-		//   INSERT events: tenant.provisioning
-		//   INSERT outbox (same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// AdminRetryMigration — POST /api/admin/tenants/{id}/retry-migration  (kind: write) — hand-written in admin.go
 
-// AdminMetrics — GET /api/admin/metrics  (kind: read)
-//   - Query Mimir PromQL: sum by (tenant_id) rate(runs_total[window])
-func (s *Server) AdminMetrics(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   Query Mimir PromQL: sum by (tenant_id) rate(runs_total[window])
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// AdminMetrics — GET /api/admin/metrics  (kind: read) — hand-written in admin.go
 
-// AdminMetricsTenant — GET /api/admin/metrics/{tenant_id}  (kind: read)
-//   - Query Mimir PromQL: rate(runs_total{tenant_id=...}[window])
-func (s *Server) AdminMetricsTenant(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   Query Mimir PromQL: rate(runs_total{tenant_id=...}[window])
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// AdminMetricsTenant — GET /api/admin/metrics/{tenant_id}  (kind: read) — hand-written in admin.go

--- a/controlplane/endpoints/admin_integration_test.go
+++ b/controlplane/endpoints/admin_integration_test.go
@@ -1,0 +1,361 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// truncatePlatform resets the platform tables. The pool is shared across the
+// package, so every test in this file starts from a known-empty state.
+func truncatePlatform(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, err := testPlatform.Exec(ctx,
+		`TRUNCATE users, tenants, bootstrap_lock, events, event_streams, outbox CASCADE`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newAdminServer() *echo.Echo {
+	e := echo.New()
+	(&Server{Platform: testPlatform}).RegisterAdmin(e.Group(""))
+	return e
+}
+
+// seedPlatformUser inserts a user (and, unless tenantStatus is "", their
+// tenant) and returns both ids.
+func seedPlatformUser(t *testing.T, ctx context.Context, email, role, status, tenantStatus string) (string, string) {
+	t.Helper()
+	var uid string
+	if err := testPlatform.QueryRow(ctx,
+		`INSERT INTO users (oauth_provider, oauth_id, email, role, status)
+		 VALUES ('google', $1, $1, $2, $3) RETURNING id`, email, role, status).Scan(&uid); err != nil {
+		t.Fatal(err)
+	}
+	var tid string
+	if tenantStatus != "" {
+		if err := testPlatform.QueryRow(ctx,
+			`INSERT INTO tenants (user_id, db_name, status)
+			 VALUES ($1, 'tenant_' || replace(gen_random_uuid()::text,'-',''), $2) RETURNING id`,
+			uid, tenantStatus).Scan(&tid); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return uid, tid
+}
+
+func doAdmin(e *echo.Echo, method, path string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Content-Type", "application/json")
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+// userStatus / tenantStatus read the rows back so assertions are against the
+// database rather than the handler's own response.
+func userStatus(t *testing.T, ctx context.Context, uid string) string {
+	t.Helper()
+	var s string
+	if err := testPlatform.QueryRow(ctx, `SELECT status FROM users WHERE id=$1`, uid).Scan(&s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func tenantStatusOf(t *testing.T, ctx context.Context, tid string) string {
+	t.Helper()
+	var s string
+	if err := testPlatform.QueryRow(ctx, `SELECT status FROM tenants WHERE id=$1`, tid).Scan(&s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// eventTypesFor returns the event types recorded against an aggregate id. The
+// aggregate id is the point: a previous stub emitted these against a fresh
+// uuid.New(), so events existed but could never be tied to the row they
+// described. Querying BY id is what catches a regression to that.
+func eventTypesFor(t *testing.T, ctx context.Context, aggID string) []string {
+	t.Helper()
+	rows, err := testPlatform.Query(ctx,
+		`SELECT event_type FROM events WHERE aggregate_id=$1 ORDER BY id`, aggID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestAdminApproveTransition covers the transition that has a real side effect:
+// tenant.provisioning is what makes the provisioner build a database.
+func TestAdminApproveTransition(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	uid, tid := seedPlatformUser(t, ctx, "approve@test", "user", "pending", "pending")
+
+	rec := doAdmin(e, "POST", "/api/admin/users/"+uid+"/approve")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := userStatus(t, ctx, uid); got != "approved" {
+		t.Errorf("user status: want approved, got %q", got)
+	}
+	// The tenant must move too — approving a user without starting their
+	// tenant would leave an approved account with nothing to talk to.
+	if got := tenantStatusOf(t, ctx, tid); got != "provisioning" {
+		t.Errorf("tenant status: want provisioning, got %q", got)
+	}
+
+	if got := eventTypesFor(t, ctx, uid); len(got) != 1 || got[0] != "user.approved" {
+		t.Errorf("events on the user aggregate: want [user.approved], got %v", got)
+	}
+	if got := eventTypesFor(t, ctx, tid); len(got) != 1 || got[0] != "tenant.provisioning" {
+		t.Errorf("events on the tenant aggregate: want [tenant.provisioning], got %v", got)
+	}
+}
+
+func TestAdminSuspendResumeRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	uid, tid := seedPlatformUser(t, ctx, "suspend@test", "user", "approved", "approved")
+
+	if rec := doAdmin(e, "POST", "/api/admin/users/"+uid+"/suspend"); rec.Code != http.StatusOK {
+		t.Fatalf("suspend: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := userStatus(t, ctx, uid); got != "suspended" {
+		t.Errorf("after suspend, user: want suspended, got %q", got)
+	}
+	if got := tenantStatusOf(t, ctx, tid); got != "suspended" {
+		t.Errorf("after suspend, tenant: want suspended, got %q", got)
+	}
+
+	if rec := doAdmin(e, "POST", "/api/admin/users/"+uid+"/resume"); rec.Code != http.StatusOK {
+		t.Fatalf("resume: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := userStatus(t, ctx, uid); got != "approved" {
+		t.Errorf("after resume, user: want approved, got %q", got)
+	}
+	if got := tenantStatusOf(t, ctx, tid); got != "approved" {
+		t.Errorf("after resume, tenant: want approved, got %q", got)
+	}
+
+	// resume is outbox:false in endpoints.yaml, so it must emit NOTHING. This
+	// is a real audit gap, asserted here so it stays a deliberate one.
+	got := eventTypesFor(t, ctx, uid)
+	for _, et := range got {
+		if strings.Contains(et, "resume") {
+			t.Errorf("resume must not emit an event (endpoints.yaml outbox:false), got %v", got)
+		}
+	}
+}
+
+func TestAdminRejectLeavesTenantAlone(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	uid, tid := seedPlatformUser(t, ctx, "reject@test", "user", "pending", "pending")
+
+	if rec := doAdmin(e, "POST", "/api/admin/users/"+uid+"/reject"); rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := userStatus(t, ctx, uid); got != "suspended" {
+		t.Errorf("user: want suspended, got %q", got)
+	}
+	// Rejection never provisioned anything, so there is nothing to unwind.
+	if got := tenantStatusOf(t, ctx, tid); got != "pending" {
+		t.Errorf("tenant must be untouched by a rejection: want pending, got %q", got)
+	}
+	if got := eventTypesFor(t, ctx, uid); len(got) != 1 || got[0] != "user.rejected" {
+		t.Errorf("want [user.rejected], got %v", got)
+	}
+}
+
+// TestAdminWrongStateIs409 is the guard that stops a second approve from
+// re-firing tenant.provisioning at a live tenant.
+func TestAdminWrongStateIs409(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	approved, _ := seedPlatformUser(t, ctx, "already@test", "user", "approved", "approved")
+	pending, _ := seedPlatformUser(t, ctx, "pending@test", "user", "pending", "pending")
+
+	for _, tc := range []struct{ name, path string }{
+		{"approve an already-approved user", "/api/admin/users/" + approved + "/approve"},
+		{"reject an already-approved user", "/api/admin/users/" + approved + "/reject"},
+		{"suspend a pending user", "/api/admin/users/" + pending + "/suspend"},
+		{"resume a pending user", "/api/admin/users/" + pending + "/resume"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doAdmin(e, "POST", tc.path)
+			if rec.Code != http.StatusConflict {
+				t.Errorf("want 409, got %d: %s", rec.Code, rec.Body.String())
+			}
+			// The message must name the state actually found, otherwise an
+			// operator cannot tell why the action was refused.
+			if !strings.Contains(rec.Body.String(), "approved") && !strings.Contains(rec.Body.String(), "pending") {
+				t.Errorf("409 should name the current state, got: %s", rec.Body.String())
+			}
+		})
+	}
+
+	// A refused transition must not have emitted anything.
+	if got := eventTypesFor(t, ctx, approved); len(got) != 0 {
+		t.Errorf("a refused transition must emit no events, got %v", got)
+	}
+}
+
+func TestAdminUnknownIDIs404(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	missing := "11111111-1111-1111-1111-111111111111"
+	for _, path := range []string{
+		"/api/admin/users/" + missing + "/approve",
+		"/api/admin/users/" + missing + "/suspend",
+		"/api/admin/tenants/" + missing + "/retry-migration",
+	} {
+		if rec := doAdmin(e, "POST", path); rec.Code != http.StatusNotFound {
+			t.Errorf("%s: want 404, got %d: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+	// Malformed ids are a validation error, not a miss, and must not reach
+	// Postgres as a 22P02.
+	rec := doAdmin(e, "POST", "/api/admin/users/not-a-uuid/approve")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("malformed id: want 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "SQLSTATE") {
+		t.Errorf("response leaks the driver error: %s", rec.Body.String())
+	}
+}
+
+// TestAdminRetryMigration pins the spec-vs-schema resolution: endpoints.yaml
+// says the guard state is 'provisioning_failed', which the tenants CHECK cannot
+// hold. 'failed' is the real one.
+func TestAdminRetryMigration(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	_, tid := seedPlatformUser(t, ctx, "retry@test", "user", "approved", "failed")
+	if _, err := testPlatform.Exec(ctx,
+		`UPDATE tenants SET failure_reason='disk full' WHERE id=$1`, tid); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec := doAdmin(e, "POST", "/api/admin/tenants/"+tid+"/retry-migration"); rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := tenantStatusOf(t, ctx, tid); got != "provisioning" {
+		t.Errorf("tenant: want provisioning, got %q", got)
+	}
+	// The old reason must be cleared, or the next failure is indistinguishable
+	// from the last one.
+	var reason *string
+	if err := testPlatform.QueryRow(ctx, `SELECT failure_reason FROM tenants WHERE id=$1`, tid).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if reason != nil {
+		t.Errorf("failure_reason: want NULL after a retry, got %q", *reason)
+	}
+	if got := eventTypesFor(t, ctx, tid); len(got) != 1 || got[0] != "tenant.provisioning" {
+		t.Errorf("want [tenant.provisioning], got %v", got)
+	}
+
+	// A tenant that is not failed cannot be retried.
+	if rec := doAdmin(e, "POST", "/api/admin/tenants/"+tid+"/retry-migration"); rec.Code != http.StatusConflict {
+		t.Errorf("retrying a non-failed tenant: want 409, got %d", rec.Code)
+	}
+}
+
+func TestAdminListUsers(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	seedPlatformUser(t, ctx, "a@test", "admin", "approved", "approved")
+	seedPlatformUser(t, ctx, "b@test", "user", "pending", "pending")
+	seedPlatformUser(t, ctx, "c@test", "user", "pending", "pending")
+
+	var resp AdminListUsersResponse
+	rec := doAdmin(e, "GET", "/api/admin/users")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != 3 || len(resp.Users) != 3 {
+		t.Errorf("unfiltered: want 3/3, got %d/%d", len(resp.Users), resp.Total)
+	}
+
+	// The filter must constrain BOTH the page and the total, or a console
+	// renders "showing 2 of 3" for a filtered view.
+	rec = doAdmin(e, "GET", "/api/admin/users?status=pending")
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != 2 || len(resp.Users) != 2 {
+		t.Errorf("status=pending: want 2/2, got %d/%d", len(resp.Users), resp.Total)
+	}
+
+	// Pagination: the total stays the FULL count while the page shrinks.
+	rec = doAdmin(e, "GET", "/api/admin/users?limit=1&offset=1")
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Users) != 1 || resp.Total != 3 {
+		t.Errorf("limit=1&offset=1: want 1 user of total 3, got %d/%d", len(resp.Users), resp.Total)
+	}
+
+	// An unrecognised status must not silently read as "no such users".
+	if rec := doAdmin(e, "GET", "/api/admin/users?status=bogus"); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status=bogus: want 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := doAdmin(e, "GET", "/api/admin/users?limit=abc"); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("limit=abc: want 422, got %d", rec.Code)
+	}
+}
+
+// TestAdminMetricsAreHonestlyUnimplemented — the endpoints declare a Mimir
+// backend that does not exist here. 501 is the honest answer; the previous
+// stub's empty 200 was indistinguishable from "every tenant has zero activity".
+func TestAdminMetricsAreHonestlyUnimplemented(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAdminServer()
+
+	for _, path := range []string{
+		"/api/admin/metrics",
+		"/api/admin/metrics/11111111-1111-1111-1111-111111111111",
+	} {
+		rec := doAdmin(e, "GET", path)
+		if rec.Code != http.StatusNotImplemented {
+			t.Errorf("%s: want 501, got %d: %s", path, rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(strings.ToLower(rec.Body.String()), "mimir") {
+			t.Errorf("%s: the 501 should name the missing backend, got: %s", path, rec.Body.String())
+		}
+	}
+}

--- a/controlplane/endpoints/assistants_graph.go
+++ b/controlplane/endpoints/assistants_graph.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
@@ -16,13 +17,31 @@ import (
 // assistant with no graph row).
 func (s *Server) AssistantsGetGraph(c echo.Context) error {
 	ctx := c.Request().Context()
-	aid := c.Param("id")
+
+	// assistant_id here is NOT uuid-only. The OpenAPI types it as
+	// anyOf[{string,format:uuid,"Assistant ID"}, {string,"Graph ID"}], so a
+	// non-UUID is a LEGAL request identifying the graph by name — not a
+	// validation error. Interpolating it raw into `WHERE assistant_id = $1`
+	// (a uuid column) made Postgres reject the legal form:
+	//
+	//	GET /assistants/my-graph/graph
+	//	  500 {"message":"ERROR: invalid input syntax for type uuid: \"my-graph\" (SQLSTATE 22P02)"}
+	//
+	// So the branch is on which arm of the anyOf was sent: a UUID selects by
+	// assistant, anything else by graphs.name (indexed, idx_graphs_name).
+	// A name that matches nothing falls through to the same 404 as an unknown
+	// assistant, which is the declared response.
+	raw := c.Param("id")
+	where, arg := "name = $1", raw
+	if _, err := uuid.Parse(raw); err == nil {
+		where, arg = "assistant_id = $1", raw
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, assistant_id, name, version, description, nodes, edges, config, created_at, updated_at
 		FROM graphs
-		WHERE assistant_id = $1
+		WHERE `+where+`
 		ORDER BY version DESC
-		LIMIT 1`, aid)
+		LIMIT 1`, arg)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/controlplane/endpoints/assistants_integration_test.go
+++ b/controlplane/endpoints/assistants_integration_test.go
@@ -31,8 +31,9 @@ import (
 // Both are populated by TestMain and shared across every test in this
 // package.
 var (
-	testPool *pgxpool.Pool
-	testNATS *natsgo.Conn
+	testPool     *pgxpool.Pool
+	testPlatform *pgxpool.Pool
+	testNATS     *natsgo.Conn
 )
 
 func TestMain(m *testing.M) {
@@ -119,7 +120,29 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
 		os.Exit(1)
 	}
+
+	// --- platform database (same container, separate DB) ---
+	// The platform surface (auth, admin, /me) targets its own database
+	// (endpoints.yaml: db: platform), with its own users/tenants tables AND its
+	// own eventstore. A separate DB in the same container keeps the two schemas
+	// genuinely distinct — a handler that reaches for the wrong pool fails here
+	// rather than silently finding a table that only exists per-tenant.
+	if _, err := testPool.Exec(ctx, "CREATE DATABASE platform"); err != nil {
+		fmt.Fprintf(os.Stderr, "create platform db: %v\n", err)
+		os.Exit(1)
+	}
+	platDSN := strings.Replace(dsn, "/tenant?", "/platform?", 1)
+	testPlatform, err = pgxpool.New(ctx, platDSN)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "platform pool: %v\n", err)
+		os.Exit(1)
+	}
+	if err := applyMigrations(ctx, testPlatform, "platform"); err != nil {
+		fmt.Fprintf(os.Stderr, "platform migrate: %v\n", err)
+		os.Exit(1)
+	}
 	code := m.Run()
+	testPlatform.Close()
 	testPool.Close()
 	_ = pg.Terminate(ctx)
 	os.Exit(code)
@@ -137,8 +160,16 @@ func freeTCPPort() (int, error) {
 }
 
 // applyTenantMigrations runs every tenant *.up.sql in order against the pool.
+// applyTenantMigrations applies the tenant migration set.
 func applyTenantMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-	dir := filepath.Join("..", "db", "migrations", "tenant")
+	return applyMigrations(ctx, pool, "tenant")
+}
+
+// applyMigrations applies every *.up.sql in db/migrations/<set> in filename
+// order. Globbed rather than listed so a new migration is picked up by the
+// suite the moment it lands.
+func applyMigrations(ctx context.Context, pool *pgxpool.Pool, set string) error {
+	dir := filepath.Join("..", "db", "migrations", set)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return err

--- a/controlplane/endpoints/auth.go
+++ b/controlplane/endpoints/auth.go
@@ -1,0 +1,456 @@
+// Hand-written auth endpoints (the OAuth surface at /api/auth/*). Routes
+// generated into auth_gen.go; bodies live here. Targets the PLATFORM database
+// (endpoints.yaml: group auth, db: platform).
+//
+// The provider exchange itself is NOT reimplemented: the Exchanger seam and its
+// goth-backed implementation already exist in
+// internal/infrastructure/http/handlers/auth and are imported here. That
+// package bridges Echo's :provider path param to gothic's context-based
+// provider lookup — a detail that is easy to get wrong (gothic's own lookup is
+// gorilla/mux-flavoured and silently falls back to a ?provider= query param
+// that this surface never sets) and that there is no reason to get wrong twice.
+//
+// What IS different here from that older implementation is persistence: it
+// wrote through DDD repositories, whereas the control plane is event-sourced.
+// Every branch that creates or changes a user goes through writeTx so the rows,
+// the events and the outbox notify commit as one unit.
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/labstack/echo/v4"
+	"github.com/markbates/goth"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+	authpkg "github.com/duragraph/duragraph/internal/infrastructure/auth"
+	authhandlers "github.com/duragraph/duragraph/internal/infrastructure/http/handlers/auth"
+)
+
+// supportedProviders is a CLOSED set. goth will happily attempt any provider
+// name it has been configured with; pinning the set here means adding a
+// provider is a deliberate change to this file rather than a side effect of
+// configuration.
+var supportedProviders = map[string]struct{}{
+	"google": {},
+	"github": {},
+}
+
+// oauthExchanger is the provider-exchange seam. It is satisfied by
+// authhandlers.Exchanger (and therefore by authhandlers.GothExchanger); tests
+// substitute a stub because a real OAuth round trip cannot run in-process.
+type oauthExchanger interface {
+	BeginAuth(w http.ResponseWriter, r *http.Request, provider string) error
+	CompleteAuth(w http.ResponseWriter, r *http.Request, provider string) (goth.User, error)
+}
+
+// exchanger returns the configured exchange implementation, defaulting to the
+// real goth-backed one. Defaulting lazily (rather than requiring the
+// composition root to set it) keeps the zero-value Server usable.
+func (s *Server) exchanger() oauthExchanger {
+	if s.OAuth != nil {
+		return s.OAuth
+	}
+	return authhandlers.NewGothExchanger()
+}
+
+// authUnavailable reports whether the surface can operate at all.
+//
+// With no JWTSecret there is no key to sign or verify with. Signing with an
+// empty key would produce tokens that ANY other empty-key deployment could
+// forge, so this fails closed with 503 rather than minting them.
+func (s *Server) authUnavailable() error {
+	if len(s.Auth.JWTSecret) == 0 {
+		return echo.NewHTTPError(http.StatusServiceUnavailable,
+			"authentication is not configured on this deployment")
+	}
+	return nil
+}
+
+// AuthLogin starts the OAuth flow.
+// GET /api/auth/{provider}/login -> 302 to the provider / 400 / 502.
+func (s *Server) AuthLogin(c echo.Context) error {
+	if err := s.authUnavailable(); err != nil {
+		return err
+	}
+	provider, err := s.checkProvider(c)
+	if err != nil {
+		return err
+	}
+	// BeginAuth writes the 302 and the state cookie directly onto the
+	// ResponseWriter, so there is nothing further to return on success.
+	if err := s.exchanger().BeginAuth(c.Response().Writer, c.Request(), provider); err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, "provider_error")
+	}
+	return nil
+}
+
+// checkProvider validates :provider twice: against the closed set above, and
+// against what goth actually has registered. Both misses are 400
+// unknown_provider — a provider that is supported in principle but unregistered
+// (its client id/secret was never configured) is, from the caller's side,
+// simply not available, and reporting 502 would blame the provider for a local
+// configuration gap.
+func (s *Server) checkProvider(c echo.Context) (string, error) {
+	provider := strings.ToLower(strings.TrimSpace(c.Param("provider")))
+	if _, ok := supportedProviders[provider]; !ok {
+		return "", echo.NewHTTPError(http.StatusBadRequest, "unknown_provider")
+	}
+	// A stub exchanger (tests) means goth is not configured at all; the
+	// registration check only applies to the real one.
+	if s.OAuth == nil {
+		if _, err := goth.GetProvider(provider); err != nil {
+			return "", echo.NewHTTPError(http.StatusBadRequest, "unknown_provider")
+		}
+	}
+	return provider, nil
+}
+
+// AuthCallback completes the OAuth flow and establishes the session.
+// GET /api/auth/{provider}/callback -> 302 / 400 / 502 / 500.
+//
+// The decision tree (endpoints.yaml auth.callback branches):
+//
+//	known identity  -> existing: mint a JWT, write nothing
+//	unknown, no users at all -> bootstrap: first user becomes admin+approved
+//	unknown, users exist     -> new_user: pending, awaiting operator approval
+func (s *Server) AuthCallback(c echo.Context) error {
+	ctx := c.Request().Context()
+	if err := s.authUnavailable(); err != nil {
+		return err
+	}
+	provider, err := s.checkProvider(c)
+	if err != nil {
+		return err
+	}
+
+	gu, err := s.exchanger().CompleteAuth(c.Response().Writer, c.Request(), provider)
+	if err != nil {
+		// goth exposes no typed sentinel for a state mismatch, so this is a
+		// string match — the same compromise the existing implementation makes.
+		// A state mismatch is the CSRF failure case and is the caller's
+		// problem (400); anything else is the provider's (502).
+		low := strings.ToLower(err.Error())
+		if strings.Contains(low, "state") && strings.Contains(low, "mismatch") {
+			return echo.NewHTTPError(http.StatusBadRequest, "state_mismatch")
+		}
+		return echo.NewHTTPError(http.StatusBadGateway, "provider_exchange_failed")
+	}
+
+	email := strings.TrimSpace(gu.Email)
+	oauthID := strings.TrimSpace(gu.UserID)
+	if email == "" {
+		// GitHub can return an empty email when every address is private.
+		// Without one there is no account to key on.
+		return echo.NewHTTPError(http.StatusBadRequest, "no_verified_email")
+	}
+	if oauthID == "" {
+		return echo.NewHTTPError(http.StatusBadGateway, "provider_exchange_failed")
+	}
+
+	existing, err := s.findUserByOAuth(ctx, provider, oauthID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if existing != nil {
+		return s.completeExistingUser(c, existing)
+	}
+	return s.completeNewIdentity(c, provider, oauthID, email)
+}
+
+// platformUser is the subset of a users row the auth flow needs.
+type platformUser struct {
+	ID       uuid.UUID
+	Email    string
+	Role     string
+	Status   string
+	TenantID *uuid.UUID
+}
+
+func (s *Server) findUserByOAuth(ctx context.Context, provider, oauthID string) (*platformUser, error) {
+	var u platformUser
+	err := s.Platform.QueryRow(ctx, `
+		SELECT u.id, u.email, u.role, u.status, t.id
+		FROM users u
+		LEFT JOIN tenants t ON t.user_id = u.id
+		WHERE u.oauth_provider = $1 AND u.oauth_id = $2`,
+		provider, oauthID).Scan(&u.ID, &u.Email, &u.Role, &u.Status, &u.TenantID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+// completeExistingUser handles a known identity: no writes at all, just a
+// session (or deliberately none, for a suspended user).
+func (s *Server) completeExistingUser(c echo.Context, u *platformUser) error {
+	switch u.Status {
+	case "approved":
+		tenantID := ""
+		if u.TenantID != nil {
+			tenantID = u.TenantID.String()
+		}
+		// An approved user with no tenant is a broken invariant, not a
+		// degraded login: their JWT would carry no tenant and every tenant
+		// -scoped call would fail confusingly later. Fail loudly, here.
+		if tenantID == "" {
+			return echo.NewHTTPError(http.StatusInternalServerError,
+				"approved user has no tenant")
+		}
+		if _, err := s.issueSession(c, u.ID.String(), u.Email, u.Role, tenantID); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		return c.Redirect(http.StatusFound, "/")
+
+	case "pending":
+		// Role is pinned to "user" and the tenant left empty regardless of what
+		// the row says: a pending account must not carry admin authority in its
+		// token before an operator has approved it.
+		if _, err := s.issueSession(c, u.ID.String(), u.Email, "user", ""); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		return c.Redirect(http.StatusFound, "/awaiting-approval")
+
+	case "suspended":
+		// NO token and NO cookie — a suspended user must leave the callback
+		// with strictly less authority than they arrived with.
+		return c.Redirect(http.StatusFound, "/suspended")
+
+	default:
+		// Unreachable while the users CHECK holds; defence in depth.
+		return echo.NewHTTPError(http.StatusInternalServerError, "unknown user status")
+	}
+}
+
+// completeNewIdentity handles an identity with no users row yet: either the
+// installation's first user (bootstrap) or a normal pending signup.
+func (s *Server) completeNewIdentity(c echo.Context, provider, oauthID, email string) error {
+	ctx := c.Request().Context()
+
+	var count int
+	if err := s.Platform.QueryRow(ctx, `SELECT count(*) FROM users`).Scan(&count); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	bootstrap := false
+	if count == 0 {
+		claimed, err := s.claimBootstrap(ctx)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		// Losing the claim means a concurrent first login already became admin.
+		// Falling through to the pending path is correct — we are now simply
+		// the second user.
+		bootstrap = claimed
+	}
+
+	created, err := s.insertIdentity(ctx, provider, oauthID, email, bootstrap)
+	if err != nil {
+		if isUniqueViolation(err) {
+			// A concurrent callback for the SAME identity inserted first. Re-read
+			// and treat this as a normal existing-user login rather than failing
+			// a legitimate sign-in on a race.
+			existing, ferr := s.findUserByOAuth(ctx, provider, oauthID)
+			if ferr != nil || existing == nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "signup raced and could not be resolved")
+			}
+			return s.completeExistingUser(c, existing)
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return s.completeExistingUser(c, created)
+}
+
+// claimBootstrap atomically elects the first user as admin.
+//
+// count(*)==0 above is only an advisory probe — two simultaneous first logins
+// can both read zero. The election itself is this insert: bootstrap_lock's
+// primary key is a BOOLEAN pinned TRUE by CHECK, so the table admits exactly
+// one row for the lifetime of the installation. The winner gets nil; every
+// later attempt gets a unique violation, which is a normal outcome and not an
+// error.
+func (s *Server) claimBootstrap(ctx context.Context) (bool, error) {
+	_, err := s.Platform.Exec(ctx, `INSERT INTO bootstrap_lock (id) VALUES (true)`)
+	if err == nil {
+		return true, nil
+	}
+	if isUniqueViolation(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// insertIdentity creates the users + tenants rows and emits the branch's
+// events, all in one transaction.
+func (s *Server) insertIdentity(ctx context.Context, provider, oauthID, email string, bootstrap bool) (*platformUser, error) {
+	role, userStatus := "user", "pending"
+	events := []string{"user.signed_up", "tenant.pending"}
+	if bootstrap {
+		role, userStatus = "admin", "approved"
+		events = []string{"user.signed_up", "user.promoted_to_admin", "user.approved", "tenant.pending", "tenant.provisioning"}
+	}
+
+	out := &platformUser{Email: email, Role: role, Status: userStatus}
+	err := s.writeTxDeferred(ctx, s.Platform, func(tx pgx.Tx) ([]eventstore.Event, error) {
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO users (oauth_provider, oauth_id, email, role, status)
+			VALUES ($1,$2,$3,$4,$5) RETURNING id`,
+			provider, oauthID, email, role, userStatus).Scan(&out.ID); err != nil {
+			return nil, err
+		}
+
+		// db_name is NOT NULL UNIQUE and the spec's format is tenant_<32hex>.
+		// It is assigned at signup even though the database itself is only
+		// created later by the provisioner, because the name has to be stable
+		// from the moment the tenant row exists.
+		dbName := "tenant_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		var tid uuid.UUID
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO tenants (user_id, db_name, status)
+			VALUES ($1,$2,'pending') RETURNING id`, out.ID, dbName).Scan(&tid); err != nil {
+			return nil, err
+		}
+		out.TenantID = &tid
+
+		evs := make([]eventstore.Event, 0, len(events))
+		for _, et := range events {
+			if strings.HasPrefix(et, "user.") {
+				evs = append(evs, eventstore.Event{
+					AggregateType: "User",
+					AggregateID:   out.ID,
+					EventType:     et,
+					Payload: mustJSON(map[string]any{
+						"user_id": out.ID.String(),
+						"email":   email,
+						"role":    role,
+						"status":  userStatus,
+					}),
+				})
+				continue
+			}
+			evs = append(evs, eventstore.Event{
+				AggregateType: "Tenant",
+				AggregateID:   tid,
+				EventType:     et,
+				Payload: mustJSON(map[string]any{
+					"tenant_id": tid.String(),
+					"user_id":   out.ID.String(),
+					"db_name":   dbName,
+				}),
+			})
+		}
+		return evs, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// isUniqueViolation reports whether err is a Postgres unique-constraint
+// violation (SQLSTATE 23505).
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// AuthLogout clears the session cookie.
+// POST /api/auth/logout -> 204 / 403.
+//
+// There is no server-side revocation: the JWT stays valid until it expires.
+// That is the documented v0 behaviour and the reason the TTL is 24h rather
+// than longer.
+func (s *Server) AuthLogout(c echo.Context) error {
+	// A Bearer credential is presented explicitly by a client that had to hold
+	// the token, so there is no ambient authority to abuse and CSRF does not
+	// apply. A cookie-based logout is exactly the ambient case, so it must
+	// prove same-origin.
+	if bearerToken(c) == "" {
+		if err := s.checkSameOrigin(c); err != nil {
+			return err
+		}
+	}
+	s.clearSession(c)
+	return c.NoContent(http.StatusNoContent)
+}
+
+// checkSameOrigin enforces the logout CSRF rule: Origin (or Referer) must match
+// the configured BaseURL on scheme and host.
+//
+// FAIL-CLOSED. If neither header is present there is nothing to compare, and a
+// cross-site form post is precisely the request that would arrive without them,
+// so the absence is treated as a failure rather than waved through.
+func (s *Server) checkSameOrigin(c echo.Context) error {
+	if s.Auth.BaseURL == "" {
+		return echo.NewHTTPError(http.StatusForbidden, "csrf_check_failed")
+	}
+	base, err := url.Parse(s.Auth.BaseURL)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusForbidden, "csrf_check_failed")
+	}
+	raw := c.Request().Header.Get(echo.HeaderOrigin)
+	if raw == "" {
+		raw = c.Request().Header.Get("Referer")
+	}
+	if raw == "" {
+		return echo.NewHTTPError(http.StatusForbidden, "csrf_check_failed")
+	}
+	got, err := url.Parse(raw)
+	if err != nil || got.Scheme != base.Scheme || got.Host != base.Host {
+		return echo.NewHTTPError(http.StatusForbidden, "csrf_check_failed")
+	}
+	return nil
+}
+
+// AuthRefreshResponse is the refresh body: the new token and its expiry, so a
+// client can schedule the next refresh without decoding the JWT itself.
+type AuthRefreshResponse struct {
+	Token string `json:"token"`
+	Exp   int64  `json:"exp"`
+}
+
+// AuthRefresh re-issues a JWT with the same claims and a later expiry.
+// POST /api/auth/refresh -> 200 AuthRefreshResponse / 401 / 503.
+//
+// BEARER ONLY, deliberately: the cookie is not read. Refresh is an API-client
+// operation, and honouring an ambient cookie here would let any cross-site page
+// silently extend a browser session.
+func (s *Server) AuthRefresh(c echo.Context) error {
+	if err := s.authUnavailable(); err != nil {
+		return err
+	}
+	raw := bearerToken(c)
+	if raw == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+	claims, err := authpkg.VerifyJWT(s.Auth.JWTSecret, raw)
+	if err != nil {
+		// The specific reason (expired vs forged vs malformed) is withheld —
+		// it is not information a caller should be able to probe for.
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session")
+	}
+
+	token, err := authpkg.IssueJWT(s.Auth.JWTSecret,
+		claims.UserID, claims.Email, claims.Role, claims.TenantID, s.Auth.ttl())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	// Read the expiry back off the freshly-signed token rather than recomputing
+	// now()+ttl: the two can differ by a second, and the value a client
+	// schedules against must be the one actually inside the token.
+	fresh, err := authpkg.VerifyJWT(s.Auth.JWTSecret, token)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, AuthRefreshResponse{Token: token, Exp: fresh.ExpiresAt.Unix()})
+}

--- a/controlplane/endpoints/auth_gen.go
+++ b/controlplane/endpoints/auth_gen.go
@@ -4,10 +4,6 @@
 package endpoints
 
 import (
-	"net/http"
-
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
 
@@ -19,75 +15,10 @@ func (s *Server) RegisterAuth(g *echo.Group) {
 	g.POST("/api/auth/refresh", s.AuthRefresh)
 }
 
-// AuthLogin — GET /api/auth/{provider}/login  (kind: special)
-//   - Set goth CSRF state cookie
-//   - 302 redirect to provider authorization URL
-func (s *Server) AuthLogin(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SPECIAL: bespoke (auth redirect / health / metrics). Fill in.
-	//   Set goth CSRF state cookie
-	//   302 redirect to provider authorization URL
-	return echo.NewHTTPError(http.StatusNotImplemented, "handler not implemented")
-}
+// AuthLogin — GET /api/auth/{provider}/login  (kind: special) — hand-written in auth.go
 
-// AuthCallback — GET /api/auth/{provider}/callback  (kind: write)
-//   - Validate goth session state cookie
-//   - Exchange code (provider token exchange)
-//   - Fetch userinfo (email, oauth_id)
-//   - UPSERT users ON CONFLICT (oauth_provider, oauth_id) DO UPDATE SET email
-//   - branch: bootstrap | new_user | existing (see branches)
-//   - Set cookie duragraph_session = JWT
-//   - 302 redirect to dashboard / awaiting-approval / suspended
-func (s *Server) AuthCallback(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (AuthCallback request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "User", AggregateID: aggID, EventType: "user.signed_up"},
-		{AggregateType: "User", AggregateID: aggID, EventType: "user.promoted_to_admin"},
-		{AggregateType: "User", AggregateID: aggID, EventType: "user.approved"},
-		{AggregateType: "Tenant", AggregateID: aggID, EventType: "tenant.pending"},
-		{AggregateType: "Tenant", AggregateID: aggID, EventType: "tenant.provisioning"},
-	}
-	if err := s.writeTx(ctx, s.Platform, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   Validate goth session state cookie
-		//   Exchange code (provider token exchange)
-		//   Fetch userinfo (email, oauth_id)
-		//   UPSERT users ON CONFLICT (oauth_provider, oauth_id) DO UPDATE SET email
-		//   branch: bootstrap | new_user | existing (see branches)
-		//   Set cookie duragraph_session = JWT
-		//   302 redirect to dashboard / awaiting-approval / suspended
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// AuthCallback — GET /api/auth/{provider}/callback  (kind: write) — hand-written in auth.go
 
-// AuthLogout — POST /api/auth/logout  (kind: special)
-//   - Clear cookie: Set-Cookie duragraph_session=; Max-Age=0
-func (s *Server) AuthLogout(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SPECIAL: bespoke (auth redirect / health / metrics). Fill in.
-	//   Clear cookie: Set-Cookie duragraph_session=; Max-Age=0
-	return echo.NewHTTPError(http.StatusNotImplemented, "handler not implemented")
-}
+// AuthLogout — POST /api/auth/logout  (kind: special) — hand-written in auth.go
 
-// AuthRefresh — POST /api/auth/refresh  (kind: special)
-//   - Validate current JWT (signature + expiry)
-//   - Mint new JWT (same claims, new exp)
-func (s *Server) AuthRefresh(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// SPECIAL: bespoke (auth redirect / health / metrics). Fill in.
-	//   Validate current JWT (signature + expiry)
-	//   Mint new JWT (same claims, new exp)
-	return echo.NewHTTPError(http.StatusNotImplemented, "handler not implemented")
-}
+// AuthRefresh — POST /api/auth/refresh  (kind: special) — hand-written in auth.go

--- a/controlplane/endpoints/auth_integration_test.go
+++ b/controlplane/endpoints/auth_integration_test.go
@@ -1,0 +1,389 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/markbates/goth"
+
+	authpkg "github.com/duragraph/duragraph/internal/infrastructure/auth"
+)
+
+var testJWTSecret = []byte("test-secret-at-least-32-bytes-long-ok")
+
+// stubExchanger stands in for the OAuth provider round trip, which cannot run
+// in-process. It is the ONLY thing faked in these tests — the decision tree,
+// the writes, the events and the cookies are all real.
+type stubExchanger struct {
+	user goth.User
+	err  error
+}
+
+func (s stubExchanger) BeginAuth(w http.ResponseWriter, r *http.Request, provider string) error {
+	return s.err
+}
+
+func (s stubExchanger) CompleteAuth(w http.ResponseWriter, r *http.Request, provider string) (goth.User, error) {
+	return s.user, s.err
+}
+
+func newAuthServer(ex oauthExchanger) *echo.Echo {
+	e := echo.New()
+	srv := &Server{
+		Platform: testPlatform,
+		Auth: AuthConfig{
+			JWTSecret: testJWTSecret,
+			BaseURL:   "https://example.test",
+		},
+		OAuth: ex,
+	}
+	srv.RegisterAuth(e.Group(""))
+	return e
+}
+
+// callback drives one OAuth callback for the given identity.
+func callback(e *echo.Echo, email, oauthID string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/auth/google/callback?code=x&state=y", nil)
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func newCallbackServer(email, oauthID string) *echo.Echo {
+	return newAuthServer(stubExchanger{user: goth.User{Email: email, UserID: oauthID}})
+}
+
+func sessionCookie(rec *httptest.ResponseRecorder) string {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == SessionCookieName {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+func countUsers(t *testing.T, ctx context.Context) int {
+	t.Helper()
+	var n int
+	if err := testPlatform.QueryRow(ctx, `SELECT count(*) FROM users`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// TestAuthCallbackBootstrap covers the first-ever login: it must produce an
+// admin who is already approved, with a tenant, and the full five-event trail.
+func TestAuthCallbackBootstrap(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newCallbackServer("first@test", "oauth-1")
+
+	rec := callback(e, "first@test", "oauth-1")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// An approved user goes to the app, not the waiting room.
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Errorf("Location: want /, got %q", loc)
+	}
+
+	var uid, role, status string
+	if err := testPlatform.QueryRow(ctx,
+		`SELECT id, role, status FROM users WHERE email='first@test'`).Scan(&uid, &role, &status); err != nil {
+		t.Fatal(err)
+	}
+	if role != "admin" || status != "approved" {
+		t.Errorf("first user: want admin/approved, got %s/%s", role, status)
+	}
+
+	var tid, dbName string
+	if err := testPlatform.QueryRow(ctx,
+		`SELECT id, db_name FROM tenants WHERE user_id=$1`, uid).Scan(&tid, &dbName); err != nil {
+		t.Fatalf("bootstrap must create a tenant: %v", err)
+	}
+	// db_name is assigned at signup and must match the spec's shape, because
+	// the provisioner builds the database from it later.
+	if !strings.HasPrefix(dbName, "tenant_") || len(dbName) != len("tenant_")+32 {
+		t.Errorf("db_name: want tenant_<32hex>, got %q", dbName)
+	}
+
+	// The token must carry the tenant, or every tenant-scoped call afterwards
+	// has nothing to address.
+	tok := sessionCookie(rec)
+	if tok == "" {
+		t.Fatal("bootstrap must set the session cookie")
+	}
+	claims, err := authpkg.VerifyJWT(testJWTSecret, tok)
+	if err != nil {
+		t.Fatalf("session cookie must be a valid JWT: %v", err)
+	}
+	if claims.Role != "admin" || claims.TenantID != tid {
+		t.Errorf("claims: want admin + tenant %s, got %s + %q", tid, claims.Role, claims.TenantID)
+	}
+
+	if got := eventTypesFor(t, ctx, uid); len(got) != 3 {
+		t.Errorf("user events: want 3 (signed_up, promoted_to_admin, approved), got %v", got)
+	}
+	if got := eventTypesFor(t, ctx, tid); len(got) != 2 {
+		t.Errorf("tenant events: want 2 (pending, provisioning), got %v", got)
+	}
+}
+
+// TestAuthCallbackNewUser: once anyone exists, the next identity is pending.
+func TestAuthCallbackNewUser(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+
+	// First login takes the bootstrap.
+	callback(newCallbackServer("first@test", "oauth-1"), "first@test", "oauth-1")
+
+	rec := callback(newCallbackServer("second@test", "oauth-2"), "second@test", "oauth-2")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/awaiting-approval" {
+		t.Errorf("Location: want /awaiting-approval, got %q", loc)
+	}
+
+	var uid, role, status string
+	if err := testPlatform.QueryRow(ctx,
+		`SELECT id, role, status FROM users WHERE email='second@test'`).Scan(&uid, &role, &status); err != nil {
+		t.Fatal(err)
+	}
+	if role != "user" || status != "pending" {
+		t.Errorf("second user: want user/pending, got %s/%s", role, status)
+	}
+
+	// A pending session must carry NO tenant and NOT claim admin, even though
+	// a tenant row exists in 'pending'.
+	claims, err := authpkg.VerifyJWT(testJWTSecret, sessionCookie(rec))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.TenantID != "" {
+		t.Errorf("a pending user's token must carry no tenant, got %q", claims.TenantID)
+	}
+	if claims.Role != "user" {
+		t.Errorf("claims role: want user, got %q", claims.Role)
+	}
+
+	if got := eventTypesFor(t, ctx, uid); len(got) != 1 || got[0] != "user.signed_up" {
+		t.Errorf("want [user.signed_up], got %v", got)
+	}
+}
+
+// TestAuthBootstrapLockPreventsSecondAdmin is the reason bootstrap_lock exists.
+// count(*)==0 is racy on its own; the lock is the actual election.
+func TestAuthBootstrapLockPreventsSecondAdmin(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+
+	callback(newCallbackServer("a@test", "oauth-a"), "a@test", "oauth-a")
+
+	// Simulate the loser of the race: clear the users table so the count probe
+	// reads 0 again, but leave bootstrap_lock claimed. Only the lock should
+	// decide, and it must refuse.
+	if _, err := testPlatform.Exec(ctx, `TRUNCATE users, tenants CASCADE`); err != nil {
+		t.Fatal(err)
+	}
+	callback(newCallbackServer("b@test", "oauth-b"), "b@test", "oauth-b")
+
+	var role, status string
+	if err := testPlatform.QueryRow(ctx,
+		`SELECT role, status FROM users WHERE email='b@test'`).Scan(&role, &status); err != nil {
+		t.Fatal(err)
+	}
+	if role == "admin" {
+		t.Error("bootstrap_lock is already claimed, so this user must NOT become admin")
+	}
+	if role != "user" || status != "pending" {
+		t.Errorf("want user/pending, got %s/%s", role, status)
+	}
+}
+
+// TestAuthCallbackExistingUserWritesNothing — a repeat login is a read.
+func TestAuthCallbackExistingUserWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+
+	e := newCallbackServer("first@test", "oauth-1")
+	callback(e, "first@test", "oauth-1")
+	before := countUsers(t, ctx)
+
+	rec := callback(e, "first@test", "oauth-1")
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "/" {
+		t.Fatalf("want 302 to /, got %d %q", rec.Code, rec.Header().Get("Location"))
+	}
+	if after := countUsers(t, ctx); after != before {
+		t.Errorf("a repeat login must not create a user: %d -> %d", before, after)
+	}
+	if sessionCookie(rec) == "" {
+		t.Error("a repeat login must still establish a session")
+	}
+}
+
+// TestAuthCallbackSuspendedGetsNothing — a suspended user must leave the
+// callback with strictly less authority than they arrived with.
+func TestAuthCallbackSuspendedGetsNothing(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+
+	e := newCallbackServer("susp@test", "oauth-s")
+	callback(e, "susp@test", "oauth-s") // bootstraps as admin/approved
+	if _, err := testPlatform.Exec(ctx,
+		`UPDATE users SET status='suspended' WHERE email='susp@test'`); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := callback(e, "susp@test", "oauth-s")
+	if loc := rec.Header().Get("Location"); loc != "/suspended" {
+		t.Errorf("Location: want /suspended, got %q", loc)
+	}
+	if tok := sessionCookie(rec); tok != "" {
+		t.Errorf("a suspended user must receive NO session cookie, got one: %q", tok)
+	}
+}
+
+func TestAuthLoginRejectsUnknownProvider(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAuthServer(stubExchanger{})
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest("GET", "/api/auth/myspace/login", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "unknown_provider") {
+		t.Errorf("want unknown_provider, got: %s", rec.Body.String())
+	}
+}
+
+// TestAuthLogoutCSRF — a cookie logout is the ambient-authority case and must
+// prove same-origin; a Bearer logout is not and need not.
+func TestAuthLogoutCSRF(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAuthServer(stubExchanger{})
+
+	do := func(headers map[string]string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Fail-closed: no Origin at all is exactly what a cross-site post looks like.
+	if rec := do(nil); rec.Code != http.StatusForbidden {
+		t.Errorf("no Origin: want 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := do(map[string]string{"Origin": "https://evil.test"}); rec.Code != http.StatusForbidden {
+		t.Errorf("foreign Origin: want 403, got %d", rec.Code)
+	}
+	rec := do(map[string]string{"Origin": "https://example.test"})
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("matching Origin: want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// The clearing cookie must actually be sent, or the browser keeps the old one.
+	var cleared bool
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == SessionCookieName && ck.Value == "" && ck.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("logout must send an expiring session cookie")
+	}
+
+	if rec := do(map[string]string{"Authorization": "Bearer whatever"}); rec.Code != http.StatusNoContent {
+		t.Errorf("bearer logout needs no Origin: want 204, got %d", rec.Code)
+	}
+}
+
+func TestAuthRefresh(t *testing.T) {
+	ctx := context.Background()
+	truncatePlatform(t, ctx)
+	e := newAuthServer(stubExchanger{})
+
+	do := func(auth string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/auth/refresh", nil)
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := do(""); rec.Code != http.StatusUnauthorized {
+		t.Errorf("no bearer: want 401, got %d", rec.Code)
+	}
+	if rec := do("Bearer garbage"); rec.Code != http.StatusUnauthorized {
+		t.Errorf("garbage bearer: want 401, got %d", rec.Code)
+	}
+
+	// A cookie must NOT be accepted here: refresh is bearer-only so an ambient
+	// cookie cannot be used cross-site to extend a session.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/refresh", nil)
+	original, err := authpkg.IssueJWT(testJWTSecret, "11111111-1111-1111-1111-111111111111",
+		"r@test", "user", "22222222-2222-2222-2222-222222222222", DefaultSessionTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: original})
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("cookie-only refresh must be refused: want 401, got %d", rec.Code)
+	}
+
+	// The happy path returns a NEW token carrying the SAME identity.
+	got := do("Bearer " + original)
+	if got.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", got.Code, got.Body.String())
+	}
+	var resp AuthRefreshResponse
+	if err := json.Unmarshal(got.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	fresh, err := authpkg.VerifyJWT(testJWTSecret, resp.Token)
+	if err != nil {
+		t.Fatalf("refreshed token must verify: %v", err)
+	}
+	if fresh.UserID != "11111111-1111-1111-1111-111111111111" || fresh.TenantID != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("refresh must preserve the identity, got %+v", fresh)
+	}
+	// The advertised exp must be the one actually inside the token — that is
+	// what a client schedules its next refresh against.
+	if resp.Exp != fresh.ExpiresAt.Unix() {
+		t.Errorf("advertised exp %d != token exp %d", resp.Exp, fresh.ExpiresAt.Unix())
+	}
+}
+
+// TestAuthUnconfiguredFailsClosed — with no secret the surface must refuse
+// rather than sign with an empty key that any other empty-key deployment could
+// forge.
+func TestAuthUnconfiguredFailsClosed(t *testing.T) {
+	e := echo.New()
+	(&Server{Platform: testPlatform, OAuth: stubExchanger{}}).RegisterAuth(e.Group(""))
+
+	for _, path := range []string{"/api/auth/google/login", "/api/auth/refresh"} {
+		rec := httptest.NewRecorder()
+		method := "GET"
+		if strings.HasSuffix(path, "refresh") {
+			method = "POST"
+		}
+		e.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("%s with no JWTSecret: want 503, got %d: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/controlplane/endpoints/crons_create.go
+++ b/controlplane/endpoints/crons_create.go
@@ -13,10 +13,13 @@ package endpoints
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/cron"
 )
 
 // cronReturningColumns is the full cronRow column set, shared by the create
@@ -39,10 +42,25 @@ func (s *Server) CronsCreate(c echo.Context) error {
 	if err != nil {
 		return assistantRefHTTPError(err)
 	}
-	rows, err := s.Tenant.Query(ctx, `INSERT INTO crons (thread_id, assistant_id, schedule, input, config, metadata, end_time)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+
+	// Reject an unparseable schedule at creation. Stored unvalidated it would
+	// look accepted and simply never fire, which is the worst failure mode
+	// available: silent and permanent.
+	if err := cron.Validate(req.Schedule); err != nil {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity,
+			"invalid schedule: must be a 5-field cron expression (minute hour day-of-month month day-of-week)")
+	}
+	// next_run_at is what the scheduler polls. Nothing set it before, so every
+	// cron ever created was inert regardless of the rest of the machinery.
+	next, err := cron.NextRun(req.Schedule, time.Now().UTC())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid schedule")
+	}
+
+	rows, err := s.Tenant.Query(ctx, `INSERT INTO crons (thread_id, assistant_id, schedule, input, config, metadata, end_time, next_run_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING `+cronReturningColumns, pathID, assistantID, req.Schedule,
-		mustJSON(req.Input), jsonbObjectOrEmpty(req.Config), jsonbObjectOrEmpty(req.Metadata), req.EndTime)
+		mustJSON(req.Input), jsonbObjectOrEmpty(req.Config), jsonbObjectOrEmpty(req.Metadata), req.EndTime, next)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/controlplane/endpoints/path_params.go
+++ b/controlplane/endpoints/path_params.go
@@ -43,6 +43,19 @@ func pathUUID(c echo.Context, name string) (uuid.UUID, error) {
 	return id, nil
 }
 
+// pathUUIDString is pathUUID for the handlers whose downstream helpers take the
+// id as a string (the worker lease/event path). Returning the PARSED value's
+// String() rather than the raw parameter also canonicalises the accepted
+// spellings — uuid.Parse takes the braced and urn: forms — so what reaches the
+// query is always the plain 36-character form.
+func pathUUIDString(c echo.Context, name string) (string, error) {
+	id, err := pathUUID(c, name)
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}
+
 // parseCheckpointID parses a checkpoint identifier. The OpenAPI types
 // checkpoint_id as a STRING (CheckpointConfig.checkpoint_id), but a checkpoint
 // is a snapshots row and snapshots.id is BIGSERIAL — so the string must denote

--- a/controlplane/endpoints/path_params_integration_test.go
+++ b/controlplane/endpoints/path_params_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/labstack/echo/v4"
 )
 
 // TestMalformedIdentifiersAreValidationErrors pins the API boundary for the
@@ -92,5 +94,107 @@ func TestWellFormedIdentifiersStillResolve(t *testing.T) {
 				t.Errorf("want %d, got %d: %s", tc.want, rec.Code, rec.Body.String())
 			}
 		})
+	}
+}
+
+// TestWorkerPathParamsAreValidated extends the boundary to the worker and
+// checkpoint routes, which kept the raw-parameter pattern after the thread
+// state paths were fixed. Every one of these answered 500 with the driver text:
+//
+//	{"message":"ERROR: invalid input syntax for type uuid: \"not-a-uuid\" (SQLSTATE 22P02)"}
+//
+// These routes are internal (absent from the public OpenAPI), so no declared
+// response set forces the code — 422 is chosen to match the thread paths rather
+// than invent a second convention for the same class of mistake.
+func TestWorkerPathParamsAreValidated(t *testing.T) {
+	ctx := context.Background()
+	e := newTestServerWithWorkers()
+
+	var aid string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (name) VALUES ('pp-worker') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, method, path, body string }{
+		{"heartbeat: malformed worker id", "POST", "/api/v1/workers/not-a-uuid/heartbeat", `{"status":"idle","active_runs":0}`},
+		{"deregister: malformed worker id", "POST", "/api/v1/workers/not-a-uuid/deregister", ""},
+		{"events: malformed worker id", "POST", "/api/v1/workers/not-a-uuid/runs/" + aid + "/events", `{"events":[]}`},
+		{"events: malformed run id", "POST", "/api/v1/workers/" + aid + "/runs/not-a-uuid/events", `{"events":[]}`},
+		{"read checkpoint: malformed thread id", "GET", "/api/v1/threads/not-a-uuid/checkpoints/1", ""},
+		{"read checkpoint: malformed checkpoint id", "GET", "/api/v1/threads/" + aid + "/checkpoints/not-a-bigint", ""},
+		{"load graph: malformed run id", "GET", "/api/v1/workers/runs/not-a-uuid/graph", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Errorf("want 422, got %d: %s", rec.Code, rec.Body.String())
+			}
+			for _, leak := range []string{"SQLSTATE", "invalid input syntax", "bigint", "uuid:", "snapshots", "workers"} {
+				if strings.Contains(rec.Body.String(), leak) {
+					t.Errorf("response leaks internals (%q): %s", leak, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestAssistantGraphAcceptsGraphIdOrAssistantId covers the one path parameter in
+// this group that must NOT be rejected when it isn't a UUID.
+//
+// The OpenAPI types assistant_id on /assistants/{assistant_id}/graph as
+// anyOf[{format: uuid, "Assistant ID"}, {string, "Graph ID"}] — so a non-UUID is
+// a legal request selecting the graph by name. The handler interpolated it raw
+// into `WHERE assistant_id = $1` (a uuid column), so the legal form 500ed with
+// SQLSTATE 22P02. Validating it as a UUID would have been the WRONG fix: it
+// would turn a supported request into a 422.
+func TestAssistantGraphAcceptsGraphIdOrAssistantId(t *testing.T) {
+	ctx := context.Background()
+	e := echo.New()
+	(&Server{Tenant: testPool}).RegisterAssistants(e.Group("/api/v1"))
+
+	var aid string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (name) VALUES ('pp-graph') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO graphs (assistant_id, name, version, nodes, edges)
+		 VALUES ($1, 'named-graph', '1', '[{"id":"A"}]'::jsonb, '[]'::jsonb)`, aid); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both arms of the anyOf must resolve the SAME graph.
+	for _, tc := range []struct{ name, id string }{
+		{"by assistant uuid", aid},
+		{"by graph name", "named-graph"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/api/v1/assistants/"+tc.id+"/graph", nil)
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), `"A"`) {
+				t.Errorf("want the seeded graph's node, got: %s", rec.Body.String())
+			}
+		})
+	}
+
+	// A name matching nothing is a miss, not a validation error or a 500.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/assistants/no-such-graph/graph", nil)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown graph name: want 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "SQLSTATE") {
+		t.Errorf("response leaks the driver error: %s", rec.Body.String())
 	}
 }

--- a/controlplane/endpoints/platform.go
+++ b/controlplane/endpoints/platform.go
@@ -1,0 +1,89 @@
+// Hand-written platform endpoints (the self-service surface at
+// /api/platform/*). Route generated into platform_gen.go; body lives here.
+// Targets the PLATFORM database (endpoints.yaml: group platform, db: platform)
+// — users/tenants, not the per-tenant workflow schema.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// PlatformMeResponse is the /api/platform/me body. The shape mirrors the one
+// already served by internal/infrastructure/http/handlers/platform (MeResponse)
+// so a dashboard can talk to either surface unchanged: user_id (NOT id — see
+// that package's header note on the platform.yaml ↔ oauth.yml divergence),
+// email, role, status, tenant_id, created_at.
+//
+// TenantID is a POINTER, and deliberately not `omitempty`: "this user has no
+// tenant yet" is a real state (a pending signup awaiting operator approval),
+// and the dashboard distinguishes an explicit null from a missing field when
+// it decides between the app shell and the awaiting-approval page.
+type PlatformMeResponse struct {
+	UserID    string    `json:"user_id"`
+	Email     string    `json:"email"`
+	Role      string    `json:"role"`
+	Status    string    `json:"status"`
+	TenantID  *string   `json:"tenant_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// PlatformMe returns the caller's identity, FRESH FROM THE DATABASE.
+// GET /api/platform/me -> 200 PlatformMeResponse / 401.
+//
+// The freshness is the whole point of the endpoint. A session token is a
+// bearer snapshot taken at login and valid for 24h (DefaultSessionTTL), so
+// everything an operator does in between — approve, reject, suspend, promote
+// to admin, provision the tenant — is invisible to the token until it expires.
+// Answering /me from the claims alone would therefore tell a user suspended
+// five minutes ago that they are still approved, and tell a user approved five
+// minutes ago that they are still pending. So the claims are used for one
+// thing only — WHICH user is asking — and every attribute that can change
+// (status, role, email, tenant_id) is re-read from the users/tenants rows.
+//
+// Note that `status` is not even carried in the token: authpkg.Claims is
+// {user_id, tenant_id, role, email} (internal/infrastructure/auth/jwt.go), so
+// endpoints.yaml's "Read JWT claims (user_id, email, role, status, tenant_id)"
+// is only satisfiable via the row read the very next step prescribes.
+//
+// 401 (not 404) when the row is gone: the token references a user the platform
+// no longer has — a deleted account mid-session — which is a dead session, not
+// a missing resource. Saying 401 is what makes the dashboard clear its cookie
+// and route to /login instead of rendering an error page for a ghost.
+func (s *Server) PlatformMe(c echo.Context) error {
+	ctx := c.Request().Context()
+	claims, err := s.requireSession(c)
+	if err != nil {
+		return err
+	}
+	// The subject is a users.id (uuid). A syntactically impossible one can only
+	// come from a token this server would not have minted, so it is treated as
+	// an invalid session rather than passed to Postgres to reject as a 500.
+	uid, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session")
+	}
+
+	// One round trip: the user row plus its tenant (LEFT JOIN — tenants.user_id
+	// is UNIQUE, so this can match at most one row, and no match simply leaves
+	// tenant_id null for a user whose tenant has not been created yet).
+	var resp PlatformMeResponse
+	err = s.Platform.QueryRow(ctx, `
+		SELECT u.id::text, u.email, u.role, u.status, t.id::text, u.created_at
+		FROM users u
+		LEFT JOIN tenants t ON t.user_id = u.id
+		WHERE u.id = $1`, uid).
+		Scan(&resp.UserID, &resp.Email, &resp.Role, &resp.Status, &resp.TenantID, &resp.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, resp)
+}

--- a/controlplane/endpoints/platform_gen.go
+++ b/controlplane/endpoints/platform_gen.go
@@ -4,8 +4,6 @@
 package endpoints
 
 import (
-	"net/http"
-
 	"github.com/labstack/echo/v4"
 )
 
@@ -14,14 +12,4 @@ func (s *Server) RegisterPlatform(g *echo.Group) {
 	g.GET("/api/platform/me", s.PlatformMe)
 }
 
-// PlatformMe — GET /api/platform/me  (kind: read)
-//   - Read JWT claims (user_id, email, role, status, tenant_id)
-//   - SELECT users WHERE id = :user_id (fresh status)
-func (s *Server) PlatformMe(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	// TODO read query (no side effects):
-	//   Read JWT claims (user_id, email, role, status, tenant_id)
-	//   SELECT users WHERE id = :user_id (fresh status)
-	return c.JSON(http.StatusOK, map[string]any{})
-}
+// PlatformMe — GET /api/platform/me  (kind: read) — hand-written in platform.go

--- a/controlplane/endpoints/platform_integration_test.go
+++ b/controlplane/endpoints/platform_integration_test.go
@@ -1,0 +1,248 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	authpkg "github.com/duragraph/duragraph/internal/infrastructure/auth"
+)
+
+// meTestSecret is the HMAC key every /me test signs with. A fixed value keeps
+// "valid token" and "garbage token" trivially distinguishable.
+var meTestSecret = []byte("platform-me-test-secret")
+
+// newMeTestServer mounts the platform surface at the ROOT (not /api/v1) —
+// endpoints.yaml declares /api/platform/me with an absolute path and
+// controlplane/server mounts it on e.Group(""), so the tests must too or they
+// would be exercising a URL the product never serves.
+func newMeTestServer() *echo.Echo {
+	e := echo.New()
+	s := &Server{
+		Platform: testPlatform,
+		Auth:     AuthConfig{JWTSecret: meTestSecret},
+	}
+	s.RegisterPlatform(e.Group(""))
+	return e
+}
+
+// seedMeUser inserts a platform user and returns its id.
+func seedMeUser(t *testing.T, ctx context.Context, email, role, status string) string {
+	t.Helper()
+	var id string
+	if err := testPlatform.QueryRow(ctx,
+		`INSERT INTO users (email, role, status) VALUES ($1,$2,$3) RETURNING id`,
+		email, role, status).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// seedMeTenant inserts the user's tenant row and returns its id.
+func seedMeTenant(t *testing.T, ctx context.Context, userID, status string) string {
+	t.Helper()
+	var id string
+	if err := testPlatform.QueryRow(ctx,
+		`INSERT INTO tenants (user_id, db_name, status) VALUES ($1,$2,$3) RETURNING id`,
+		userID, "tenant_"+uuid.NewString()[:8], status).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// mintMeToken signs a session token with the given claims. role/tenant are
+// what the token BELIEVES — the point of most of these tests is that /me does
+// not take its word for it.
+func mintMeToken(t *testing.T, userID, email, role, tenantID string) string {
+	t.Helper()
+	tok, err := authpkg.IssueJWT(meTestSecret, userID, email, role, tenantID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+// getMe issues GET /api/platform/me with an optional bearer credential.
+func getMe(t *testing.T, e *echo.Echo, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/platform/me", nil)
+	if token != "" {
+		req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
+	}
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func resetMeTables(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, err := testPlatform.Exec(ctx, "TRUNCATE users, tenants CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPlatformMeReadsFreshRow is the endpoint's reason to exist: the response
+// must reflect the DATABASE, not the snapshot baked into the session token.
+//
+// The token is minted while the user is pending with role 'user' and no
+// tenant; then an operator approves them, promotes them, and their tenant is
+// provisioned — all invisible to a token that stays valid for its full TTL.
+// /me must report the new state.
+func TestPlatformMeReadsFreshRow(t *testing.T) {
+	ctx := context.Background()
+	resetMeTables(t, ctx)
+	e := newMeTestServer()
+
+	uid := seedMeUser(t, ctx, "ada@example.com", "user", "pending")
+	// Minted against the STALE world: pending, plain user, no tenant. (status
+	// is not even a JWT claim — authpkg.Claims carries user_id/email/role/
+	// tenant_id — which is precisely why it has to come from the row.)
+	token := mintMeToken(t, uid, "ada@example.com", "user", "")
+
+	// ... meanwhile, out of band:
+	if _, err := testPlatform.Exec(ctx,
+		`UPDATE users SET status='approved', role='admin', email='ada+new@example.com' WHERE id=$1`, uid); err != nil {
+		t.Fatal(err)
+	}
+	tid := seedMeTenant(t, ctx, uid, "approved")
+
+	rec := getMe(t, e, token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got PlatformMeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+	}
+	if got.UserID != uid {
+		t.Errorf("user_id: want %s, got %s", uid, got.UserID)
+	}
+	if got.Status != "approved" {
+		t.Errorf("status must come from the row, not the session: want approved, got %s", got.Status)
+	}
+	if got.Role != "admin" {
+		t.Errorf("role must come from the row (token said 'user'): want admin, got %s", got.Role)
+	}
+	if got.Email != "ada+new@example.com" {
+		t.Errorf("email must come from the row: want ada+new@example.com, got %s", got.Email)
+	}
+	if got.TenantID == nil || *got.TenantID != tid {
+		t.Errorf("tenant_id must come from the row (token had none): want %s, got %v", tid, got.TenantID)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("created_at must be populated")
+	}
+
+	// And the reverse direction: a suspension lands on the very next call,
+	// with the same still-valid token.
+	if _, err := testPlatform.Exec(ctx, `UPDATE users SET status='suspended' WHERE id=$1`, uid); err != nil {
+		t.Fatal(err)
+	}
+	rec = getMe(t, e, token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me after suspend: want 200, got %d", rec.Code)
+	}
+	var after PlatformMeResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &after)
+	if after.Status != "suspended" {
+		t.Errorf("status after suspension: want suspended, got %s", after.Status)
+	}
+}
+
+// TestPlatformMeTenantID pins the two tenant shapes: a user with a tenant gets
+// its id, a user without one gets an explicit null (a pending signup is a real
+// state the dashboard renders, not an error).
+func TestPlatformMeTenantID(t *testing.T) {
+	ctx := context.Background()
+	resetMeTables(t, ctx)
+	e := newMeTestServer()
+
+	withTenant := seedMeUser(t, ctx, "with@example.com", "user", "approved")
+	tid := seedMeTenant(t, ctx, withTenant, "approved")
+	without := seedMeUser(t, ctx, "without@example.com", "user", "pending")
+
+	rec := getMe(t, e, mintMeToken(t, withTenant, "with@example.com", "user", tid))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me (tenant): want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got PlatformMeResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.TenantID == nil || *got.TenantID != tid {
+		t.Errorf("tenant_id: want %s, got %v", tid, got.TenantID)
+	}
+
+	rec = getMe(t, e, mintMeToken(t, without, "without@example.com", "user", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me (no tenant): want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatal(err)
+	}
+	// Explicit null, not an omitted key: the dashboard branches on it.
+	if v, ok := raw["tenant_id"]; !ok || string(v) != "null" {
+		t.Errorf("tenant_id for a tenantless user: want explicit null, got %s (present=%v)", v, ok)
+	}
+}
+
+// TestPlatformMeUnauthorized covers every way a caller fails to be someone:
+// no credential at all, a credential that is not a token this server minted,
+// and a perfectly valid token for a user that no longer exists.
+func TestPlatformMeUnauthorized(t *testing.T) {
+	ctx := context.Background()
+	resetMeTables(t, ctx)
+	e := newMeTestServer()
+
+	if rec := getMe(t, e, ""); rec.Code != http.StatusUnauthorized {
+		t.Errorf("no credential: want 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := getMe(t, e, "not.a.jwt"); rec.Code != http.StatusUnauthorized {
+		t.Errorf("garbage token: want 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Correctly-shaped token, wrong signing key — must not be distinguishable
+	// from any other bad credential.
+	foreign, err := authpkg.IssueJWT([]byte("some-other-secret"), uuid.NewString(), "x@example.com", "user", "", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec := getMe(t, e, foreign); rec.Code != http.StatusUnauthorized {
+		t.Errorf("foreign-signed token: want 401, got %d", rec.Code)
+	}
+
+	// Valid session for a deleted user: the session references nobody.
+	uid := seedMeUser(t, ctx, "gone@example.com", "user", "approved")
+	token := mintMeToken(t, uid, "gone@example.com", "user", "")
+	if _, err := testPlatform.Exec(ctx, `DELETE FROM users WHERE id=$1`, uid); err != nil {
+		t.Fatal(err)
+	}
+	rec := getMe(t, e, token)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("deleted user: want 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// A token whose subject is not even a uuid is a 401, not a 500 from the
+	// driver rejecting the bind.
+	bogus := mintMeToken(t, "not-a-uuid", "x@example.com", "user", "")
+	rec = getMe(t, e, bogus)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("non-uuid subject: want 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The cookie path is equivalent to the bearer path.
+	live := seedMeUser(t, ctx, "cookie@example.com", "user", "approved")
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/platform/me", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: mintMeToken(t, live, "cookie@example.com", "user", "")})
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("cookie session: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/controlplane/endpoints/runtime.go
+++ b/controlplane/endpoints/runtime.go
@@ -25,6 +25,15 @@ type Server struct {
 	Tenant   *pgxpool.Pool
 	Platform *pgxpool.Pool
 
+	// Auth carries the session/JWT settings for the platform surface
+	// (/api/auth, /api/platform, /api/admin). See session.go.
+	Auth AuthConfig
+
+	// OAuth is the provider-exchange seam used by the /api/auth callback.
+	// Nil means the real goth-backed exchanger; tests inject a stub because an
+	// OAuth round trip cannot run in-process. See auth.go.
+	OAuth oauthExchanger
+
 	// Subscriber tails NATS for SSE/wait endpoints. Nil when NATS is disabled
 	// (those endpoints then return 503). Set by the server composition root.
 	Subscriber *nats.Subscriber
@@ -59,6 +68,40 @@ func (s *Server) writeTx(ctx context.Context, pool *pgxpool.Pool, events []Event
 		}
 	}
 	// NotifyOutbox — visible to LISTENers only on commit.
+	if _, err := tx.Exec(ctx, `SELECT pg_notify('outbox_new', '')`); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// writeTxDeferred is writeTx for the case where the events are not known until
+// the write has run — a guarded `UPDATE ... WHERE status = $from RETURNING ...`
+// decides both WHETHER anything changed and WHAT the event should say, so the
+// events cannot be built before the transaction opens.
+//
+// Same guarantee as writeTx: the projection, the events, the outbox rows and
+// the notify all commit together or not at all. The only difference is
+// ordering inside the transaction (projection first, events second), which is
+// invisible outside it.
+//
+// Returning no events is legitimate and not a no-op: a transition the spec
+// marks outbox:false (AdminResume) still has to commit its row change.
+func (s *Server) writeTxDeferred(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) ([]Event, error)) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
+
+	events, err := fn(tx)
+	if err != nil {
+		return err
+	}
+	for _, e := range events {
+		if err := eventstore.Append(ctx, tx, e); err != nil {
+			return err
+		}
+	}
 	if _, err := tx.Exec(ctx, `SELECT pg_notify('outbox_new', '')`); err != nil {
 		return err
 	}

--- a/controlplane/endpoints/session.go
+++ b/controlplane/endpoints/session.go
@@ -1,0 +1,172 @@
+// Session plumbing for the platform surface (/api/auth, /api/platform,
+// /api/admin) — built from spec/models/d2/api.d2 and endpoints.yaml's auth
+// group.
+//
+// The JWT itself is NOT reimplemented here. internal/infrastructure/auth
+// already carries a reviewed, tested implementation whose only dependency is
+// golang-jwt — no echo, no pgx, no domain types — so the control plane imports
+// it rather than growing a second copy that could drift on the security-
+// relevant details (issuer pinning, HMAC-only keyfunc, the required-claim set).
+//
+// What DOES live here is everything that implementation deliberately left to
+// the caller: the cookie contract, how a request is turned into claims, and the
+// guard middleware.
+package endpoints
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	authpkg "github.com/duragraph/duragraph/internal/infrastructure/auth"
+)
+
+// SessionCookieName is the browser-facing session cookie. It matches the name
+// used by internal/infrastructure/http (duragraph_session) so a token minted by
+// either surface is readable by the other.
+const SessionCookieName = "duragraph_session"
+
+// DefaultSessionTTL is the spec default JWT lifetime (24h).
+const DefaultSessionTTL = 24 * time.Hour
+
+// AuthConfig carries the session settings. Zero values are usable in tests:
+// SessionTTL falls back to DefaultSessionTTL and CookieDomain empty means a
+// host-only cookie, which is the correct dev behaviour.
+type AuthConfig struct {
+	// JWTSecret is the HMAC key. When empty the platform surface refuses to
+	// mint or accept sessions — an unset secret must fail closed, never
+	// silently sign with "".
+	JWTSecret []byte
+
+	// SessionTTL is the JWT lifetime; DefaultSessionTTL when zero.
+	SessionTTL time.Duration
+
+	// CookieDomain scopes the cookie. Empty = host-only. Must carry neither
+	// scheme nor port.
+	CookieDomain string
+
+	// CookieSecure sets the Secure attribute. False in dev (plain http).
+	CookieSecure bool
+
+	// BaseURL is the canonical external origin, used for the logout CSRF
+	// origin check.
+	BaseURL string
+}
+
+func (a AuthConfig) ttl() time.Duration {
+	if a.SessionTTL <= 0 {
+		return DefaultSessionTTL
+	}
+	return a.SessionTTL
+}
+
+// errNoSession distinguishes "no credential presented" from "credential
+// presented and bad" — the first is a plain 401, the second is worth saying
+// more about.
+var errNoSession = errors.New("no session")
+
+// issueSession mints a JWT for the user and writes the session cookie.
+//
+// tenantID is empty for a pending user: they have a session (so the UI can show
+// "awaiting approval") but no tenant to address yet, and authpkg.IssueJWT
+// deliberately permits that while still requiring userID/email/role.
+func (s *Server) issueSession(c echo.Context, userID, email, role, tenantID string) (string, error) {
+	if len(s.Auth.JWTSecret) == 0 {
+		return "", errors.New("session: JWTSecret is not configured")
+	}
+	token, err := authpkg.IssueJWT(s.Auth.JWTSecret, userID, email, role, tenantID, s.Auth.ttl())
+	if err != nil {
+		return "", err
+	}
+	c.SetCookie(&http.Cookie{
+		Name:     SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		Domain:   s.Auth.CookieDomain,
+		MaxAge:   int(s.Auth.ttl().Seconds()),
+		HttpOnly: true,
+		Secure:   s.Auth.CookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return token, nil
+}
+
+// clearSession expires the session cookie. Path and Domain MUST match the
+// issued cookie or the browser keeps the original. MaxAge -1 renders as
+// "Max-Age=0" per RFC 6265, which is the delete instruction.
+func (s *Server) clearSession(c echo.Context) {
+	c.SetCookie(&http.Cookie{
+		Name:     SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Domain:   s.Auth.CookieDomain,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.Auth.CookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// bearerToken extracts a Bearer credential, case-insensitively on the scheme
+// (RFC 7235 says the scheme is case-insensitive; clients send "bearer").
+func bearerToken(c echo.Context) string {
+	h := c.Request().Header.Get(echo.HeaderAuthorization)
+	if len(h) < 7 || !strings.EqualFold(h[:7], "bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(h[7:])
+}
+
+// sessionClaims resolves the caller's identity from the request.
+//
+// Bearer wins over the cookie: an explicit Authorization header is a deliberate
+// act by an API client, whereas the cookie is ambient and may just be a stale
+// browser session riding along on the same request.
+func (s *Server) sessionClaims(c echo.Context) (*authpkg.Claims, error) {
+	if len(s.Auth.JWTSecret) == 0 {
+		return nil, errors.New("session: JWTSecret is not configured")
+	}
+	raw := bearerToken(c)
+	if raw == "" {
+		ck, err := c.Cookie(SessionCookieName)
+		if err != nil || ck.Value == "" {
+			return nil, errNoSession
+		}
+		raw = ck.Value
+	}
+	return authpkg.VerifyJWT(s.Auth.JWTSecret, raw)
+}
+
+// requireSession returns the caller's claims or an echo HTTPError ready to be
+// returned from a handler.
+func (s *Server) requireSession(c echo.Context) (*authpkg.Claims, error) {
+	claims, err := s.sessionClaims(c)
+	if err != nil {
+		if errors.Is(err, errNoSession) {
+			return nil, echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+		}
+		// Never echo the library's reason back: whether a token was expired,
+		// wrongly signed, or malformed is information the caller should not be
+		// able to enumerate.
+		return nil, echo.NewHTTPError(http.StatusUnauthorized, "invalid session")
+	}
+	return claims, nil
+}
+
+// requireAdmin is requireSession plus the role gate.
+//
+// 403 (not 404) on a non-admin: the caller IS authenticated, and hiding the
+// route's existence buys nothing once /api/admin/* is a published surface.
+func (s *Server) requireAdmin(c echo.Context) (*authpkg.Claims, error) {
+	claims, err := s.requireSession(c)
+	if err != nil {
+		return nil, err
+	}
+	if claims.Role != "admin" {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "admin role required")
+	}
+	return claims, nil
+}

--- a/controlplane/endpoints/worker_types.go
+++ b/controlplane/endpoints/worker_types.go
@@ -14,6 +14,33 @@ type WorkerRegisterRequest struct {
 	WorkerID uuid.UUID `json:"worker_id"`
 	Graphs   []string  `json:"graphs"`
 	Capacity int       `json:"capacity"`
+
+	// GraphDefinitions carries the actual graph bodies the worker can run.
+	//
+	// system-architecture.d2 routes graph_entity.graph_def to this endpoint —
+	// "SDK registers graph definition" — and it is the ONLY declared way a
+	// definition enters the system: nothing else in the API writes to `graphs`
+	// (the two graph routes are both GETs). Without it a graph could only be
+	// installed with direct SQL, so a user with nothing but the HTTP API could
+	// create an assistant, a thread and a run, and the run could never execute.
+	//
+	// Optional and additive: `graphs` (names only) still registers a worker for
+	// graphs that already exist, which is what an executor-only worker does.
+	GraphDefinitions []GraphDefinitionInput `json:"graph_definitions,omitempty"`
+}
+
+// GraphDefinitionInput is one graph body as the SDK registers it. The shape
+// mirrors the graphs table (name, version, description, nodes, edges, config)
+// and WorkerGraphResponse, which is what the worker reads back at execution
+// time — the same definition making a round trip.
+type GraphDefinitionInput struct {
+	Name        string          `json:"name"`
+	Version     string          `json:"version,omitempty"`
+	Description string          `json:"description,omitempty"`
+	AssistantID *uuid.UUID      `json:"assistant_id,omitempty"`
+	Nodes       json.RawMessage `json:"nodes"`
+	Edges       json.RawMessage `json:"edges"`
+	Config      json.RawMessage `json:"config,omitempty"`
 }
 
 type WorkerRegisterResponse struct {

--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -36,7 +36,10 @@ func (s *Server) WorkersRegister(c echo.Context) error {
 // WorkersHeartbeat renews the worker lease. POST /workers/{id}/heartbeat -> 200.
 func (s *Server) WorkersHeartbeat(c echo.Context) error {
 	ctx := c.Request().Context()
-	wid := c.Param("id")
+	wid, err := pathUUIDString(c, "id")
+	if err != nil {
+		return err
+	}
 	var req WorkerHeartbeatRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -60,7 +63,10 @@ func (s *Server) WorkersHeartbeat(c echo.Context) error {
 // POST /workers/{id}/deregister -> 204.
 func (s *Server) WorkersDeregister(c echo.Context) error {
 	ctx := c.Request().Context()
-	wid := c.Param("id")
+	wid, err := pathUUIDString(c, "id")
+	if err != nil {
+		return err
+	}
 	tx, err := s.Tenant.Begin(ctx)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -86,8 +92,14 @@ func (s *Server) WorkersDeregister(c echo.Context) error {
 // doc "events endpoint". runs has no lease_expires_at — fence on epoch only.
 func (s *Server) WorkersStreamEvents(c echo.Context) error {
 	ctx := c.Request().Context()
-	wid := c.Param("id")
-	rid := c.Param("rid")
+	wid, err := pathUUIDString(c, "id")
+	if err != nil {
+		return err
+	}
+	rid, err := pathUUIDString(c, "rid")
+	if err != nil {
+		return err
+	}
 	var req WorkerEventsRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -334,8 +346,14 @@ func (s *Server) WorkersWriteCheckpoint(c echo.Context) error {
 // GET /threads/{tid}/checkpoints/{ckpt} -> 200 / 404.
 func (s *Server) WorkersReadCheckpoint(c echo.Context) error {
 	ctx := c.Request().Context()
-	tid := c.Param("tid")
-	ckpt := c.Param("ckpt")
+	tid, err := pathUUIDString(c, "tid")
+	if err != nil {
+		return err
+	}
+	ckpt, err := parseCheckpointID(c.Param("ckpt"))
+	if err != nil {
+		return err
+	}
 	rows, err := s.Tenant.Query(ctx, `
 		SELECT id, stream_id, aggregate_id, version, state, created_at
 		FROM snapshots
@@ -384,7 +402,10 @@ func (s *Server) WorkersLatestCheckpoint(c echo.Context) error {
 // -> 200 WorkerGraphResponse / 404 (unknown run, or assistant with no graph).
 func (s *Server) WorkersLoadGraph(c echo.Context) error {
 	ctx := c.Request().Context()
-	rid := c.Param("rid")
+	rid, err := pathUUIDString(c, "rid")
+	if err != nil {
+		return err
+	}
 	var resp WorkerGraphResponse
 	// Latest graph for the run's assistant. Ordered by created_at, NOT version:
 	// version is VARCHAR(50), so `ORDER BY version DESC` sorts lexicographically
@@ -392,7 +413,7 @@ func (s *Server) WorkersLoadGraph(c echo.Context) error {
 	// one version. Slice-1 assumes one graph per assistant; created_at keeps
 	// "latest wins" correct if that assumption is ever relaxed. (Selecting by
 	// graph_id/name is a separate TARGET — see graph-engine.d2 loader.)
-	err := s.Tenant.QueryRow(ctx, `
+	err = s.Tenant.QueryRow(ctx, `
 		SELECT nodes, edges, config FROM graphs
 		WHERE assistant_id = (SELECT assistant_id FROM runs WHERE id = $1)
 		ORDER BY created_at DESC LIMIT 1`, rid).Scan(&resp.Nodes, &resp.Edges, &resp.Config)

--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -9,19 +9,44 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
 
-// WorkersRegister upserts a worker as online. POST /workers/register -> 200.
+// WorkersRegister upserts a worker as online and installs any graph
+// definitions it brought with it. POST /workers/register -> 200.
+//
+// Registering the DEFINITIONS here is what system-architecture.d2 prescribes
+// ("SDK registers graph definition" -> workers_ep.register), and it is the only
+// declared route by which a graph body enters the system: every other graph
+// endpoint is a GET. The two halves are one transaction because they are one
+// claim — "I can run these graphs, and here is what they are". Registering the
+// worker while failing to install its graphs would advertise capacity for
+// something unrunnable, and the claim endpoint would hand it work it cannot
+// load.
 func (s *Server) WorkersRegister(c echo.Context) error {
 	ctx := c.Request().Context()
 	var req WorkerRegisterRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	if _, err := s.Tenant.Exec(ctx, `
+	for i, g := range req.GraphDefinitions {
+		if strings.TrimSpace(g.Name) == "" {
+			return echo.NewHTTPError(http.StatusUnprocessableEntity,
+				"graph_definitions["+strconv.Itoa(i)+"]: name is required")
+		}
+	}
+
+	tx, err := s.Tenant.Begin(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
+
+	if _, err := tx.Exec(ctx, `
 		INSERT INTO workers (worker_id, graphs, capacity, status, lease_expires_at, last_heartbeat_at)
 		VALUES ($1, $2, $3, 'online', now() + interval '60 seconds', now())
 		ON CONFLICT (worker_id) DO UPDATE
@@ -30,7 +55,52 @@ func (s *Server) WorkersRegister(c echo.Context) error {
 		req.WorkerID, req.Graphs, req.Capacity); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
+
+	for _, g := range req.GraphDefinitions {
+		// Re-registering is the NORMAL case — every worker restart replays its
+		// definitions — so a repeat must update in place rather than pile up
+		// duplicate rows that WorkersLoadGraph would then have to choose
+		// between. There is no unique constraint on graphs(name) to hang an
+		// ON CONFLICT on, so the upsert is done explicitly: update the newest
+		// row for the name, insert only when nothing matched.
+		ct, err := tx.Exec(ctx, `
+			UPDATE graphs SET
+			    assistant_id = COALESCE($2, assistant_id),
+			    version      = COALESCE(NULLIF($3,''), version),
+			    description  = COALESCE(NULLIF($4,''), description),
+			    nodes = $5, edges = $6, config = $7, updated_at = now()
+			WHERE id = (SELECT id FROM graphs WHERE name = $1 ORDER BY created_at DESC LIMIT 1)`,
+			g.Name, g.AssistantID, g.Version, g.Description,
+			jsonOrEmptyArray(g.Nodes), jsonOrEmptyArray(g.Edges), jsonOrEmpty(g.Config))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		if ct.RowsAffected() > 0 {
+			continue
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO graphs (assistant_id, name, version, description, nodes, edges, config)
+			VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7)`,
+			g.AssistantID, g.Name, g.Version, g.Description,
+			jsonOrEmptyArray(g.Nodes), jsonOrEmptyArray(g.Edges), jsonOrEmpty(g.Config)); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 	return c.JSON(http.StatusOK, WorkerRegisterResponse{WorkerID: req.WorkerID, Status: "online"})
+}
+
+// jsonOrEmptyArray defaults absent nodes/edges to [] rather than {}: both
+// columns are jsonb holding ARRAYS (Node[] / Edge[] per postgres.d2), and an
+// object there would fail to decode in the worker's graph loader.
+func jsonOrEmptyArray(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("[]")
+	}
+	return b
 }
 
 // WorkersHeartbeat renews the worker lease. POST /workers/{id}/heartbeat -> 200.
@@ -413,10 +483,33 @@ func (s *Server) WorkersLoadGraph(c echo.Context) error {
 	// one version. Slice-1 assumes one graph per assistant; created_at keeps
 	// "latest wins" correct if that assumption is ever relaxed. (Selecting by
 	// graph_id/name is a separate TARGET — see graph-engine.d2 loader.)
+	// Resolve the graph by EITHER binding postgres.d2 declares:
+	//
+	//	graphs_t.assistant_id -> assistants_t.id  "bound via graph_id name match"
+	//	assistants_t.graph_id -> graphs_t.name    "resolves by name"
+	//
+	// Only the first was implemented, and that made a graph registered by NAME
+	// invisible: the SDK registers a definition under its graph_id (from
+	// langgraph.json) with no assistant attached, so graphs.assistant_id is
+	// NULL and the assistant-id lookup found nothing. Every such run failed
+	// with 404 "no graph for run", burned its redeliveries, and died — the
+	// only graphs that ever worked were ones written straight into Postgres
+	// with an assistant_id already set.
+	//
+	// The direct binding is preferred when both match (an assistant with its
+	// own pinned graph beats a shared one of the same name); created_at breaks
+	// the remaining tie, NOT version — version is VARCHAR(50), so ordering by
+	// it sorts '10' before '2'.
 	err = s.Tenant.QueryRow(ctx, `
-		SELECT nodes, edges, config FROM graphs
-		WHERE assistant_id = (SELECT assistant_id FROM runs WHERE id = $1)
-		ORDER BY created_at DESC LIMIT 1`, rid).Scan(&resp.Nodes, &resp.Edges, &resp.Config)
+		SELECT g.nodes, g.edges, g.config
+		FROM runs r
+		LEFT JOIN assistants a ON a.id = r.assistant_id
+		JOIN graphs g
+		  ON g.assistant_id = r.assistant_id
+		  OR (a.graph_id IS NOT NULL AND a.graph_id <> '' AND g.name = a.graph_id)
+		WHERE r.id = $1
+		ORDER BY (g.assistant_id = r.assistant_id) DESC NULLS LAST, g.created_at DESC
+		LIMIT 1`, rid).Scan(&resp.Nodes, &resp.Edges, &resp.Config)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return echo.NewHTTPError(http.StatusNotFound, "no graph for run")

--- a/controlplane/endpoints/workers_claim.go
+++ b/controlplane/endpoints/workers_claim.go
@@ -1,0 +1,310 @@
+// Hand-written worker run-claim endpoint (the PULL half of the worker↔control-
+// plane protocol). Route is generated into workers_gen.go; the body lives here
+// rather than in workers.go because the claim is the one worker endpoint that
+// is a scheduler: it decides WHICH runs a worker gets, under concurrency, and
+// that decision is most of the file. Source of truth: endpoints.yaml workers
+// group, endpoint `claim` + the worker-execution design doc.
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+)
+
+// WorkerClaimRequest is the claim body. Limit is accepted as an alias for
+// MaxRuns because the spec step says `LIMIT :max_runs` while every other
+// paginated surface in this API says `limit`; accepting both costs one line
+// and spares a worker author a silent zero-claim.
+//
+// The body is optional: an absent/empty body claims defaultClaimBatch run.
+type WorkerClaimRequest struct {
+	MaxRuns int `json:"max_runs"`
+	Limit   int `json:"limit"`
+}
+
+// Claim batch bounds. A worker that asks for nothing gets one run (the safe
+// default: it can always claim again). maxClaimBatch caps what a single call
+// can lock at once — the claim holds row locks for the length of its
+// transaction, so an unbounded :max_runs would let one worker stall every
+// other claimer while it drains the queue.
+const (
+	defaultClaimBatch = 1
+	maxClaimBatch     = 100
+)
+
+func (r WorkerClaimRequest) batchSize() int {
+	n := r.MaxRuns
+	if n <= 0 {
+		n = r.Limit
+	}
+	if n <= 0 {
+		return defaultClaimBatch
+	}
+	if n > maxClaimBatch {
+		return maxClaimBatch
+	}
+	return n
+}
+
+// ClaimedRun is one run handed to a worker, matching the spec's
+// "returns: run + checkpoint_id (null if fresh, set if resuming)".
+//
+// LeaseEpoch is carried alongside because the claim IS the lease acquisition:
+// every subsequent worker→server event is fenced on this epoch
+// (WorkersStreamEvents), so a claim that withheld it would force the worker to
+// post a second run.started just to learn its own epoch — which would bump the
+// epoch again and fence writes against a token it had never used.
+//
+// Input is included so a claiming worker can execute without a second round
+// trip; the graph itself is still fetched from /workers/runs/{rid}/graph.
+type ClaimedRun struct {
+	Run          Run             `json:"run"`
+	LeaseEpoch   int             `json:"lease_epoch"`
+	CheckpointID *int64          `json:"checkpoint_id"`
+	GraphID      string          `json:"graph_id,omitempty"`
+	Input        json.RawMessage `json:"input,omitempty"`
+}
+
+// WorkerClaimResponse wraps the claimed set. Runs is never null — an empty
+// queue is `{"runs":[]}`, so a polling worker can range over it unconditionally.
+type WorkerClaimResponse struct {
+	Runs []ClaimedRun `json:"runs"`
+}
+
+// claimedRunRow is runRow plus the per-run latest checkpoint id. Embedded (not
+// copied) so the claim scans the exact same run shape every other run handler
+// does — one runRow definition, one toAPI mapper.
+//
+// CheckpointID is `db:"-"`: it is not a runs column and is filled by
+// attachLatestCheckpoints after the lease, so RowToStructByName (strict — it
+// errors on a field with no matching column) must be told to skip it.
+//
+// EffectiveGraphID is the graph the run actually matched on — runs.graph_id
+// when set, else the assistant's. Reporting runRow.GraphID instead would hand
+// the worker an empty string for every run created through the current API
+// path, which does not populate the denormalized column.
+type claimedRunRow struct {
+	runRow
+	CheckpointID     *int64  `db:"-"`
+	EffectiveGraphID *string `db:"effective_graph_id"`
+}
+
+// claimSQL atomically selects and leases the next runs for a worker.
+//
+// Two things in here are load-bearing:
+//
+//  1. FOR UPDATE SKIP LOCKED. Workers poll concurrently; without SKIP LOCKED
+//     the candidate SELECTs would either serialize (each waiting on the other's
+//     row locks, turning the pool into a queue of one) or — with a plain
+//     SELECT then UPDATE — hand the SAME run to two workers, which is a
+//     double-execution bug no fencing token can undo after the fact. SKIP
+//     LOCKED makes concurrent claimers step over each other's in-flight
+//     candidates instead.
+//
+//  2. The select and the update are ONE statement (CTE + UPDATE ... FROM). The
+//     row locks taken by the CTE are held for the rest of the transaction, so
+//     nothing can slip between "chosen" and "leased".
+//
+// The graph filter is `effective graph_id = ANY(worker.graphs)`, where the
+// effective graph is COALESCE(runs.graph_id, assistants.graph_id): runs.graph_id
+// is a denormalization added by migration 005 that the run-create path does not
+// populate yet (see runs_create.go — it inserts no graph_id), so filtering on
+// the column alone would match nothing and every worker would idle forever.
+// Falling back to the run's assistant's graph_id honours the spec's intent
+// ("graph_id IN (worker graphs)") against the schema as it actually is. A run
+// with no effective graph is deliberately unclaimable: NULL is in no set, and
+// handing a worker a run whose graph it never advertised is exactly what this
+// filter exists to prevent.
+//
+// ORDER BY priority DESC, created_at — priority first, then FIFO within a
+// priority, per the spec and the idx_runs_claim index that backs it.
+const claimSQL = `
+WITH candidate AS (
+    SELECT r.id
+    FROM runs r
+    WHERE r.status = 'queued'
+      AND COALESCE(r.graph_id, (SELECT a.graph_id FROM assistants a WHERE a.id = r.assistant_id)) = ANY($2::text[])
+    ORDER BY r.priority DESC, r.created_at
+    LIMIT $3
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE runs r
+SET status      = 'in_progress',
+    worker_id   = $1,
+    lease_epoch = r.lease_epoch + 1,
+    started_at  = COALESCE(r.started_at, now()),
+    version     = r.version + 1
+FROM candidate c
+WHERE r.id = c.id
+RETURNING r.id, r.thread_id, r.assistant_id, r.status, r.input, r.output, r.error,
+          r.metadata, r.kwargs, r.multitask_strategy, r.version, r.lease_epoch,
+          r.worker_id, r.priority, r.graph_id, r.created_at, r.started_at,
+          r.completed_at, r.updated_at,
+          COALESCE(r.graph_id, (SELECT a.graph_id FROM assistants a WHERE a.id = r.assistant_id)) AS effective_graph_id`
+
+// WorkersClaim leases the next queued runs matching the worker's graphs.
+// POST /workers/{id}/runs/claim -> 200 WorkerClaimResponse / 409 / 422.
+//
+// lease_epoch+1 on every claim is the fencing token, and incrementing it here
+// is what makes a stolen run safe: the moment this row is re-leased, the
+// PREVIOUS holder's epoch is stale, so its node/terminal/checkpoint writes are
+// rejected by the epoch guards in workers.go (nodeEvent, terminalRun,
+// requiresActionRun, WorkersWriteCheckpoint) instead of corrupting a run
+// another worker now owns. Same increment, same meaning as leaseRun — this
+// endpoint just reaches the lease by claiming rather than by being told.
+//
+// started_at uses COALESCE(started_at, now()) rather than the spec's bare
+// now(): a run that was requeued (WorkersDeregister) and re-claimed keeps its
+// FIRST start, so queue→start latency stays measurable. version+1 IS taken
+// literally from the spec here, even though leaseRun does not bump it —
+// noted in the report as a divergence between the two lease paths.
+func (s *Server) WorkersClaim(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid, err := pathUUIDString(c, "id")
+	if err != nil {
+		return err
+	}
+	var req WorkerClaimRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	// The worker's advertised graphs, and — free with it — proof the worker
+	// exists. 409 rather than 404 mirrors WorkersHeartbeat: an unregistered
+	// worker is not a missing URL, it is a worker that must re-register. It
+	// also has to be caught here, because runs.worker_id FKs workers(worker_id)
+	// and the UPDATE below would otherwise fail as an opaque 500.
+	var graphs []string
+	if err := s.Tenant.QueryRow(ctx, `SELECT graphs FROM workers WHERE worker_id = $1`, wid).Scan(&graphs); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusConflict, "unknown worker; re-register")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if len(graphs) == 0 {
+		// A worker advertising no graphs can match no run. Answer without
+		// opening a transaction (and without firing a pointless outbox notify).
+		return c.JSON(http.StatusOK, WorkerClaimResponse{Runs: []ClaimedRun{}})
+	}
+
+	var claimed []claimedRunRow
+	// One transaction for select+lease+events+outbox+notify, per the spec's
+	// step list. The events are appended INSIDE the projection rather than
+	// handed to writeTx up front, because which runs were claimed is only
+	// known once the SELECT ... FOR UPDATE SKIP LOCKED has run — and it can
+	// only run inside this transaction, since that is what holds the locks.
+	// Appending in-projection keeps the identical guarantee writeTx exists to
+	// provide: a rollback drops the lease, the events, the outbox rows, and
+	// the notify together.
+	if err := s.writeTx(ctx, s.Tenant, nil, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, claimSQL, wid, graphs, req.batchSize())
+		if err != nil {
+			return err
+		}
+		claimed, err = pgx.CollectRows(rows, pgx.RowToStructByName[claimedRunRow])
+		if err != nil {
+			return err
+		}
+		if len(claimed) == 0 {
+			return nil
+		}
+		if err := attachLatestCheckpoints(ctx, tx, claimed); err != nil {
+			return err
+		}
+		// One run.started per claimed run, on the RUN's own aggregate — the
+		// event stream a run's checkpoints and later events all hang off
+		// (WorkersWriteCheckpoint resolves the stream by aggregate_id), so a
+		// synthetic aggregate id here would strand every subsequent write.
+		events := make([]Event, 0, len(claimed))
+		for _, r := range claimed {
+			events = append(events, Event{
+				AggregateType: "Run",
+				AggregateID:   r.ID,
+				EventType:     "run.started",
+				Payload: mustJSON(map[string]any{
+					"run_id":      r.ID,
+					"worker_id":   wid,
+					"lease_epoch": r.LeaseEpoch,
+				}),
+			})
+		}
+		return appendEvents(ctx, tx, events)
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resp := WorkerClaimResponse{Runs: make([]ClaimedRun, 0, len(claimed))}
+	for _, r := range claimed {
+		resp.Runs = append(resp.Runs, ClaimedRun{
+			Run:          r.toAPI(),
+			LeaseEpoch:   r.LeaseEpoch,
+			CheckpointID: r.CheckpointID,
+			GraphID:      deref(r.EffectiveGraphID),
+			Input:        json.RawMessage(r.Input),
+		})
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// attachLatestCheckpoints fills CheckpointID for each claimed run: the id of
+// its newest snapshot, or nil when the run has never checkpointed (a fresh
+// run — the spec's "null if fresh, set if resuming"). It is what tells a
+// worker whether to start the graph from its entry node or resume from state.
+//
+// Newest is max(id), NOT max(version): snapshots.version is per event-stream
+// while id is BIGSERIAL, i.e. the true global write order — the same reasoning
+// the thread state/history reads already follow (see rows.go DIVERGENCES).
+// One grouped query for the whole batch rather than one per run.
+func attachLatestCheckpoints(ctx context.Context, tx pgx.Tx, claimed []claimedRunRow) error {
+	ids := make([]uuid.UUID, 0, len(claimed))
+	for _, r := range claimed {
+		ids = append(ids, r.ID)
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT aggregate_id, max(id) AS checkpoint_id
+		FROM snapshots
+		WHERE aggregate_type = 'Run' AND aggregate_id = ANY($1::uuid[])
+		GROUP BY aggregate_id`, ids)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	latest := make(map[uuid.UUID]int64, len(claimed))
+	for rows.Next() {
+		var id uuid.UUID
+		var ckpt int64
+		if err := rows.Scan(&id, &ckpt); err != nil {
+			return err
+		}
+		latest[id] = ckpt
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for i := range claimed {
+		if ckpt, ok := latest[claimed[i].ID]; ok {
+			c := ckpt
+			claimed[i].CheckpointID = &c
+		}
+	}
+	return nil
+}
+
+// appendEvents is writeTx's own append loop, exposed for the events whose
+// aggregate ids are discovered inside the transaction (see WorkersClaim).
+func appendEvents(ctx context.Context, tx pgx.Tx, events []Event) error {
+	for _, e := range events {
+		if err := eventstore.Append(ctx, tx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/controlplane/endpoints/workers_claim_integration_test.go
+++ b/controlplane/endpoints/workers_claim_integration_test.go
@@ -1,0 +1,422 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// --- claim-test fixtures -----------------------------------------------------
+
+// resetClaimTables truncates everything the claim path touches. Every claim
+// test starts from an empty queue so priority/limit assertions mean what they
+// say.
+func resetClaimTables(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx,
+		"TRUNCATE workers, runs, snapshots, events, outbox, event_streams, assistants, threads CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// seedClaimWorker registers a worker directly (no HTTP) advertising graphs.
+func seedClaimWorker(t *testing.T, ctx context.Context, graphs ...string) string {
+	t.Helper()
+	if graphs == nil {
+		graphs = []string{} // workers.graphs is NOT NULL; a nil slice binds as NULL
+	}
+	wid := uuid.NewString()
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO workers (worker_id, graphs, capacity, status, lease_expires_at, last_heartbeat_at)
+		 VALUES ($1, $2, 4, 'online', now() + interval '60 seconds', now())`, wid, graphs); err != nil {
+		t.Fatal(err)
+	}
+	return wid
+}
+
+// seedClaimAssistant creates an assistant bound to a graph name. runs.graph_id
+// is not populated by the create path, so the assistant's graph_id is what the
+// claim filter actually resolves through (see claimSQL's COALESCE).
+func seedClaimAssistant(t *testing.T, ctx context.Context, graph string) string {
+	t.Helper()
+	var aid string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO assistants (name, graph_id) VALUES ($1, $1) RETURNING id`, graph).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	return aid
+}
+
+// seedQueuedRun inserts a queued run for an assistant at a given priority.
+func seedQueuedRun(t *testing.T, ctx context.Context, aid string, priority int) string {
+	t.Helper()
+	var rid string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO runs (assistant_id, status, priority) VALUES ($1,'queued',$2) RETURNING id`,
+		aid, priority).Scan(&rid); err != nil {
+		t.Fatal(err)
+	}
+	return rid
+}
+
+// claim POSTs a claim and decodes the response. Fails the test on a non-200.
+func claim(t *testing.T, e *echo.Echo, wid string, maxRuns int) WorkerClaimResponse {
+	t.Helper()
+	rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/runs/claim",
+		`{"max_runs":`+itoa(maxRuns)+`}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("claim: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got WorkerClaimResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("claim decode: %v (%s)", err, rec.Body.String())
+	}
+	return got
+}
+
+// --- tests -------------------------------------------------------------------
+
+// TestWorkersClaimLeasesMatchingRun proves the happy path: a queued run whose
+// graph the worker advertises is leased to it — status in_progress, worker_id
+// set, lease_epoch incremented — and a run.started event lands on the run's own
+// aggregate.
+func TestWorkersClaimLeasesMatchingRun(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	wid := seedClaimWorker(t, ctx, "counter")
+	aid := seedClaimAssistant(t, ctx, "counter")
+	rid := seedQueuedRun(t, ctx, aid, 0)
+
+	got := claim(t, e, wid, 5)
+	if len(got.Runs) != 1 {
+		t.Fatalf("claimed runs: want 1, got %d (%+v)", len(got.Runs), got.Runs)
+	}
+	cr := got.Runs[0]
+	if cr.Run.RunId.String() != rid {
+		t.Errorf("claimed run id: want %s, got %s", rid, cr.Run.RunId)
+	}
+	if cr.LeaseEpoch != 1 {
+		t.Errorf("lease_epoch in response: want 1, got %d", cr.LeaseEpoch)
+	}
+	if cr.CheckpointID != nil {
+		t.Errorf("fresh run must have null checkpoint_id, got %d", *cr.CheckpointID)
+	}
+	// The graph reported is the one the run actually matched on — resolved
+	// through the assistant, since runs.graph_id is unpopulated today.
+	if cr.GraphID != "counter" {
+		t.Errorf("graph_id: want counter, got %q", cr.GraphID)
+	}
+
+	// The row itself: leased, to this worker, epoch bumped, started_at stamped.
+	var status string
+	var workerID *string
+	var epoch, version int
+	var startedAt *time.Time
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, worker_id::text, lease_epoch, version, started_at FROM runs WHERE id=$1`, rid).
+		Scan(&status, &workerID, &epoch, &version, &startedAt); err != nil {
+		t.Fatal(err)
+	}
+	if status != "in_progress" {
+		t.Errorf("run status: want in_progress, got %s", status)
+	}
+	if workerID == nil || *workerID != wid {
+		t.Errorf("run worker_id: want %s, got %v", wid, workerID)
+	}
+	if epoch != 1 {
+		t.Errorf("lease_epoch: want 1 (0+1), got %d", epoch)
+	}
+	if version != 1 {
+		t.Errorf("version: want 1 (0+1), got %d", version)
+	}
+	if startedAt == nil {
+		t.Error("started_at must be stamped on claim")
+	}
+
+	// The event must carry the REAL run id as aggregate_id — a synthetic
+	// aggregate would strand every later write on this run (checkpoints
+	// resolve their stream by aggregate_id).
+	if n := countRows(t, ctx,
+		`SELECT count(*) FROM events WHERE event_type='run.started' AND aggregate_id=$1 AND aggregate_type='Run'`, rid); n != 1 {
+		t.Errorf("run.started events for run: want 1, got %d", n)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM events WHERE event_type='run.started'`); n != 1 {
+		t.Errorf("run.started events overall: want 1 (none on a bogus aggregate), got %d", n)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM outbox WHERE event_type='run.started' AND aggregate_id=$1`, rid); n != 1 {
+		t.Errorf("run.started outbox rows: want 1, got %d", n)
+	}
+}
+
+// TestWorkersClaimFiltersByGraph proves a run whose graph the worker does NOT
+// advertise is left queued — the claim is graph-scoped dispatch, not a queue pop.
+func TestWorkersClaimFiltersByGraph(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	wid := seedClaimWorker(t, ctx, "counter")
+	mine := seedQueuedRun(t, ctx, seedClaimAssistant(t, ctx, "counter"), 0)
+	theirs := seedQueuedRun(t, ctx, seedClaimAssistant(t, ctx, "summarizer"), 0)
+
+	got := claim(t, e, wid, 10)
+	if len(got.Runs) != 1 || got.Runs[0].Run.RunId.String() != mine {
+		t.Fatalf("want only the counter run %s claimed, got %+v", mine, got.Runs)
+	}
+	if s := runStatus(t, ctx, theirs); s != "queued" {
+		t.Errorf("run for an unadvertised graph must stay queued, got %s", s)
+	}
+}
+
+// TestWorkersClaimPriorityOrder proves ORDER BY priority DESC, created_at:
+// the highest-priority run goes first even though it was queued last.
+func TestWorkersClaimPriorityOrder(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	wid := seedClaimWorker(t, ctx, "counter")
+	aid := seedClaimAssistant(t, ctx, "counter")
+	low := seedQueuedRun(t, ctx, aid, 0)
+	high := seedQueuedRun(t, ctx, aid, 10)
+
+	got := claim(t, e, wid, 1)
+	if len(got.Runs) != 1 {
+		t.Fatalf("claimed runs: want 1, got %d", len(got.Runs))
+	}
+	if got.Runs[0].Run.RunId.String() != high {
+		t.Errorf("want the priority-10 run %s first, got %s", high, got.Runs[0].Run.RunId)
+	}
+	if s := runStatus(t, ctx, low); s != "queued" {
+		t.Errorf("lower-priority run must stay queued, got %s", s)
+	}
+}
+
+// TestWorkersClaimRespectsMaxRuns proves LIMIT :max_runs bounds one claim, and
+// that the remainder stays claimable.
+func TestWorkersClaimRespectsMaxRuns(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	wid := seedClaimWorker(t, ctx, "counter")
+	aid := seedClaimAssistant(t, ctx, "counter")
+	for i := 0; i < 5; i++ {
+		seedQueuedRun(t, ctx, aid, 0)
+	}
+
+	got := claim(t, e, wid, 2)
+	if len(got.Runs) != 2 {
+		t.Fatalf("max_runs=2: want 2 claimed, got %d", len(got.Runs))
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM runs WHERE status='queued'`); n != 3 {
+		t.Errorf("still-queued runs: want 3, got %d", n)
+	}
+	// An absent body claims the default of one.
+	rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/"+wid+"/runs/claim", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty-body claim: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var deflt WorkerClaimResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &deflt)
+	if len(deflt.Runs) != defaultClaimBatch {
+		t.Errorf("default batch: want %d, got %d", defaultClaimBatch, len(deflt.Runs))
+	}
+}
+
+// TestWorkersClaimCheckpointID proves the resume contract: checkpoint_id is
+// null for a fresh run and carries the LATEST snapshot id for a run that has
+// checkpointed.
+func TestWorkersClaimCheckpointID(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	wid := seedClaimWorker(t, ctx, "counter")
+	aid := seedClaimAssistant(t, ctx, "counter")
+	fresh := seedQueuedRun(t, ctx, aid, 0)
+	resuming := seedQueuedRun(t, ctx, aid, 0)
+
+	// A run that has checkpointed: two snapshots, so "latest" is provable.
+	seedSnapshot(t, ctx, resuming, 1, `{"count":1}`)
+	want := seedSnapshot(t, ctx, resuming, 2, `{"count":2}`)
+
+	got := claim(t, e, wid, 10)
+	if len(got.Runs) != 2 {
+		t.Fatalf("claimed runs: want 2, got %d", len(got.Runs))
+	}
+	byRun := map[string]*int64{}
+	for _, r := range got.Runs {
+		byRun[r.Run.RunId.String()] = r.CheckpointID
+	}
+	if ck, ok := byRun[fresh]; !ok || ck != nil {
+		t.Errorf("fresh run checkpoint_id: want null, got %v", ck)
+	}
+	ck, ok := byRun[resuming]
+	if !ok || ck == nil {
+		t.Fatalf("resuming run checkpoint_id: want %d, got nil", want)
+	}
+	if *ck != want {
+		t.Errorf("resuming run checkpoint_id: want the latest snapshot %d, got %d", want, *ck)
+	}
+}
+
+// TestWorkersClaimSkipsLockedRuns proves the FOR UPDATE SKIP LOCKED clause
+// directly: with one candidate row locked by another transaction, the claim
+// steps over it and takes the next one instead of blocking on it.
+//
+// The request carries a deadline, so a claim that used a plain FOR UPDATE
+// would fail this test (context deadline while waiting on the lock) rather
+// than hang the suite.
+func TestWorkersClaimSkipsLockedRuns(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	wid := seedClaimWorker(t, ctx, "counter")
+	aid := seedClaimAssistant(t, ctx, "counter")
+	locked := seedQueuedRun(t, ctx, aid, 10) // highest priority: chosen first...
+	free := seedQueuedRun(t, ctx, aid, 0)    // ...unless it is locked away
+
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	var held string
+	if err := tx.QueryRow(ctx, `SELECT id FROM runs WHERE id=$1 FOR UPDATE`, locked).Scan(&held); err != nil {
+		t.Fatal(err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers/"+wid+"/runs/claim",
+		strings.NewReader(`{"max_runs":5}`)).WithContext(reqCtx)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("claim with a locked candidate: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got WorkerClaimResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if len(got.Runs) != 1 || got.Runs[0].Run.RunId.String() != free {
+		t.Fatalf("want only the unlocked run %s claimed, got %+v", free, got.Runs)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if s := runStatus(t, ctx, locked); s != "queued" {
+		t.Errorf("the locked run must be left queued for the next claim, got %s", s)
+	}
+}
+
+// TestWorkersClaimConcurrentNoDoubleClaim drives two claims at once against a
+// queue of two runs and proves no run is handed to both workers — the property
+// SKIP LOCKED exists to guarantee.
+func TestWorkersClaimConcurrentNoDoubleClaim(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	w1 := seedClaimWorker(t, ctx, "counter")
+	w2 := seedClaimWorker(t, ctx, "counter")
+	aid := seedClaimAssistant(t, ctx, "counter")
+	seedQueuedRun(t, ctx, aid, 0)
+	seedQueuedRun(t, ctx, aid, 0)
+
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		codes []int
+		runs  []string
+	)
+	start := make(chan struct{})
+	for _, wid := range []string{w1, w2} {
+		wg.Add(1)
+		go func(wid string) {
+			defer wg.Done()
+			<-start
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/workers/"+wid+"/runs/claim",
+				strings.NewReader(`{"max_runs":2}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			e.ServeHTTP(rec, req)
+			var got WorkerClaimResponse
+			_ = json.Unmarshal(rec.Body.Bytes(), &got)
+			mu.Lock()
+			defer mu.Unlock()
+			codes = append(codes, rec.Code)
+			for _, r := range got.Runs {
+				runs = append(runs, r.Run.RunId.String())
+			}
+		}(wid)
+	}
+	close(start)
+	wg.Wait()
+
+	for _, code := range codes {
+		if code != http.StatusOK {
+			t.Fatalf("concurrent claim: want 200, got %d", code)
+		}
+	}
+	seen := map[string]int{}
+	for _, r := range runs {
+		seen[r]++
+	}
+	for rid, n := range seen {
+		if n > 1 {
+			t.Errorf("run %s was claimed %d times — concurrent claims overlapped", rid, n)
+		}
+	}
+	if len(runs) != 2 || len(seen) != 2 {
+		t.Errorf("both queued runs should be claimed exactly once between the two workers, got %v", runs)
+	}
+	// Each run ended up owned by exactly one worker, with one run.started each.
+	if n := countRows(t, ctx, `SELECT count(*) FROM runs WHERE status='in_progress' AND worker_id IS NOT NULL`); n != 2 {
+		t.Errorf("in_progress runs: want 2, got %d", n)
+	}
+	if n := countRows(t, ctx, `SELECT count(*) FROM events WHERE event_type='run.started'`); n != 2 {
+		t.Errorf("run.started events: want 2, got %d", n)
+	}
+}
+
+// TestWorkersClaimBadRequests covers the boundary: a malformed worker id is a
+// 422 from pathUUIDString (never interpolated into the query), and an
+// unregistered worker is a 409 telling it to re-register.
+func TestWorkersClaimBadRequests(t *testing.T) {
+	ctx := context.Background()
+	resetClaimTables(t, ctx)
+	e := newTestServerWithWorkers()
+
+	rec := doJSON(t, e, http.MethodPost, "/api/v1/workers/not-a-uuid/runs/claim", `{"max_runs":1}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("malformed worker id: want 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "SQLSTATE") {
+		t.Errorf("422 body must not leak a driver error: %s", rec.Body.String())
+	}
+
+	rec = doJSON(t, e, http.MethodPost, "/api/v1/workers/"+uuid.NewString()+"/runs/claim", `{"max_runs":1}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("unregistered worker: want 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// A registered worker advertising no graphs claims nothing, successfully.
+	wid := seedClaimWorker(t, ctx)
+	seedQueuedRun(t, ctx, seedClaimAssistant(t, ctx, "counter"), 0)
+	got := claim(t, e, wid, 5)
+	if len(got.Runs) != 0 {
+		t.Errorf("worker with no graphs: want 0 claimed, got %d", len(got.Runs))
+	}
+}

--- a/controlplane/endpoints/workers_gen.go
+++ b/controlplane/endpoints/workers_gen.go
@@ -4,10 +4,6 @@
 package endpoints
 
 import (
-	"net/http"
-
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
 
@@ -30,38 +26,7 @@ func (s *Server) RegisterWorkers(g *echo.Group) {
 
 // WorkersDeregister — POST /workers/{id}/deregister  (kind: write) — hand-written in workers.go
 
-// WorkersClaim — POST /workers/{id}/runs/claim  (kind: write)
-//   - SELECT runs WHERE status='queued' AND graph_id IN (worker graphs) ORDER BY priority DESC, created_at FOR UPDATE SKIP LOCKED LIMIT :max_runs
-//   - SELECT snapshots: latest checkpoint_id per run (if resuming)
-//   - UPDATE runs SET status='in_progress', worker_id=:id, lease_epoch=lease_epoch+1, started_at=now(), version=version+1
-//   - INSERT events: event_type='run.started' for each claimed run
-//   - INSERT outbox (same TX)
-//   - pg_notify('outbox_new',”)
-func (s *Server) WorkersClaim(c echo.Context) error {
-	ctx := c.Request().Context()
-	_ = ctx
-	var req map[string]any // TODO: bind OpenAPI type (WorkersClaim request schema)
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-	aggID := uuid.New() // TODO: new id for create; parse from path param for update/cancel/etc.
-	events := []Event{
-		{AggregateType: "Run", AggregateID: aggID, EventType: "run.started"},
-	}
-	if err := s.writeTx(ctx, s.Tenant, events, func(tx pgx.Tx) error {
-		// TODO projection write:
-		//   SELECT runs WHERE status='queued' AND graph_id IN (worker graphs) ORDER BY priority DESC, created_at FOR UPDATE SKIP LOCKED LIMIT :max_runs
-		//   SELECT snapshots: latest checkpoint_id per run (if resuming)
-		//   UPDATE runs SET status='in_progress', worker_id=:id, lease_epoch=lease_epoch+1, started_at=now(), version=version+1
-		//   INSERT events: event_type='run.started' for each claimed run
-		//   INSERT outbox (same TX)
-		//   pg_notify('outbox_new','')
-		return nil
-	}); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]any{}) // TODO: return OpenAPI response type
-}
+// WorkersClaim — POST /workers/{id}/runs/claim  (kind: write) — hand-written in workers.go
 
 // WorkersStreamEvents — POST /workers/{id}/runs/{rid}/events  (kind: write) — hand-written in workers.go
 

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -672,6 +672,7 @@ groups:
       - name: claim
         method: POST
         path: /workers/{id}/runs/claim
+        custom: true
         kind: write
         outbox: true
         events: [run.started]
@@ -737,12 +738,14 @@ groups:
       - name: login
         method: GET
         path: /api/auth/{provider}/login
+        custom: true
         kind: special
         outbox: false
         steps: ["Set goth CSRF state cookie", "302 redirect to provider authorization URL"]
       - name: callback
         method: GET
         path: /api/auth/{provider}/callback
+        custom: true
         kind: write
         outbox: true
         events: [user.signed_up, user.promoted_to_admin, user.approved, tenant.pending, tenant.provisioning]
@@ -762,12 +765,14 @@ groups:
       - name: logout
         method: POST
         path: /api/auth/logout
+        custom: true
         kind: special
         outbox: false
         steps: ["Clear cookie: Set-Cookie duragraph_session=; Max-Age=0"]
       - name: refresh
         method: POST
         path: /api/auth/refresh
+        custom: true
         kind: special
         outbox: false
         steps: ["Validate current JWT (signature + expiry)", "Mint new JWT (same claims, new exp)"]
@@ -779,6 +784,7 @@ groups:
       - name: me
         method: GET
         path: /api/platform/me
+        custom: true
         kind: read
         outbox: false
         steps:
@@ -792,6 +798,7 @@ groups:
       - name: list_users
         method: GET
         path: /api/admin/users
+        custom: true
         kind: read
         outbox: false
         steps:
@@ -800,6 +807,7 @@ groups:
       - name: approve
         method: POST
         path: /api/admin/users/{id}/approve
+        custom: true
         kind: write
         outbox: true
         events: [user.approved, tenant.provisioning]
@@ -815,6 +823,7 @@ groups:
       - name: reject
         method: POST
         path: /api/admin/users/{id}/reject
+        custom: true
         kind: write
         outbox: true
         events: [user.rejected]
@@ -828,6 +837,7 @@ groups:
       - name: suspend
         method: POST
         path: /api/admin/users/{id}/suspend
+        custom: true
         kind: write
         outbox: true
         events: [user.suspended, tenant.suspended]
@@ -842,6 +852,7 @@ groups:
       - name: resume
         method: POST
         path: /api/admin/users/{id}/resume
+        custom: true
         kind: write
         outbox: false
         steps:
@@ -852,6 +863,7 @@ groups:
       - name: retry_migration
         method: POST
         path: /api/admin/tenants/{id}/retry-migration
+        custom: true
         kind: write
         outbox: true
         events: [tenant.provisioning]
@@ -865,6 +877,7 @@ groups:
       - name: metrics
         method: GET
         path: /api/admin/metrics
+        custom: true
         kind: read
         outbox: false
         backend: mimir
@@ -872,6 +885,7 @@ groups:
       - name: metrics_tenant
         method: GET
         path: /api/admin/metrics/{tenant_id}
+        custom: true
         kind: read
         outbox: false
         backend: mimir

--- a/controlplane/gen/main.go
+++ b/controlplane/gen/main.go
@@ -208,7 +208,12 @@ func toView(g group) groupView {
 		if !e.Custom {
 			gv.NeedsHTTP = true // generated body uses http.Status*
 		}
-		if ev.IsWrite && e.Outbox {
+		// A custom endpoint gets a route and a pointer comment, no body — so it
+		// contributes no imports. Without the !e.Custom guard, marking a write
+		// endpoint custom left pgx and uuid imported and unused, and Go makes
+		// that a compile error for the whole FILE. Nothing a hand-written
+		// handler can do about it: imports are file-scoped.
+		if ev.IsWrite && e.Outbox && !e.Custom {
 			gv.NeedsPgx = true
 			gv.NeedsUUID = true
 			ev.ProjectionSteps = e.Steps

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -54,6 +54,27 @@ type Config struct {
 	// bootstrap.
 	PlatformDSN string
 
+	// JWTSecret is the HMAC key for platform session tokens. Empty leaves
+	// the platform surface (/api/auth, /api/platform, /api/admin) unable
+	// to mint or verify sessions: auth answers 503 and /me answers 401,
+	// rather than signing with an empty key that any other unconfigured
+	// deployment could forge. Read from DURAGRAPH_JWT_SECRET when unset.
+	JWTSecret []byte
+
+	// BaseURL is the canonical external origin (scheme + host), used for
+	// the logout CSRF origin check. Read from DURAGRAPH_BASE_URL.
+	BaseURL string
+
+	// CookieDomain scopes the session cookie; empty means host-only,
+	// which is the correct default in dev. Read from
+	// DURAGRAPH_COOKIE_DOMAIN.
+	CookieDomain string
+
+	// CookieSecure sets the Secure attribute on the session cookie. Must
+	// be true wherever the platform is served over https. Read from
+	// DURAGRAPH_COOKIE_SECURE.
+	CookieSecure bool
+
 	// NATSURL is the JetStream URL for the outbox relay + SSE
 	// subscriber. Empty disables the relay (read endpoints still work).
 	NATSURL string
@@ -226,10 +247,41 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 	e.Server.IdleTimeout = 60 * time.Second
 	s.echo = e
 
+	// Environment fallbacks for the platform session settings. Config wins when
+	// set explicitly (tests, embedding); the env vars are the deployment path.
+	jwtSecret := cfg.JWTSecret
+	if len(jwtSecret) == 0 {
+		jwtSecret = []byte(os.Getenv("DURAGRAPH_JWT_SECRET"))
+	}
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("DURAGRAPH_BASE_URL")
+	}
+	cookieDomain := cfg.CookieDomain
+	if cookieDomain == "" {
+		cookieDomain = os.Getenv("DURAGRAPH_COOKIE_DOMAIN")
+	}
+	cookieSecure := cfg.CookieSecure
+	if !cookieSecure {
+		cookieSecure = os.Getenv("DURAGRAPH_COOKIE_SECURE") == "true"
+	}
+	if len(jwtSecret) == 0 {
+		// Loud, because the failure mode is otherwise silent: every login
+		// answers 503 and it looks like the provider is down.
+		slog.Warn("platform session secret is not set; /api/auth, /api/platform and /api/admin " +
+			"cannot establish sessions (set DURAGRAPH_JWT_SECRET)")
+	}
+
 	ep := &endpoints.Server{
 		Tenant:     s.tenant,
 		Platform:   s.plat,
 		Subscriber: subscriber,
+		Auth: endpoints.AuthConfig{
+			JWTSecret:    jwtSecret,
+			BaseURL:      baseURL,
+			CookieDomain: cookieDomain,
+			CookieSecure: cookieSecure,
+		},
 	}
 	g := e.Group("/api/v1")
 	ep.RegisterAssistants(g)
@@ -238,9 +290,18 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 	ep.RegisterCrons(g)
 	ep.RegisterStore(g)
 	ep.RegisterWorkers(g)
-	ep.RegisterAuth(g)
-	ep.RegisterPlatform(g)
-	ep.RegisterAdmin(g)
+
+	// The platform surface is NOT under /api/v1. endpoints.yaml declares these
+	// with absolute paths (/api/auth/..., /api/platform/..., /api/admin/...)
+	// because api.d2 puts them on their own surface — "Platform surface:
+	// /api/auth/*, /api/platform/*, /api/admin/*". Mounting them on the v1
+	// group concatenated the two and served /api/v1/api/admin/users, which is
+	// in no diagram and no spec. They mount at the root instead.
+	root := e.Group("")
+	ep.RegisterAuth(root)
+	ep.RegisterPlatform(root)
+	ep.RegisterAdmin(root)
+
 	ep.RegisterSystem(e) // root-level: /ok, /info, /metrics
 
 	return s, nil

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/duragraph/duragraph/controlplane/cron"
 	"github.com/duragraph/duragraph/controlplane/endpoints"
 	"github.com/duragraph/duragraph/controlplane/nats"
 	"github.com/duragraph/duragraph/controlplane/reaper"
@@ -127,12 +128,14 @@ type Server struct {
 	cleanup      *nats.CleanupWorker
 	runProcessor *nats.RunProcessor
 	reaper       *reaper.RunReaper
+	cronSched    *cron.Scheduler
 	echo         *echo.Echo
 
 	relayDone   chan error
 	cleanupDone chan error
 	rpDone      chan error
 	reaperDone  chan error
+	cronDone    chan error
 
 	closeOnce sync.Once
 }
@@ -155,6 +158,7 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		cleanupDone: make(chan error, 1),
 		rpDone:      make(chan error, 1),
 		reaperDone:  make(chan error, 1),
+		cronDone:    make(chan error, 1),
 	}
 
 	// --- pgxpools ---
@@ -172,9 +176,13 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		s.plat = platformPool
 	}
 
-	// --- run reaper (needs only the tenant pool, not NATS) ---
+	// --- run reaper + cron scheduler (need only the tenant pool, not NATS) ---
 	if s.tenant != nil {
 		s.reaper = reaper.NewRunReaper(s.tenant, reaper.Config{})
+		// Fires due crons by creating runs through the same event-sourced
+		// path as the API, so a scheduled run is dispatched exactly like a
+		// requested one.
+		s.cronSched = cron.NewScheduler(s.tenant, cron.Config{})
 	}
 
 	// --- migrations ---
@@ -325,6 +333,9 @@ func (s *Server) Run(ctx context.Context) error {
 	if s.reaper != nil && s.cfg.Relays {
 		go func() { s.reaperDone <- s.reaper.Start(ctx) }()
 	}
+	if s.cronSched != nil && s.cfg.Relays {
+		go func() { s.cronDone <- s.cronSched.Start(ctx) }()
+	}
 
 	// --- HTTP ---
 	httpErr := make(chan error, 1)
@@ -375,6 +386,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 	if s.reaper != nil {
 		s.reaper.Stop()
+	}
+	if s.cronSched != nil {
+		s.cronSched.Stop()
 	}
 	// Wait for those goroutines to exit (bounded by DrainTimeout).
 	select {

--- a/controlplane/worker/api_only_journey_test.go
+++ b/controlplane/worker/api_only_journey_test.go
@@ -1,0 +1,384 @@
+package worker_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// apiClient is a tiny JSON HTTP helper so the journey below reads as the
+// sequence of calls a user actually makes.
+type apiClient struct {
+	t    *testing.T
+	base string
+}
+
+func (a *apiClient) do(method, path string, body any, out any) int {
+	a.t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			a.t.Fatal(err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, a.base+path, rdr)
+	if err != nil {
+		a.t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		a.t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if out != nil && len(raw) > 0 {
+		if err := json.Unmarshal(raw, out); err != nil {
+			a.t.Fatalf("%s %s: decode %q: %v", method, path, raw, err)
+		}
+	}
+	if resp.StatusCode >= 400 {
+		a.t.Logf("%s %s -> %d: %s", method, path, resp.StatusCode, raw)
+	}
+	return resp.StatusCode
+}
+
+func (a *apiClient) mustDo(method, path string, body any, out any, want int) {
+	a.t.Helper()
+	if got := a.do(method, path, body, out); got != want {
+		a.t.Fatalf("%s %s: want %d, got %d", method, path, want, got)
+	}
+}
+
+// TestAPIOnlyUserJourney is the "does it actually work for one user" proof.
+//
+// The constraint that makes it meaningful: this test performs NO SQL. Every
+// step is an HTTP call a user could make with curl. The earlier end-to-end
+// tests all seeded the graph directly into Postgres with seedCounterGraph,
+// which quietly hid the fact that there was no API to install a graph at all —
+// two GET routes read `graphs` and nothing wrote it. A user with only the
+// public API could create an assistant, a thread and a run, and the run could
+// never execute.
+//
+// The journey: register a worker WITH its graph definition, create an
+// assistant, create a thread, start a run, watch it complete, then read the
+// state, history and run back.
+func TestAPIOnlyUserJourney(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	// The full public surface, as a deployment serves it.
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterStore(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	// Relay + dispatcher + a live worker.
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	graphName := "journey-" + uuid.NewString()[:8]
+
+	// --- STEP 1: the SDK registers the worker AND its graph definition ---
+	// Two nodes, A -> B, matching the shape the executors understand.
+	nodes := json.RawMessage(`[
+		{"id":"A","type":"tool","config":{"set":{"step":"a"}}},
+		{"id":"B","type":"tool","config":{"set":{"step":"b"}}}]`)
+	edges := json.RawMessage(`[{"source":"A","target":"B"}]`)
+
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name: graphName, Version: "1", Nodes: nodes, Edges: edges,
+	}}); err != nil {
+		t.Fatalf("register worker + graph: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	// The graph must now be readable back through the API — proving it landed
+	// where the worker's loader will look for it, not merely that the call
+	// returned 200.
+	var graphResp map[string]any
+	api.mustDo("GET", "/api/v1/assistants/"+graphName+"/graph", nil, &graphResp, http.StatusOK)
+
+	// --- STEP 2: create an assistant bound to that graph ---
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName,
+		"name":     "journey-assistant",
+	}, &assistant, http.StatusCreated)
+	if assistant.AssistantID == "" {
+		t.Fatal("create assistant returned no assistant_id")
+	}
+
+	// --- STEP 3: create a thread ---
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+	if thread.ThreadID == "" {
+		t.Fatal("create thread returned no thread_id")
+	}
+
+	// --- STEP 4: start a run ---
+	var run struct {
+		RunID  string `json:"run_id"`
+		Status string `json:"status"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs", map[string]any{
+		"assistant_id": assistant.AssistantID,
+		"input":        map[string]any{"count": 0},
+	}, &run, http.StatusCreated)
+	if run.RunID == "" {
+		t.Fatal("create run returned no run_id")
+	}
+
+	// --- STEP 5: it runs to completion, with no help ---
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+
+	// --- STEP 6: read it back through the API ---
+	var got struct {
+		RunID  string `json:"run_id"`
+		Status string `json:"status"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/runs/"+run.RunID, nil, &got, http.StatusOK)
+	// The API reports LangGraph vocabulary ("success"), not the DB's
+	// ("completed") — translateRunStatus in rows.go.
+	if got.Status != "success" {
+		t.Errorf("run status via API: want success, got %q", got.Status)
+	}
+
+	// State and history must be readable — a run that completed but left no
+	// retrievable state is not usable.
+	var state map[string]any
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/state", nil, &state, http.StatusOK)
+	var history []any
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/history", nil, &history, http.StatusOK)
+	if len(history) == 0 {
+		t.Error("history is empty after a completed run: the checkpoints are not retrievable")
+	}
+}
+
+// TestAPIOnlyHumanInTheLoop is the second half of the single-user story: a run
+// that pauses for a human and continues when told to. Also API-only.
+func TestAPIOnlyHumanInTheLoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	graphName := "hitl-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name:    graphName,
+		Version: "1",
+		Nodes: json.RawMessage(`[
+			{"id":"A","type":"tool","config":{"set":{"step":"a"}}},
+			{"id":"B","type":"tool","config":{"set":{"step":"b"}}}]`),
+		Edges: json.RawMessage(`[{"source":"A","target":"B"}]`),
+	}}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "hitl-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+
+	// interrupt_before B: the run must stop and ASK before running B.
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs", map[string]any{
+		"assistant_id":     assistant.AssistantID,
+		"input":            map[string]any{"count": 0},
+		"interrupt_before": []string{"B"},
+	}, &run, http.StatusCreated)
+
+	rid := uuid.MustParse(run.RunID)
+	waitForRunStatus(t, ctx, pool, rid, "requires_action", 30*time.Second)
+
+	// A paused run must be visible AS paused through the API, or a user has no
+	// way to know it is waiting for them.
+	var paused struct {
+		Status string `json:"status"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/runs/"+run.RunID, nil, &paused, http.StatusOK)
+	if paused.Status != "interrupted" {
+		t.Errorf("paused run via API: want interrupted, got %q", paused.Status)
+	}
+
+	// B must NOT have run yet — that is what the interrupt is for.
+	assertNodeCount(t, ctx, pool, rid, "B", 0)
+
+	// --- the human answers ---
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs/"+run.RunID+"/resume",
+		map[string]any{"command": map[string]any{"resume": "go ahead"}}, nil, http.StatusOK)
+
+	waitForRunStatus(t, ctx, pool, rid, "completed", 30*time.Second)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+}
+
+// TestAPIOnlyRunFailureIsVisible — a user must be able to tell that a run
+// failed, and why. A run that dies silently is worse than one that errors.
+func TestAPIOnlyRunFailureIsVisible(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	graphName := "fail-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name:    graphName,
+		Version: "1",
+		Nodes:   json.RawMessage(`[{"id":"A","type":"tool","config":{"fail":"boom"}}]`),
+		Edges:   json.RawMessage(`[]`),
+	}}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "fail-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs", map[string]any{
+		"assistant_id": assistant.AssistantID,
+	}, &run, http.StatusCreated)
+
+	rid := uuid.MustParse(run.RunID)
+	waitForRunStatus(t, ctx, pool, rid, "failed", 30*time.Second)
+
+	var got map[string]any
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/runs/"+run.RunID, nil, &got, http.StatusOK)
+	if got["status"] != "error" {
+		t.Errorf("failed run via API: want status error, got %v", got["status"])
+	}
+	// The reason must survive to the user, not just to the log.
+	var errText *string
+	if err := pool.QueryRow(ctx, `SELECT error FROM runs WHERE id=$1`, rid).Scan(&errText); err != nil {
+		t.Fatal(err)
+	}
+	if errText == nil || *errText == "" {
+		t.Error("a failed run must record why it failed")
+	}
+	fmt.Fprintln(io.Discard, got)
+}

--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -43,11 +43,37 @@ func NewClient(baseURL string, workerID uuid.UUID, httpClient *http.Client) *Cli
 // Register upserts this worker as online, advertising the graphs it can run
 // and its concurrency capacity. POST /api/v1/workers/register.
 func (c *Client) Register(ctx context.Context, graphs []string, capacity int) error {
+	return c.RegisterWithGraphs(ctx, graphs, capacity, nil)
+}
+
+// GraphDefinition0 is one graph body as the SDK hands it to the control plane
+// at registration. Named to avoid colliding with the worker's own
+// GraphDefinition (the decoded form it executes); this is the wire shape.
+type GraphDefinition0 struct {
+	Name        string          `json:"name"`
+	Version     string          `json:"version,omitempty"`
+	Description string          `json:"description,omitempty"`
+	AssistantID *uuid.UUID      `json:"assistant_id,omitempty"`
+	Nodes       json.RawMessage `json:"nodes"`
+	Edges       json.RawMessage `json:"edges"`
+	Config      json.RawMessage `json:"config,omitempty"`
+}
+
+// RegisterWithGraphs registers the worker AND installs the graph definitions it
+// can run, in one call.
+//
+// This is the path system-architecture.d2 describes as "SDK registers graph
+// definition". It matters because nothing else in the API writes graphs: before
+// it existed, a graph could only be installed with direct SQL, so a user
+// holding only the HTTP API could create an assistant, a thread and a run, and
+// the run would never execute for want of a graph to load.
+func (c *Client) RegisterWithGraphs(ctx context.Context, graphs []string, capacity int, defs []GraphDefinition0) error {
 	req := struct {
-		WorkerID uuid.UUID `json:"worker_id"`
-		Graphs   []string  `json:"graphs"`
-		Capacity int       `json:"capacity"`
-	}{WorkerID: c.workerID, Graphs: graphs, Capacity: capacity}
+		WorkerID         uuid.UUID          `json:"worker_id"`
+		Graphs           []string           `json:"graphs"`
+		Capacity         int                `json:"capacity"`
+		GraphDefinitions []GraphDefinition0 `json:"graph_definitions,omitempty"`
+	}{WorkerID: c.workerID, Graphs: graphs, Capacity: capacity, GraphDefinitions: defs}
 	_, err := c.doJSON(ctx, http.MethodPost, "/api/v1/workers/register", req, nil)
 	return err
 }

--- a/controlplane/worker/cron_e2e_test.go
+++ b/controlplane/worker/cron_e2e_test.go
@@ -1,0 +1,232 @@
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	dcron "github.com/duragraph/duragraph/controlplane/cron"
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// TestCronFiresAndRunsEndToEnd: a cron created through the API produces a run
+// that a worker actually executes.
+//
+// Before this, a cron was inert in two independent ways — next_run_at was never
+// set at creation, and nothing polled it — so the endpoints stored a schedule
+// that could never fire. API-only apart from advancing the clock, which is done
+// by moving next_run_at rather than waiting for a real minute to elapse.
+func TestCronFiresAndRunsEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterCrons(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	graphName := "cron-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name:    graphName,
+		Version: "1",
+		Nodes:   json.RawMessage(`[{"id":"A","type":"tool","config":{"set":{"step":"a"}}}]`),
+		Edges:   json.RawMessage(`[]`),
+	}}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "cron-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+
+	// Create the cron through the API.
+	var created struct {
+		CronID      string  `json:"cron_id"`
+		NextRunDate *string `json:"next_run_date"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs/crons", map[string]any{
+		"assistant_id": assistant.AssistantID,
+		"schedule":     "*/5 * * * *",
+		"input":        map[string]any{"from": "cron"},
+	}, &created, http.StatusOK)
+	if created.CronID == "" {
+		t.Fatal("create cron returned no cron_id")
+	}
+	// Without this the whole mechanism is dead on arrival: nothing else ever
+	// populates next_run_at, so the scheduler would find nothing due, forever.
+	if created.NextRunDate == nil || *created.NextRunDate == "" {
+		t.Fatal("a newly created cron must carry next_run_date, or it can never fire")
+	}
+
+	// Make it due now instead of waiting for the wall clock.
+	if _, err := pool.Exec(ctx,
+		`UPDATE crons SET next_run_at = now() - interval '1 second' WHERE id = $1`,
+		created.CronID); err != nil {
+		t.Fatal(err)
+	}
+
+	sched := dcron.NewScheduler(pool, dcron.Config{})
+	n, err := sched.FireDue(ctx)
+	if err != nil {
+		t.Fatalf("FireDue: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("want 1 cron fired, got %d", n)
+	}
+
+	// The schedule must have advanced, or the next tick fires it again.
+	var next time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT next_run_at FROM crons WHERE id=$1`, created.CronID).Scan(&next); err != nil {
+		t.Fatal(err)
+	}
+	if !next.After(time.Now().UTC()) {
+		t.Errorf("next_run_at must move into the future, got %s", next)
+	}
+	// Firing again immediately must be a no-op — proof the advance is what
+	// prevents a hot loop.
+	if again, err := sched.FireDue(ctx); err != nil || again != 0 {
+		t.Errorf("second FireDue: want 0 fired, got %d (err %v)", again, err)
+	}
+
+	// The run it created must be traceable to the cron, and must actually run.
+	var rid uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM runs WHERE metadata->>'cron_id' = $1`, created.CronID).Scan(&rid); err != nil {
+		t.Fatalf("cron did not create a run: %v", err)
+	}
+	waitForRunStatus(t, ctx, pool, rid, "completed", 30*time.Second)
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+}
+
+// TestCronCreateRejectsBadSchedule — an unparseable schedule stored as valid
+// would look accepted and never fire, which is silent and permanent.
+func TestCronCreateRejectsBadSchedule(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterCrons(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	var aid string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO assistants (name, graph_id) VALUES ('cron-bad','g') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	var tid string
+	if err := pool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+
+	got := api.do("POST", "/api/v1/threads/"+tid+"/runs/crons", map[string]any{
+		"assistant_id": aid,
+		"schedule":     "not a cron",
+	}, nil)
+	if got != http.StatusUnprocessableEntity {
+		t.Errorf("bad schedule: want 422, got %d", got)
+	}
+}
+
+// TestCronSkipsMissedWindows: the next firing is computed from NOW, so an
+// outage does not replay every window it spanned.
+func TestCronSkipsMissedWindows(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Three hours "down" for a five-minute cron.
+	next, err := dcron.NextRun("*/5 * * * *", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := next.Sub(now); got > 5*time.Minute {
+		t.Errorf("next run should be within one window of now, got %s later", got)
+	}
+	// It fires once and moves on, rather than owing 36 runs.
+	if !next.After(now) {
+		t.Errorf("next run must be strictly after now, got %s", next)
+	}
+}
+
+// TestCronEndTimeStopsFiring — a cron past its end_time must not fire.
+func TestCronEndTimeStopsFiring(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	var aid string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO assistants (name, graph_id) VALUES ('cron-end','g') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	var cid string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO crons (assistant_id, schedule, next_run_at, end_time)
+		VALUES ($1, '*/5 * * * *', now() - interval '1 minute', now() - interval '1 minute')
+		RETURNING id`, aid).Scan(&cid); err != nil {
+		t.Fatal(err)
+	}
+
+	sched := dcron.NewScheduler(pool, dcron.Config{})
+	n, err := sched.FireDue(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var runs int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM runs WHERE metadata->>'cron_id' = $1`, cid).Scan(&runs); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 0 {
+		t.Errorf("a cron past end_time must not fire, but created %d run(s) (fired=%d)", runs, n)
+	}
+}

--- a/controlplane/worker/single_user_e2e_test.go
+++ b/controlplane/worker/single_user_e2e_test.go
@@ -1,0 +1,178 @@
+package worker_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// TestSingleUserRunEndToEnd is the event-store proof for one user: a run
+// created through the PUBLIC HTTP API must reach a worker and complete, driven
+// only by the event store and the outbox.
+//
+// WHY THIS TEST EXISTS. The two pre-existing end-to-end tests
+// (TestExecuteRunEndToEnd, TestStreamEndToEnd) both start by hand-publishing a
+// run.created ENVELOPE straight onto the RUNS stream — they say so in their own
+// comments ("This bypasses the DB events/outbox table for run.created itself").
+// That is a fine way to test the dispatcher and the SSE bridge, but it means
+// the first link of the chain was never covered: nothing proved that creating a
+// run through POST /threads/{id}/runs actually produces an events row, an
+// outbox row, a NOTIFY, and ultimately a running worker. Every stage was tested
+// except the join between them.
+//
+// The chain exercised here, with NOTHING synthesized:
+//
+//	POST /api/v1/threads/{tid}/runs   (real endpoint, real writeTx)
+//	  -> events + outbox rows, pg_notify('outbox_new')          [event store]
+//	  -> Relay LISTENs, drains the outbox, publishes to RUNS     [relay]
+//	  -> RunProcessor turns run.created into worker.graph.execute[dispatch]
+//	  -> Runner leases the run and executes the graph            [worker]
+//	  -> runs.status = 'completed', execution_history filled     [state]
+//
+// If any single link is broken this test hangs and then fails, which is the
+// point: it is the smallest thing that says "the platform works for one user".
+func TestSingleUserRunEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	// A thread and an assistant with a real graph. No run is seeded — creating
+	// it through the API is the thing under test.
+	var tid, aid string
+	if err := pool.QueryRow(ctx, `INSERT INTO threads DEFAULT VALUES RETURNING id`).Scan(&tid); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO assistants (name, graph_id) VALUES ('single-user','counter') RETURNING id`).Scan(&aid); err != nil {
+		t.Fatal(err)
+	}
+	seedCounterGraph(t, ctx, pool, uuid.MustParse(aid), false)
+
+	// The runs API, mounted for real. This is the entry point a user hits.
+	e := echo.New()
+	(&endpoints.Server{Tenant: pool}).RegisterRuns(e.Group("/api/v1"))
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+
+	// The real outbox relay: LISTENs on outbox_new, drains the table, publishes
+	// each row to NATS. This is the link the other e2e tests skip.
+	relay := dnats.NewRelay(
+		dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20,
+	)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+
+	// The dispatcher: run.created -> worker.graph.execute.
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	// A live worker consuming the graph-executor consumer.
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	// --- the user's actual request ---
+	body, _ := json.Marshal(map[string]any{
+		"assistant_id": aid,
+		"input":        map[string]any{"count": 0},
+	})
+	resp, err := http.Post(apiSrv.URL+"/api/v1/threads/"+tid+"/runs",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(resp.Body)
+		t.Fatalf("create run: status %d: %s", resp.StatusCode, buf.String())
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("create response carried no run_id")
+	}
+	rid := uuid.MustParse(created.RunID)
+
+	// The event store must have recorded the creation BEFORE anything
+	// downstream can work. Asserting it separately means a failure downstream
+	// is attributable: if this passes and the wait below times out, the break
+	// is in the relay or the dispatcher, not in the write.
+	var nEvents, nOutbox int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='run.created'`, rid).Scan(&nEvents); err != nil {
+		t.Fatal(err)
+	}
+	if nEvents != 1 {
+		t.Fatalf("event store: want exactly 1 run.created event for the run, got %d", nEvents)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM outbox WHERE aggregate_id=$1 AND event_type='run.created'`, rid).Scan(&nOutbox); err != nil {
+		t.Fatal(err)
+	}
+	if nOutbox != 1 {
+		t.Fatalf("outbox: want exactly 1 mirrored run.created row, got %d", nOutbox)
+	}
+
+	// --- and now the whole chain, unaided ---
+	waitForRunStatus(t, ctx, pool, rid, "completed", 30*time.Second)
+
+	// The run actually executed rather than merely being marked done.
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+	assertNodeCount(t, ctx, pool, rid, "B", 1)
+
+	// The relay must have marked the row published — an outbox row that stays
+	// unpublished would be redelivered forever.
+	var published bool
+	if err := pool.QueryRow(ctx,
+		`SELECT published FROM outbox WHERE aggregate_id=$1 AND event_type='run.created'`, rid).Scan(&published); err != nil {
+		t.Fatal(err)
+	}
+	if !published {
+		t.Error("outbox row for run.created was never marked published")
+	}
+
+	// The full lifecycle is in the event log, which is what makes the run
+	// reconstructible: created (API) -> started (worker lease) -> completed.
+	for _, want := range []string{"run.created", "run.started", "run.completed"} {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type=$2`, rid, want).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n == 0 {
+			t.Errorf("event log is missing %q for the run", want)
+		}
+	}
+}


### PR DESCRIPTION
Five commits. The through-line: **the control plane did not compile, and once it did, a single user still could not run anything through the public API.** Both are fixed and covered by tests that use no SQL.

---

## 1. `fix(api)` — raw path params no longer reach Postgres as 500s

Five endpoints returned `500` with driver text (`SQLSTATE 22P02`). Now 422.

Not a validation fix in one case: `/assistants/{assistant_id}/graph` types its param as `anyOf[uuid, string "Graph ID"]`, so a non-UUID is **legal** — it selects by name. Validating it would have turned a supported request into a 422.

## 2. `feat(controlplane)` — the platform surface + worker claim

**The control plane did not compile before this.** `auth_gen.go`, `admin_gen.go`, `platform_gen.go` referenced 13 undefined methods.

Structural, not merely unimplemented:
- **The platform DB had no eventstore.** auth/admin are `db: platform` + `outbox: true`, so their writes go through `writeTx` on the platform pool — but `event_streams`/`events`/`outbox` existed only per-tenant. Added as platform migration `002`.
- **`/api/v1/api/admin/users`** — absolute paths mounted on the `/api/v1` group.
- **Codegen bug** — custom write endpoints kept `pgx`/`uuid` imports with no body; a compile error for the whole *file*, unfixable from a hand-written one.

Implemented: OAuth login/callback/logout/refresh (event-sourced, `bootstrap_lock` for atomic first-user election), all 8 admin endpoints (guard and write in the *same* statement, so two operators can't both fire `tenant.provisioning` at a live tenant), `/me` (answers from the **DB**, not the token), and worker claim (`FOR UPDATE SKIP LOCKED`, priority-ordered, epoch-fenced).

Metrics return **501 naming Mimir** rather than an empty 200 that is indistinguishable from "every tenant has zero activity".

## 3. `test(worker)` — the single-user event store path, proven

Both existing e2e tests **start by hand-publishing a `run.created` envelope**, bypassing the DB (their own comments say so). So the first link was never covered.

This starts at `POST /threads/{id}/runs` and proves: event store → outbox → `pg_notify` → relay → dispatcher → worker → `completed`. It asserts the write *before* waiting, so a downstream failure stays attributable.

## 4. `fix(worker)` — a graph is now installable and findable

**This is why nothing worked for a real user.** Two independent breaks:

- **No way to install a graph.** Nothing in the API wrote to `graphs` — both graph routes are GETs. `system-architecture.d2:76` routes `graph_def -> workers_ep.register` ("SDK registers graph definition"), but the request carried only graph **names**. A graph could only be installed with direct SQL.
- **A name-registered graph was invisible.** `postgres.d2:96-97` declares *both* bindings; only `graphs.assistant_id` was implemented. An SDK-registered graph has a NULL `assistant_id`, so every such run died with `404 "no graph for run"`.

Every prior e2e test hid this by seeding the graph directly into Postgres, `assistant_id` included — a column the real registration path never sets.

## 5. `feat(cron)` — crons actually fire

A cron was inert two ways: `next_run_at` was never set at creation, and nothing polled it.

Lives in the control plane next to the reaper so a cron-created run takes the **same** event-sourced path as an API-created one. Not pg_cron (superuser extension, per-tenant-DB, would hand-write the runs+events+outbox triple in SQL); not JetStream (no scheduled delivery). Ticker + `FOR UPDATE SKIP LOCKED`, so two control planes can't double-fire.

Missed windows skip automatically — the next firing is computed from `now()`, so no catch-up policy is needed.

---

## Tests

New tests that perform **no SQL at all** — every step is a call you could make with curl. That constraint is the point; it is exactly what the older e2e tests relaxed.

- full journey: register worker + graph definition → assistant → thread → run → completes → read run/state/history back
- human-in-the-loop: `interrupt_before` pauses, API reports `interrupted`, the gated node has **not** run, resume completes it
- failure: a poison graph surfaces as `error` with a recorded reason
- cron: created via API → run created → worker executes it → traceable via `metadata.cron_id`
- plus 39 platform-surface tests (bootstrap race, suspended user, logout CSRF, bearer-only refresh, every admin transition asserting both rows and real aggregate ids, SKIP LOCKED under concurrency)

Every fix verified to bite by reverting it.

## Known gaps — deliberate, flagged, not hidden

- **The admin auth gate is fail-OPEN when no `JWTSecret` is set.** The server warns loudly at startup. The right fix is refusing to start; I did not make that call unilaterally.
- `llm`/`tool` executors are config-driven stand-ins — no real model call.
- Nothing consumes `tenant.provisioning`, so tenants are never actually provisioned.
- A dead `CronScheduler` remains at `internal/application/service/cron_scheduler.go` (wired at `serve.go:917`); it only advances timestamps, creates nothing, and targets columns that don't exist. Should be deleted — left alone as it's outside the control plane.

## Spec

**No file under `spec/` was modified** — zero `spec/` paths in all five commits. The only spec-adjacent change is `controlplane/gen/endpoints.yaml` in this repo, marking 14 endpoints `custom: true` so they can have hand-written bodies.

Spec-vs-schema conflicts were resolved toward the schema and commented in code, not by editing the spec:
- retry-migration guards `'provisioning_failed'`, which the `tenants` CHECK cannot hold → used `'failed'`
- claim filters `runs.graph_id`, which run-create never populates → `COALESCE(runs.graph_id, assistants.graph_id)`

`[spec-skip]` impl-only throughout. Codegen verified idempotent.
