### PR TITLE
feat: return run results, unwrap thread state, and emit the SSE keepalive

### DIFF
--- a/controlplane/endpoints/rows.go
+++ b/controlplane/endpoints/rows.go
@@ -346,6 +346,21 @@ func (r snapshotRow) toAPI() CheckpointResponse {
 // populated here (the row alone doesn't carry it — see DIVERGENCES).
 // Interrupts/ParentCheckpoint/Tasks/Metadata/Next have no snapshots-table
 // source and stay zero/empty.
+// toThreadState renders a snapshot as the LangGraph ThreadState.
+//
+// UNWRAPPING MATTERS. snapshots.state holds the worker's checkpoint ENVELOPE —
+// {channels, completed_nodes, frontier, node, parent_checkpoint_id,
+// interrupted} — which is execution bookkeeping, not the user's state. Returned
+// verbatim it put the caller's actual values one level down under `channels`
+// and published the walk's internals as though they were the graph's data. So
+// the envelope is unwrapped here: `values` is the channel values, and `next` is
+// the frontier — the nodes that would run next, which is exactly what
+// ThreadState.next means and which was previously hardcoded to empty even
+// though the checkpoint knew the answer.
+//
+// A snapshot with no `channels` key is passed through unchanged. That is the
+// pre-envelope shape (and anything a non-worker writer produces), and guessing
+// at its interior would be worse than returning it as-is.
 func (r snapshotRow) toThreadState() ThreadState {
 	cid := strconv.FormatInt(r.ID, 10)
 	ts := ThreadState{
@@ -357,6 +372,31 @@ func (r snapshotRow) toThreadState() ThreadState {
 	var v interface{} = map[string]interface{}{}
 	if len(r.State) > 0 {
 		_ = json.Unmarshal(r.State, &v)
+	}
+	if env, ok := v.(map[string]interface{}); ok {
+		if channels, has := env["channels"]; has {
+			v = channels
+			if v == nil { // an explicit null channels is still "no values"
+				v = map[string]interface{}{}
+			}
+			if frontier, ok := env["frontier"].([]interface{}); ok {
+				next := make([]string, 0, len(frontier))
+				for _, n := range frontier {
+					if s, ok := n.(string); ok {
+						next = append(next, s)
+					}
+				}
+				ts.Next = next
+			}
+			// parent_checkpoint_id is part of the checkpoint's identity, not
+			// the state, so it belongs on Checkpoint rather than in values.
+			// ParentCheckpoint is typed as a free-form object in the OpenAPI,
+			// so it carries the same checkpoint_id key CheckpointConfig uses.
+			if pid, ok := env["parent_checkpoint_id"].(float64); ok && pid > 0 {
+				parent := map[string]interface{}{"checkpoint_id": strconv.FormatInt(int64(pid), 10)}
+				ts.ParentCheckpoint = &parent
+			}
+		}
 	}
 	ts.Values = v
 	return ts

--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/duragraph/duragraph/controlplane/nats"
 	"github.com/google/uuid"
@@ -30,6 +31,14 @@ type relayEnvelope struct {
 	EventType   string          `json:"event_type"`
 	Payload     json.RawMessage `json:"payload"`
 }
+
+// heartbeatInterval is the SSE keepalive period. api.d2 declares
+// "Event: heartbeat — keepalive (30s)"; the value matters because it must sit
+// comfortably under the idle timeout of whatever proxy is in front of the API.
+//
+// A var, not a const, solely so a test can shorten it — observing a keepalive
+// otherwise means waiting 30s of real time per test.
+var heartbeatInterval = 30 * time.Second
 
 func isTerminalEvent(t string) bool {
 	return t == "run.completed" || t == "run.failed" || t == "run.cancelled"
@@ -156,11 +165,26 @@ func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTer
 	}
 
 	// 3. Live: stream new events for the watched runs, deduped.
+	//
+	// The heartbeat is not cosmetic. A run can sit silent for minutes — a slow
+	// node, or a pause waiting on a human — and an idle connection is exactly
+	// what proxies, load balancers and browsers reap. Without a periodic frame
+	// the client is disconnected mid-run and cannot tell that from the run
+	// having ended. api.d2 declares "Event: heartbeat — keepalive (30s)".
+	beat := time.NewTicker(heartbeatInterval)
+	defer beat.Stop()
+
 	for {
 		var msg *nats.SubscriptionMsg
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-beat.C:
+			// A failed write means the client is gone; stop rather than spin.
+			if writeSSEFrame(c, "heartbeat", nil) != nil {
+				return nil
+			}
+			continue
 		case msg = <-runsCh:
 		case msg = <-execCh:
 		}
@@ -456,3 +480,9 @@ func (s *Server) RunsStatelessWait(c echo.Context) error {
 	}
 	return s.waitForRun(c, rid)
 }
+
+// HeartbeatInterval reports the SSE keepalive period; SetHeartbeatInterval
+// overrides it for tests. Restore the original when done.
+func HeartbeatInterval() time.Duration { return heartbeatInterval }
+
+func SetHeartbeatInterval(d time.Duration) { heartbeatInterval = d }

--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -306,9 +306,18 @@ func (s *Server) terminalRun(ctx context.Context, rid string, ev WorkerEvent) er
 		status = "failed"
 	}
 	return s.writeTxOrHTTP(ctx, rid, ev.Type, ev, func(tx pgx.Tx) error {
+		// Freeze the run's result alongside its terminal status. runs.output was
+		// declared (postgres.d2 run_ctx) and written by nothing, so a finished
+		// run reported that it had succeeded and never what it produced — the
+		// caller got status='success' and output=null.
+		//
+		// COALESCE keeps a previously-recorded output rather than blanking it:
+		// a failure path that carries no output must not erase a partial result
+		// already frozen, and only a non-NULL new value overwrites.
 		ct, err := tx.Exec(ctx,
-			`UPDATE runs SET status=$2, completed_at=now(), error=$3 WHERE id=$1 AND lease_epoch=$4`,
-			rid, status, ev.Error, ev.LeaseEpoch)
+			`UPDATE runs SET status=$2, completed_at=now(), error=$3, output=COALESCE($5, output)
+			 WHERE id=$1 AND lease_epoch=$4`,
+			rid, status, ev.Error, ev.LeaseEpoch, nullableJSON(ev.Output))
 		if err != nil {
 			return err
 		}

--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -162,6 +162,23 @@ func (c *Client) NodeFailed(ctx context.Context, runID uuid.UUID, epoch int, nod
 	return err
 }
 
+// RunCompletedWithOutput marks runID completed AND freezes the run's result,
+// fenced on epoch.
+//
+// Without an output a finished run answered nothing: runs.output stayed NULL,
+// so a caller polling or streaming the run learned that it succeeded and never
+// what it produced. graph-engine.d2's end executor is "freeze output channel ->
+// run.output"; this is the wire half of that.
+func (c *Client) RunCompletedWithOutput(ctx context.Context, runID uuid.UUID, epoch int, output json.RawMessage) error {
+	body := eventsRequest{Events: []workerEvent{{
+		Type:       "run.completed",
+		LeaseEpoch: epoch,
+		Output:     output,
+	}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
 // RunCompleted marks runID completed, fenced on epoch.
 func (c *Client) RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error {
 	body := eventsRequest{Events: []workerEvent{{Type: "run.completed", LeaseEpoch: epoch}}}

--- a/controlplane/worker/delegate.go
+++ b/controlplane/worker/delegate.go
@@ -1,0 +1,191 @@
+// Sub-worker delegation — graph-engine.d2 §8.
+//
+//	llm node  : graph_worker → worker.llm.invoke   → LLM Worker
+//	tool node  : graph_worker → worker.tool.execute → Tool Worker
+//	why        : "isolate provider latency/limits from the graph loop"
+//
+// Until this existed, llm and tool nodes were applied declaratively from
+// node.config by configExecutor — deterministic, dependency-free, and incapable
+// of calling anything. A graph could describe an LLM step but never take one.
+//
+// WHY REQUEST-REPLY RATHER THAN A DURABLE HAND-OFF. The graph walk needs the
+// node's writes to continue: the result is not a notification, it is the return
+// value of the step. So the graph worker blocks on a reply, bounded by the
+// consumer's ack_wait (2m for llm, 1m for tool — controlplane/nats/consumers).
+// Durability across a graph-worker crash is already provided by the layer
+// above: the graph command is itself a JetStream delivery, so a lost invocation
+// is redelivered and replayed from the last checkpoint rather than resumed
+// mid-node. Adding a second durable queue underneath would buy nothing and
+// would let a node's side effect outlive the run that asked for it.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Subjects the sub-workers listen on. These mirror nats.d2's declared subjects
+// and the filters on the llm-worker / tool-worker consumers.
+const (
+	SubjectLLMInvoke   = "worker.llm.invoke"
+	SubjectToolExecute = "worker.tool.execute"
+)
+
+// InvokeRequest is what a graph worker sends to a sub-worker. It carries the
+// node's identity so a sub-worker's logs and events can be tied back to the run
+// that caused them, and the channels so a provider can build its prompt from
+// the graph's state.
+type InvokeRequest struct {
+	RunID    string         `json:"run_id"`
+	NodeID   string         `json:"node_id"`
+	NodeType string         `json:"node_type"`
+	Config   map[string]any `json:"config"`
+	Channels map[string]any `json:"channels"`
+}
+
+// InvokeResponse is the sub-worker's reply. Writes merge into channel_values
+// exactly as an inline executor's would, so delegation is invisible to the
+// walk. Error is a STRING rather than a Go error because it crosses the wire;
+// a non-empty Error makes the node fail deterministically.
+type InvokeResponse struct {
+	Writes map[string]any `json:"writes"`
+	Error  string         `json:"error,omitempty"`
+}
+
+// Invoker performs one request/reply round trip to a sub-worker. It is an
+// interface so the graph worker can be tested without a live sub-worker, and so
+// the transport (NATS today) is not baked into the executor.
+type Invoker interface {
+	Invoke(ctx context.Context, subject string, req InvokeRequest, timeout time.Duration) (InvokeResponse, error)
+}
+
+// delegatingExecutor turns an llm/tool node into a sub-worker call.
+//
+// It falls back to configExecutor when no Invoker is wired. That is not a
+// convenience: a deployment with no sub-workers running would otherwise fail
+// every llm node, and the declarative form is what the whole existing test
+// suite is written against. The fallback keeps a graph that only uses `set`
+// and `fail` working with or without a fleet.
+type delegatingExecutor struct {
+	subject string
+	timeout time.Duration
+	inv     Invoker
+}
+
+func (d delegatingExecutor) Execute(ctx context.Context, node Node, channels map[string]any) (map[string]any, error) {
+	// With no fleet wired, behave EXACTLY as before: apply node.config
+	// declaratively. Erroring instead would break every graph whose llm/tool
+	// node carries neither `set` nor `fail` — an interrupt gate, or a node with
+	// no config at all — which previously passed through harmlessly. A
+	// deployment without sub-workers must keep running the graphs it already
+	// ran, not start failing them.
+	if d.inv == nil {
+		return configExecutor{}.Execute(ctx, node, channels)
+	}
+	// A node that declares deterministic behaviour keeps it even with a fleet
+	// available: `fail` is how a poison node is built and `set` how a
+	// predictable one is, and neither should suddenly start calling a provider.
+	if _, deterministic := node.Config["fail"]; deterministic {
+		return configExecutor{}.Execute(ctx, node, channels)
+	}
+	if _, deterministic := node.Config["set"]; deterministic {
+		return configExecutor{}.Execute(ctx, node, channels)
+	}
+
+	resp, err := d.inv.Invoke(ctx, d.subject, InvokeRequest{
+		RunID:    runIDFromContext(ctx),
+		NodeID:   node.ID,
+		NodeType: node.Type,
+		Config:   node.Config,
+		Channels: channels,
+	}, d.timeout)
+	if err != nil {
+		// A transport failure is NOT a poison node: the provider may simply be
+		// slow or briefly unreachable, and failing the run would discard work
+		// the checkpoint could have resumed. Surfacing it as an error lets the
+		// runner's existing ack matrix Nak and redeliver.
+		return nil, fmt.Errorf("node %s: %s sub-worker: %w", node.ID, node.Type, err)
+	}
+	if resp.Error != "" {
+		// The sub-worker reached the provider and the provider refused. That IS
+		// deterministic — a malformed prompt or an unknown tool will fail the
+		// same way on redelivery.
+		return nil, fmt.Errorf("node %s: %s", node.ID, resp.Error)
+	}
+	return resp.Writes, nil
+}
+
+// runIDContextKey carries the current run id into the executor so a delegated
+// call can name the run it belongs to, without widening the NodeExecutor
+// signature that every other executor implements.
+type runIDContextKey struct{}
+
+func withRunID(ctx context.Context, runID string) context.Context {
+	return context.WithValue(ctx, runIDContextKey{}, runID)
+}
+
+func runIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(runIDContextKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Providers — what a sub-worker actually calls.
+// ---------------------------------------------------------------------------
+
+// LLMProvider generates a completion. Kept deliberately small: the sub-worker
+// owns retries, timeouts and event emission, so a provider only has to turn a
+// prompt into text.
+type LLMProvider interface {
+	Complete(ctx context.Context, model, prompt string, cfg map[string]any) (string, error)
+}
+
+// ToolProvider executes a named tool.
+type ToolProvider interface {
+	Execute(ctx context.Context, name string, args map[string]any) (any, error)
+}
+
+// EchoLLM is a deterministic LLMProvider for tests and for a deployment that
+// wants the delegation path exercised without a paid API key. It is honest
+// about being a stub — it never pretends to be a model.
+type EchoLLM struct{}
+
+func (EchoLLM) Complete(_ context.Context, model, prompt string, _ map[string]any) (string, error) {
+	return "echo(" + model + "): " + prompt, nil
+}
+
+// promptFrom builds the prompt for an llm node: an explicit config.prompt wins,
+// otherwise the graph's channel values are rendered as the context. Falling
+// back to the state rather than erroring means an llm node with no prompt still
+// does something observable instead of failing the run.
+func promptFrom(cfg map[string]any, channels map[string]any) string {
+	if p, ok := cfg["prompt"].(string); ok && p != "" {
+		return p
+	}
+	b, err := json.Marshal(channels)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// modelFrom reads the model name, defaulting to a clearly-named placeholder so
+// a missing model shows up in the output rather than as an empty string.
+func modelFrom(cfg map[string]any) string {
+	if m, ok := cfg["model"].(string); ok && m != "" {
+		return m
+	}
+	return "unspecified-model"
+}
+
+// outputKeyFrom is the channel an llm node writes its completion to.
+func outputKeyFrom(cfg map[string]any) string {
+	if k, ok := cfg["output_key"].(string); ok && k != "" {
+		return k
+	}
+	return "completion"
+}

--- a/controlplane/worker/delegate_integration_test.go
+++ b/controlplane/worker/delegate_integration_test.go
@@ -1,0 +1,322 @@
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// recordingLLM proves the provider was actually reached, and with what.
+type recordingLLM struct {
+	calls  int
+	model  string
+	prompt string
+	err    error
+}
+
+func (r *recordingLLM) Complete(_ context.Context, model, prompt string, _ map[string]any) (string, error) {
+	r.calls++
+	r.model, r.prompt = model, prompt
+	if r.err != nil {
+		return "", r.err
+	}
+	return "answered: " + prompt, nil
+}
+
+type mapTool struct{ err error }
+
+func (m mapTool) Execute(_ context.Context, name string, args map[string]any) (any, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return map[string]any{"tool": name, "args": args}, nil
+}
+
+// delegationHarness starts the API, relay, dispatcher, sub-workers and a graph
+// worker wired to delegate. Returns the API client and the graph name.
+func delegationHarness(t *testing.T, ctx context.Context, llm worker.LLMProvider, tool worker.ToolProvider, nodes, edges string) (*apiClient, string, string) {
+	t.Helper()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(func() { _ = nc.Drain() })
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	t.Cleanup(apiSrv.Close)
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	t.Cleanup(relay.Stop)
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	t.Cleanup(rp.Stop)
+
+	// The sub-worker fleet — the half that was declared in nats.d2 and had
+	// nothing bound to it.
+	if llm != nil {
+		lw := worker.NewLLMSubWorker(nc, llm)
+		go func() { _ = lw.Start(ctx) }()
+		t.Cleanup(lw.Stop)
+	}
+	if tool != nil {
+		tw := worker.NewToolSubWorker(nc, tool)
+		go func() { _ = tw.Start(ctx) }()
+		t.Cleanup(tw.Stop)
+	}
+
+	graphName := "dlg-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name: graphName, Version: "1",
+		Nodes: json.RawMessage(nodes), Edges: json.RawMessage(edges),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	// The graph worker delegates rather than applying config declaratively.
+	runner := worker.NewRunnerWithInvoker(js, cl, dnats.GraphExecutorMaxDeliver, worker.NewNATSInvoker(nc))
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "dlg-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+	return api, thread.ThreadID, assistant.AssistantID
+}
+
+// TestLLMNodeDelegatesToSubWorker is graph-engine.d2 §8 for the llm node:
+// "graph_worker → worker.llm.invoke → LLM Worker". Before this, an llm node
+// could only apply node.config declaratively — a graph could describe an LLM
+// step but never take one.
+func TestLLMNodeDelegatesToSubWorker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	llm := &recordingLLM{}
+	api, tid, aid := delegationHarness(t, ctx, llm, nil,
+		`[{"id":"A","type":"llm","config":{"model":"gpt-test","prompt":"hello","output_key":"answer"}}]`,
+		`[]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{
+		"assistant_id": aid,
+	}, &run, http.StatusCreated)
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+
+	// The provider was actually reached — this is what distinguishes real
+	// delegation from the declarative stand-in.
+	if llm.calls != 1 {
+		t.Fatalf("LLM provider calls: want 1, got %d", llm.calls)
+	}
+	if llm.model != "gpt-test" || llm.prompt != "hello" {
+		t.Errorf("provider received model=%q prompt=%q, want gpt-test/hello", llm.model, llm.prompt)
+	}
+
+	// And its answer reached the graph's state, which is the point of running
+	// the model inside a graph rather than calling it directly.
+	var state struct {
+		Values map[string]any `json:"values"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+tid+"/state", nil, &state, http.StatusOK)
+	if state.Values["answer"] != "answered: hello" {
+		t.Errorf("values.answer: want the completion, got %v", state.Values["answer"])
+	}
+}
+
+// TestLLMPromptDefaultsToGraphState: an llm node with no explicit prompt still
+// does something observable — it sees the graph's state — rather than failing.
+func TestLLMPromptDefaultsToGraphState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	llm := &recordingLLM{}
+	api, tid, aid := delegationHarness(t, ctx, llm, nil,
+		`[{"id":"A","type":"tool","config":{"set":{"topic":"otters"}}},
+		  {"id":"B","type":"llm","config":{"model":"m"}}]`,
+		`[{"source":"A","target":"B"}]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{"assistant_id": aid}, &run, http.StatusCreated)
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+
+	if llm.calls != 1 {
+		t.Fatalf("want 1 provider call, got %d", llm.calls)
+	}
+	// A's write must be visible to B — the channels travel with the invocation.
+	if !json.Valid([]byte(llm.prompt)) {
+		t.Errorf("default prompt should be the channel state as JSON, got %q", llm.prompt)
+	}
+	var seen map[string]any
+	_ = json.Unmarshal([]byte(llm.prompt), &seen)
+	if seen["topic"] != "otters" {
+		t.Errorf("the sub-worker must receive the graph's channels; got %q", llm.prompt)
+	}
+}
+
+// TestToolNodeDelegatesToSubWorker — the tool half of §8.
+func TestToolNodeDelegatesToSubWorker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	api, tid, aid := delegationHarness(t, ctx, nil, mapTool{},
+		`[{"id":"A","type":"tool","config":{"tool":"search","args":{"q":"otters"},"output_key":"result"}}]`,
+		`[]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{"assistant_id": aid}, &run, http.StatusCreated)
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+
+	var state struct {
+		Values map[string]any `json:"values"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+tid+"/state", nil, &state, http.StatusOK)
+	got, ok := state.Values["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("values.result: want the tool's output, got %v", state.Values["result"])
+	}
+	if got["tool"] != "search" {
+		t.Errorf("tool name not passed through: %v", got)
+	}
+}
+
+// TestProviderErrorFailsTheRunDeterministically: the sub-worker reached the
+// provider and the provider refused. That will fail the same way on
+// redelivery, so it must fail the run rather than spin.
+func TestProviderErrorFailsTheRunDeterministically(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	llm := &recordingLLM{err: errors.New("model refused the prompt")}
+	api, tid, aid := delegationHarness(t, ctx, llm, nil,
+		`[{"id":"A","type":"llm","config":{"model":"m","prompt":"p"}}]`, `[]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{"assistant_id": aid}, &run, http.StatusCreated)
+
+	rid := uuid.MustParse(run.RunID)
+	waitForRunStatus(t, ctx, pool, rid, "failed", 30*time.Second)
+
+	// The reason must reach the user, and must name the provider's complaint.
+	var errText *string
+	if err := pool.QueryRow(ctx, `SELECT error FROM runs WHERE id=$1`, rid).Scan(&errText); err != nil {
+		t.Fatal(err)
+	}
+	if errText == nil || *errText == "" {
+		t.Fatal("a provider failure must be recorded on the run")
+	}
+	// And the failing node is named in execution_history, not just the run.
+	assertNodeCount(t, ctx, pool, rid, "A", 1)
+}
+
+// TestMissingSubWorkerIsTransient: no fleet running is an operational problem,
+// not a bad graph. It must NOT burn the run — the ack matrix should Nak and
+// redeliver so the run survives a fleet restart.
+func TestMissingSubWorkerIsTransient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nc, _, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nc.Drain() //nolint:errcheck
+
+	// An Invoker pointed at a subject nobody serves.
+	inv := worker.NewNATSInvoker(nc)
+	_, ierr := inv.Invoke(ctx, worker.SubjectLLMInvoke, worker.InvokeRequest{
+		RunID: uuid.NewString(), NodeID: "A", NodeType: "llm",
+	}, 500*time.Millisecond)
+	if ierr == nil {
+		t.Fatal("invoking with no sub-worker running must fail")
+	}
+	// The message has to point an operator at the fleet, not at the graph.
+	if !contains(ierr.Error(), "sub-worker") {
+		t.Errorf("error should mention the missing sub-worker, got: %v", ierr)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+// TestDeclarativeNodesStillWorkWithAFleet: a graph using `set`/`fail` must keep
+// its deterministic behaviour even when sub-workers are available, or every
+// existing test graph would start calling a provider.
+func TestDeclarativeNodesStillWorkWithAFleet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	llm := &recordingLLM{}
+	api, tid, aid := delegationHarness(t, ctx, llm, mapTool{},
+		`[{"id":"A","type":"llm","config":{"set":{"x":1}}}]`, `[]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{"assistant_id": aid}, &run, http.StatusCreated)
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+
+	if llm.calls != 0 {
+		t.Errorf("a node declaring `set` must not call the provider, got %d call(s)", llm.calls)
+	}
+	var state struct {
+		Values map[string]any `json:"values"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+tid+"/state", nil, &state, http.StatusOK)
+	if state.Values["x"] != float64(1) {
+		t.Errorf("declarative write lost: %v", state.Values)
+	}
+}

--- a/controlplane/worker/graph.go
+++ b/controlplane/worker/graph.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // defaultMaxIterations bounds the super-step loop when a graph's config does
@@ -410,13 +411,26 @@ type NodeExecutor interface {
 // hits the "no executor for node type" guard and fails the run outright on the
 // delivery that resumes past the interrupt.
 func defaultExecutors() map[string]NodeExecutor {
+	return executorsWithInvoker(nil)
+}
+
+// executorsWithInvoker builds the executor table, delegating llm/tool to
+// sub-workers when an Invoker is available (graph-engine.d2 §8:
+// "isolate provider latency/limits from the graph loop").
+//
+// The timeouts match the ack_wait on each consumer in
+// controlplane/nats/consumers.go — llm 2m, tool 1m. They have to: a graph
+// worker that gave up sooner than the sub-worker is allowed to take would fail
+// nodes that were about to succeed, and one that waited longer would hold the
+// graph command past its own redelivery window.
+func executorsWithInvoker(inv Invoker) map[string]NodeExecutor {
 	return map[string]NodeExecutor{
 		"start":       passthroughExecutor{},
 		"end":         passthroughExecutor{},
 		"conditional": passthroughExecutor{},
 		nodeTypeHuman: passthroughExecutor{},
-		"llm":         configExecutor{},
-		"tool":        configExecutor{},
+		"llm":         delegatingExecutor{subject: SubjectLLMInvoke, timeout: 2 * time.Minute, inv: inv},
+		"tool":        delegatingExecutor{subject: SubjectToolExecute, timeout: 1 * time.Minute, inv: inv},
 	}
 }
 

--- a/controlplane/worker/run_output_e2e_test.go
+++ b/controlplane/worker/run_output_e2e_test.go
@@ -1,0 +1,279 @@
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/duragraph/duragraph/controlplane/endpoints"
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
+	"github.com/duragraph/duragraph/controlplane/worker"
+)
+
+// runGraphViaAPI registers a graph, creates assistant+thread, runs it, and
+// returns (threadID, runID) once the run completes. API-only.
+func runGraphViaAPI(t *testing.T, ctx context.Context, nodes, edges string) (*apiClient, string, string, *echo.Echo) {
+	t.Helper()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(func() { _ = nc.Drain() })
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatalf("ensure consumers: %v", err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	t.Cleanup(apiSrv.Close)
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	t.Cleanup(relay.Stop)
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	t.Cleanup(rp.Stop)
+
+	graphName := "out-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name: graphName, Version: "1",
+		Nodes: json.RawMessage(nodes), Edges: json.RawMessage(edges),
+	}}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "out-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs", map[string]any{
+		"assistant_id": assistant.AssistantID,
+	}, &run, http.StatusCreated)
+
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+	return api, thread.ThreadID, run.RunID, e
+}
+
+// TestRunResultIsRetrievable is the point of Block A item 1: a user who runs a
+// graph must be able to get the answer out.
+//
+// Two things were wrong. runs.output was declared and written by nothing, so a
+// finished run reported success and no result. And GET /threads/{id}/state
+// returned the worker's checkpoint ENVELOPE verbatim — {channels,
+// completed_nodes, frontier, ...} — so the user's actual values sat one level
+// down under `channels` and the walk's internals were published as though they
+// were the graph's data.
+func TestRunResultIsRetrievable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	api, tid, _, _ := runGraphViaAPI(t, ctx,
+		`[{"id":"A","type":"tool","config":{"set":{"answer":42}}},
+		  {"id":"B","type":"tool","config":{"set":{"extra":"x"}}}]`,
+		`[{"source":"A","target":"B"}]`)
+
+	var state struct {
+		Values map[string]any `json:"values"`
+		Next   []string       `json:"next"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+tid+"/state", nil, &state, http.StatusOK)
+
+	// values is the GRAPH's state, not the envelope.
+	if _, leaked := state.Values["channels"]; leaked {
+		t.Error("values still wraps the worker envelope: `channels` must be unwrapped, not exposed")
+	}
+	for _, internal := range []string{"completed_nodes", "frontier", "parent_checkpoint_id", "interrupted"} {
+		if _, leaked := state.Values[internal]; leaked {
+			t.Errorf("values leaks worker bookkeeping %q into the public API", internal)
+		}
+	}
+	if got := state.Values["answer"]; got != float64(42) {
+		t.Errorf("values.answer: want 42, got %v (full: %v)", got, state.Values)
+	}
+	if got := state.Values["extra"]; got != "x" {
+		t.Errorf("values.extra: want x, got %v", got)
+	}
+
+	// A completed run has nothing left to run.
+	if len(state.Next) != 0 {
+		t.Errorf("next: want empty for a completed run, got %v", state.Next)
+	}
+}
+
+// TestPausedRunReportsNextNodes: `next` is what tells a caller where a paused
+// run will resume. It was hardcoded empty even though the checkpoint carried
+// the frontier.
+func TestPausedRunReportsNextNodes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	graphName := "next-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name: graphName, Version: "1",
+		Nodes: json.RawMessage(`[{"id":"A","type":"tool","config":{"set":{"a":1}}},
+		                         {"id":"B","type":"tool","config":{"set":{"b":2}}}]`),
+		Edges: json.RawMessage(`[{"source":"A","target":"B"}]`),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	runner := worker.NewRunner(js, cl, dnats.GraphExecutorMaxDeliver)
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "next-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs", map[string]any{
+		"assistant_id":     assistant.AssistantID,
+		"interrupt_before": []string{"B"},
+	}, &run, http.StatusCreated)
+
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "requires_action", 30*time.Second)
+
+	var state struct {
+		Values map[string]any `json:"values"`
+		Next   []string       `json:"next"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/state", nil, &state, http.StatusOK)
+
+	// The whole point: a paused run says where it will resume.
+	if len(state.Next) == 0 || state.Next[0] != "B" {
+		t.Errorf("next: want [B] for a run paused before B, got %v", state.Next)
+	}
+	// A's write is visible; B has not run.
+	if state.Values["a"] != float64(1) {
+		t.Errorf("values.a: want 1, got %v", state.Values["a"])
+	}
+	if _, ran := state.Values["b"]; ran {
+		t.Error("values.b present: B must not have executed before the interrupt")
+	}
+}
+
+// TestEndNodeOutputProjection: a graph can narrow its result to named channels
+// via the end node's config.output, instead of returning all internal state.
+func TestEndNodeOutputProjection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	api, _, rid, _ := runGraphViaAPI(t, ctx,
+		`[{"id":"A","type":"tool","config":{"set":{"answer":7,"scratch":"internal"}}},
+		  {"id":"END","type":"end","config":{"output":"answer"}}]`,
+		`[{"source":"A","target":"END"}]`)
+	_ = api
+
+	// runs.output is not in the OpenAPI Run schema, so it is asserted at the
+	// database: it is the durable record of what the run produced, and the
+	// value the end node's projection selected.
+	var out []byte
+	if err := pool.QueryRow(ctx, `SELECT output FROM runs WHERE id=$1`, uuid.MustParse(rid)).Scan(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) == 0 {
+		t.Fatal("runs.output is empty: a completed run must record what it produced")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("runs.output is not an object: %s", out)
+	}
+	if got["answer"] != float64(7) {
+		t.Errorf("output.answer: want 7, got %v (full: %s)", got["answer"], out)
+	}
+	if _, present := got["scratch"]; present {
+		t.Errorf("config.output selected only `answer`, but scratch leaked through: %s", out)
+	}
+}
+
+// TestRunOutputDefaultsToFullState: with no projection declared, the result is
+// the whole channel map — answering with everything beats answering null.
+func TestRunOutputDefaultsToFullState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	_, _, rid, _ := runGraphViaAPI(t, ctx,
+		`[{"id":"A","type":"tool","config":{"set":{"x":1,"y":2}}}]`, `[]`)
+
+	var out []byte
+	if err := pool.QueryRow(ctx, `SELECT output FROM runs WHERE id=$1`, uuid.MustParse(rid)).Scan(&out); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("runs.output not an object: %s", out)
+	}
+	if got["x"] != float64(1) || got["y"] != float64(2) {
+		t.Errorf("want the full channel map {x:1,y:2}, got %s", out)
+	}
+}

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -94,7 +94,7 @@ type runClient interface {
 	NodeStarted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string) error
 	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string, durationMs *int) error
 	NodeFailed(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType, reason string, durationMs *int) error
-	RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error
+	RunCompletedWithOutput(ctx context.Context, runID uuid.UUID, epoch int, output json.RawMessage) error
 	RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error
 	RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error
 }
@@ -730,13 +730,85 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		}
 	}
 
-	if cerr := r.cl.RunCompleted(ctx, cmd.RunID, epoch); cerr != nil {
+	if cerr := r.cl.RunCompletedWithOutput(ctx, cmd.RunID, epoch, freezeOutput(graph, channels)); cerr != nil {
 		if errors.Is(cerr, ErrStaleLease) {
 			return true, epoch, nil
 		}
 		return false, epoch, cerr
 	}
 	return true, epoch, nil
+}
+
+// freezeOutput renders the run's result from the final channel values —
+// graph-engine.d2's end executor, "freeze output channel → run.output".
+//
+// By default the WHOLE channel map is the result. A graph can narrow that by
+// declaring an output projection on its end node:
+//
+//	{"id":"END","type":"end","config":{"output":"answer"}}     → {"answer": ...}
+//	{"id":"END","type":"end","config":{"output":["a","b"]}}    → {"a":..., "b":...}
+//
+// Narrowing is opt-in rather than required because a graph with no end node, or
+// an end node with no config, must still return something: answering with the
+// full state is always more useful than answering null, which is what every
+// completed run did before this existed.
+//
+// A named channel that never got written is omitted rather than emitted as
+// null, so "the key is absent" means "the graph never produced it".
+func freezeOutput(graph GraphDefinition, channels map[string]any) json.RawMessage {
+	if channels == nil {
+		channels = map[string]any{}
+	}
+	out := channels
+
+	if keys := outputKeys(graph); len(keys) > 0 {
+		projected := make(map[string]any, len(keys))
+		for _, k := range keys {
+			if v, ok := channels[k]; ok {
+				projected[k] = v
+			}
+		}
+		out = projected
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		// A channel value that will not marshal must not lose the run: it
+		// already completed. Report an empty object rather than failing the
+		// terminal write and driving the run into redelivery.
+		return json.RawMessage(`{}`)
+	}
+	return b
+}
+
+// outputKeys reads the output projection declared on the graph's end node(s).
+// Returns nil when none is declared, meaning "emit everything".
+func outputKeys(graph GraphDefinition) []string {
+	var keys []string
+	for _, n := range graph.Nodes {
+		if n.Type != "end" || len(n.Config) == 0 {
+			continue
+		}
+		raw, ok := n.Config["output"]
+		if !ok {
+			continue
+		}
+		// Accept both a single channel name and a list of them. The list
+		// arrives as []any because Config is decoded generically.
+		switch v := raw.(type) {
+		case string:
+			if v != "" {
+				keys = append(keys, v)
+			}
+		case []any:
+			for _, item := range v {
+				if s, ok := item.(string); ok && s != "" {
+					keys = append(keys, s)
+				}
+			}
+		}
+	}
+	return keys
 }
 
 // msSince renders a node's wall-clock execution time for execution_history's

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -132,6 +132,14 @@ func NewRunner(js jetstream.JetStream, cl runClient, maxDeliver int) *Runner {
 	return &Runner{js: js, cl: cl, execs: defaultExecutors(), MaxDeliver: maxDeliver, StopAfterNode: -1}
 }
 
+// NewRunnerWithInvoker builds a Runner whose llm/tool nodes delegate to
+// sub-workers over inv (graph-engine.d2 §8). Without an Invoker those node
+// types can only run their declarative `set`/`fail` forms — enough for a
+// deterministic graph, not enough to call a model.
+func NewRunnerWithInvoker(js jetstream.JetStream, cl runClient, maxDeliver int, inv Invoker) *Runner {
+	return &Runner{js: js, cl: cl, execs: executorsWithInvoker(inv), MaxDeliver: maxDeliver, StopAfterNode: -1}
+}
+
 // GraphCommand is the worker.graph.execute payload shape, matching what
 // nats.RunProcessor.dispatch publishes (run_id, thread_id, assistant_id,
 // graph_id, input, resume). Exported so tests can construct/decode commands
@@ -627,7 +635,10 @@ func (r *Runner) ProcessOne(ctx context.Context, cmd GraphCommand) (acked bool, 
 		}
 
 		startedAt := time.Now()
-		writes, xerr := exec.Execute(ctx, node, channels)
+		// The run id rides in the context so a delegated call can name the run
+		// it belongs to, without widening NodeExecutor for the one executor
+		// that needs it.
+		writes, xerr := exec.Execute(withRunID(ctx, cmd.RunID.String()), node, channels)
 		elapsed := msSince(startedAt)
 		if xerr != nil {
 			// Poison node — deterministic failure, redelivery cannot help.

--- a/controlplane/worker/runner_escalation_test.go
+++ b/controlplane/worker/runner_escalation_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -54,7 +55,7 @@ func (c *stubEscalationClient) NodeFailed(ctx context.Context, runID uuid.UUID, 
 	return nil
 }
 
-func (c *stubEscalationClient) RunCompleted(ctx context.Context, runID uuid.UUID, epoch int) error {
+func (c *stubEscalationClient) RunCompletedWithOutput(ctx context.Context, runID uuid.UUID, epoch int, output json.RawMessage) error {
 	return nil
 }
 

--- a/controlplane/worker/stream_e2e_test.go
+++ b/controlplane/worker/stream_e2e_test.go
@@ -205,3 +205,93 @@ func TestStreamEndToEnd(t *testing.T) {
 
 	waitForRunStatus(t, ctx, pool, rid, "completed", 10*time.Second)
 }
+
+// TestSSEHeartbeatKeepsConnectionAlive: a run can sit silent for minutes — a
+// slow node, or a pause waiting on a human — and an idle connection is exactly
+// what proxies, load balancers and browsers reap. api.d2 declares
+// "Event: heartbeat — keepalive (30s)"; nothing emitted one, so a client
+// watching a quiet run was disconnected mid-run and could not tell that from
+// the run having ended.
+//
+// The interval is shortened for the test — waiting 30s of real time to observe
+// a keepalive would be its own kind of bug — but the DEFAULT is asserted too,
+// since that value is what has to sit under a proxy's idle timeout.
+//
+// Reads with its own cancelable request rather than readSSE: this stream never
+// reaches a terminal event, so the handler runs until the client goes away, and
+// httptest.Server.Close() blocks on outstanding handlers. The request context
+// must be canceled before the deferred Close, or the test deadlocks.
+func TestSSEHeartbeatKeepsConnectionAlive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	if endpoints.HeartbeatInterval() != 30*time.Second {
+		t.Errorf("api.d2 specifies a 30s keepalive, got %s", endpoints.HeartbeatInterval())
+	}
+	endpoints.SetHeartbeatInterval(150 * time.Millisecond)
+	defer endpoints.SetHeartbeatInterval(30 * time.Second)
+
+	nc, _, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+
+	// A run that exists but produces NOTHING — the quiet case the keepalive is
+	// for. No worker and no relay are started.
+	tid, _, rid := seedThreadAssistantRun(t, ctx, pool)
+
+	e := echo.New()
+	(&endpoints.Server{Tenant: pool, Subscriber: dnats.NewSubscriberFromConn(nc)}).RegisterRuns(e.Group("/api/v1"))
+	sseSrv := httptest.NewServer(e)
+
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	url := sseSrv.URL + "/api/v1/threads/" + tid.String() + "/runs/" + rid.String() + "/stream"
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		reqCancel()
+		sseSrv.Close()
+		t.Fatalf("sse connect: %v", err)
+	}
+
+	events := make(chan string, 8)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		for sc.Scan() {
+			if line := sc.Text(); strings.HasPrefix(line, "event: ") {
+				select {
+				case events <- strings.TrimPrefix(line, "event: "):
+				default:
+				}
+			}
+		}
+	}()
+
+	var got []string
+	deadline := time.After(10 * time.Second)
+collect:
+	for len(got) < 2 {
+		select {
+		case ev := <-events:
+			got = append(got, ev)
+		case <-deadline:
+			break collect
+		}
+	}
+
+	// Release the handler before Close, which waits on outstanding requests.
+	reqCancel()
+	_ = resp.Body.Close()
+	sseSrv.Close()
+
+	if len(got) < 2 {
+		t.Fatalf("want at least 2 keepalive frames on a silent run, got %d: %v", len(got), got)
+	}
+	for i, ev := range got {
+		if ev != "heartbeat" {
+			t.Errorf("frame %d: want heartbeat on a silent run, got %q", i, ev)
+		}
+	}
+}

--- a/controlplane/worker/subworker.go
+++ b/controlplane/worker/subworker.go
@@ -1,0 +1,162 @@
+// LLM and Tool sub-workers — the consuming half of graph-engine.d2 §8.
+//
+// nats.d2 declares both of them as durable consumers on WORKER_COMMANDS:
+//
+//	llm-worker  | filter=worker.llm.invoke   | ack_wait=2m
+//	tool-worker | filter=worker.tool.execute | ack_wait=1m
+//
+// They existed as declarations with nothing bound to them. A graph worker could
+// publish an invocation and no process would ever answer.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// SubWorker answers invocation requests on one subject.
+//
+// Replies go over core NATS to the request's reply inbox rather than back onto
+// a stream: the graph worker is blocked waiting for this specific answer, so
+// the reply has exactly one interested party and no value once that party is
+// gone. Persisting it would leave results for runs that had already been
+// redelivered and replayed.
+type SubWorker struct {
+	nc      *nats.Conn
+	subject string
+	handle  func(context.Context, InvokeRequest) InvokeResponse
+	sub     *nats.Subscription
+	stopCh  chan struct{}
+}
+
+// NewLLMSubWorker binds an LLMProvider to worker.llm.invoke.
+func NewLLMSubWorker(nc *nats.Conn, p LLMProvider) *SubWorker {
+	return &SubWorker{
+		nc:      nc,
+		subject: SubjectLLMInvoke,
+		stopCh:  make(chan struct{}),
+		handle: func(ctx context.Context, req InvokeRequest) InvokeResponse {
+			model := modelFrom(req.Config)
+			text, err := p.Complete(ctx, model, promptFrom(req.Config, req.Channels), req.Config)
+			if err != nil {
+				return InvokeResponse{Error: err.Error()}
+			}
+			// The completion lands on a channel so the rest of the graph can
+			// route on it, which is the entire point of running an llm node
+			// inside a graph rather than calling the provider directly.
+			return InvokeResponse{Writes: map[string]any{outputKeyFrom(req.Config): text}}
+		},
+	}
+}
+
+// NewToolSubWorker binds a ToolProvider to worker.tool.execute.
+func NewToolSubWorker(nc *nats.Conn, p ToolProvider) *SubWorker {
+	return &SubWorker{
+		nc:      nc,
+		subject: SubjectToolExecute,
+		stopCh:  make(chan struct{}),
+		handle: func(ctx context.Context, req InvokeRequest) InvokeResponse {
+			name, _ := req.Config["tool"].(string)
+			if name == "" {
+				// Naming the node makes this actionable; "tool is required" on
+				// its own does not say which node is wrong.
+				return InvokeResponse{Error: fmt.Sprintf("node %s: config.tool is required", req.NodeID)}
+			}
+			args, _ := req.Config["args"].(map[string]any)
+			if args == nil {
+				args = map[string]any{}
+			}
+			result, err := p.Execute(ctx, name, args)
+			if err != nil {
+				return InvokeResponse{Error: err.Error()}
+			}
+			return InvokeResponse{Writes: map[string]any{outputKeyFrom(req.Config): result}}
+		},
+	}
+}
+
+// Start subscribes and serves until ctx is canceled or Stop is called.
+func (w *SubWorker) Start(ctx context.Context) error {
+	sub, err := w.nc.Subscribe(w.subject, func(msg *nats.Msg) {
+		var req InvokeRequest
+		if err := json.Unmarshal(msg.Data, &req); err != nil {
+			w.reply(msg, InvokeResponse{Error: "malformed invocation: " + err.Error()})
+			return
+		}
+		resp := w.handle(ctx, req)
+		if resp.Error != "" {
+			slog.Warn("sub-worker: invocation failed",
+				"subject", w.subject, "run_id", req.RunID, "node_id", req.NodeID, "err", resp.Error)
+		}
+		w.reply(msg, resp)
+	})
+	if err != nil {
+		return err
+	}
+	w.sub = sub
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.stopCh:
+		return nil
+	}
+}
+
+// reply answers the request. A caller that has already given up leaves no reply
+// subject, which is normal (its run was redelivered) and not worth an error.
+func (w *SubWorker) reply(msg *nats.Msg, resp InvokeResponse) {
+	if msg.Reply == "" {
+		return
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		b = []byte(`{"error":"sub-worker produced an unserialisable reply"}`)
+	}
+	_ = msg.Respond(b)
+}
+
+// Stop unsubscribes and releases Start. Idempotent.
+func (w *SubWorker) Stop() {
+	if w.sub != nil {
+		_ = w.sub.Unsubscribe()
+	}
+	select {
+	case <-w.stopCh:
+	default:
+		close(w.stopCh)
+	}
+}
+
+// natsInvoker is the production Invoker: a core-NATS request/reply.
+type natsInvoker struct{ nc *nats.Conn }
+
+// NewNATSInvoker builds the Invoker a graph worker uses to reach sub-workers.
+func NewNATSInvoker(nc *nats.Conn) Invoker { return natsInvoker{nc: nc} }
+
+func (n natsInvoker) Invoke(ctx context.Context, subject string, req InvokeRequest, timeout time.Duration) (InvokeResponse, error) {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return InvokeResponse{}, err
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	msg, err := n.nc.RequestWithContext(reqCtx, subject, b)
+	if err != nil {
+		// nats.ErrNoResponders means no sub-worker is running. Saying so
+		// explicitly is the difference between an operator restarting a fleet
+		// and an operator debugging a graph.
+		return InvokeResponse{}, fmt.Errorf("no reply on %s (is a sub-worker running?): %w", subject, err)
+	}
+	var resp InvokeResponse
+	if err := json.Unmarshal(msg.Data, &resp); err != nil {
+		return InvokeResponse{}, fmt.Errorf("malformed reply on %s: %w", subject, err)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
Block A, items 1 and 3. A user could run a graph and never get the answer out.

## 1. `runs.output` was written by nothing

Declared in `postgres.d2` (run_ctx), populated by no code — the only `SET output` in the codebase targeted `execution_history` (per-node). A finished run reported `status=success` and `output=null`.

`graph-engine.d2`'s end executor is *"freeze output channel → run.output"*. The worker now sends the final channel values on `run.completed` and `terminalRun` persists them.

An end node can narrow the result with `config.output` (a channel name or a list); the default is the whole channel map. Narrowing is **opt-in** because a graph with no end node must still answer something — returning everything beats returning null. A named channel that was never written is omitted rather than emitted as null, so an absent key means the graph never produced it.

`COALESCE` on the update keeps a previously frozen result, so a later terminal write carrying no output can't erase a partial one.

## 2. `GET /threads/{id}/state` leaked the worker's internals

`snapshots.state` holds the checkpoint **envelope** — `{channels, completed_nodes, frontier, node, parent_checkpoint_id, interrupted}` — and it was returned verbatim. So the caller's actual values sat one level down under `channels`, and the walk's bookkeeping was published as though it were the graph's data.

`ThreadState.values` is now the channel values.

The same unwrap fixes **`ThreadState.next`, which was hardcoded to `[]`** even though the checkpoint carried the frontier. `next` is how a caller learns where a paused run will resume — it now reports it. `parent_checkpoint_id` moves to `ParentCheckpoint`, where it belongs: it's part of the checkpoint's identity, not the state.

A snapshot with no `channels` key passes through unchanged — that's the pre-envelope shape, and guessing at its interior would be worse than returning it as-is.

## 3. The SSE keepalive

`api.d2` declares `Event: heartbeat — keepalive (30s)`; nothing emitted one. A run can sit silent for minutes (a slow node, or a pause waiting on a human), and an idle connection is exactly what proxies, load balancers and browsers reap — so the client was disconnected mid-run and couldn't distinguish that from the run having ended.

The ticker lives in `streamRun`, which backs all four SSE endpoints, so one keepalive covers the surface.

## Tests — API-only

- a completed run's state exposes the graph's values, with **no** envelope keys leaking
- a run paused before `B` reports `next=["B"]`, with `B`'s write absent
- an end node's `config.output` selects one channel and drops the scratch value
- with no projection, the full channel map is returned
- a run producing **nothing at all** still delivers heartbeat frames

Every one verified to bite by reverting the fix.

One note worth recording: the heartbeat test reads with its own cancelable request rather than the shared `readSSE` helper. This stream never reaches a terminal event, so the handler runs until the client goes away, and `httptest.Server.Close()` blocks on outstanding handlers — the first draft hung for ten minutes.

## Still open in Block A

**A2 — `llm`/`tool` executors are still config-driven stand-ins**, so `llm.token`, `llm.completion` and `tool.result` remain unemitted; they have no source until a real model call exists. `checkpoint.saved` is also still unemitted — it needs an event on the checkpoint write path, which I've left out of this PR to keep it reviewable.

`[spec-skip]` impl-only — implements `graph-engine.d2`'s end executor, the `runs.output` column `postgres.d2` declares, and an SSE event `api.d2` declares. No OpenAPI or schema change.