### PR TITLE
feat(sse): emit checkpoint.saved, tool.call, tool.result, llm.completion

### DIFF
--- a/controlplane/endpoints/workers.go
+++ b/controlplane/endpoints/workers.go
@@ -7,11 +7,14 @@ package endpoints
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 )
@@ -193,6 +196,15 @@ func (s *Server) WorkersStreamEvents(c echo.Context) error {
 			}
 		case "execution.node_started", "execution.node_completed", "execution.node_failed":
 			if err := s.nodeEvent(ctx, rid, ev); err != nil {
+				return err
+			}
+		case "llm.completion", "tool.call", "tool.result":
+			// Observability only (api.d2's SSE catalogue). These describe what
+			// happened INSIDE a node; the node's own lifecycle and its writes
+			// are carried by execution.node_* and the checkpoint, so these
+			// change no run state and take no epoch guard beyond the one the
+			// events endpoint already applied to the run.
+			if err := s.streamDetailEvent(ctx, rid, ev); err != nil {
 				return err
 			}
 		default:
@@ -418,6 +430,31 @@ func (s *Server) WorkersWriteCheckpoint(c echo.Context) error {
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
+
+	// checkpoint.saved (api.d2 SSE catalogue: "state checkpointed"). Emitted
+	// AFTER the snapshot commits, and deliberately not inside its transaction:
+	// the snapshot write is the epoch-fenced thing that must not be disturbed,
+	// and announcing a checkpoint that then failed to exist would be worse than
+	// a checkpoint that exists without an announcement. A failure here is
+	// logged rather than returned, because the checkpoint IS saved — failing
+	// the call would make the worker retry a write that already succeeded.
+	//
+	// The payload carries the checkpoint id, not the state: a subscriber that
+	// wants the state can fetch it, and streaming full graph state on every
+	// node boundary would put the entire execution history through NATS twice.
+	if err := s.writeTx(ctx, s.Tenant, []Event{{
+		AggregateType: "Run",
+		AggregateID:   req.RunID,
+		EventType:     "checkpoint.saved",
+		Payload: mustJSON(map[string]any{
+			"run_id":        rid,
+			"checkpoint_id": id,
+			"version":       req.Version,
+		}),
+	}}, nil); err != nil {
+		slog.Warn("checkpoint saved but checkpoint.saved not emitted",
+			"run_id", rid, "checkpoint_id", id, "err", err)
+	}
 	return c.JSON(http.StatusOK, CheckpointWriteResponse{CheckpointID: id})
 }
 
@@ -526,4 +563,38 @@ func (s *Server) WorkersLoadGraph(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, resp)
+}
+
+// streamDetailEvent records an in-node observability event (llm.completion,
+// tool.call, tool.result) so it reaches subscribers through the normal outbox →
+// relay → NATS → SSE path.
+//
+// It writes an event and NOTHING else: no run row is touched, so there is no
+// state to fence. That is deliberate — these events must never be able to alter
+// a run, only describe it. A stale worker emitting one is harmless noise,
+// whereas letting it move run state would not be.
+func (s *Server) streamDetailEvent(ctx context.Context, rid string, ev WorkerEvent) error {
+	runID, err := uuid.Parse(rid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, "invalid run id")
+	}
+	payload := map[string]any{
+		"run_id":  rid,
+		"node_id": ev.NodeID,
+	}
+	if len(ev.Output) > 0 {
+		payload["output"] = json.RawMessage(ev.Output)
+	}
+	if len(ev.Input) > 0 {
+		payload["input"] = json.RawMessage(ev.Input)
+	}
+	if ev.DurationMs != nil {
+		payload["duration_ms"] = *ev.DurationMs
+	}
+	return s.writeTx(ctx, s.Tenant, []Event{{
+		AggregateType: "Run",
+		AggregateID:   runID,
+		EventType:     ev.Type,
+		Payload:       mustJSON(payload),
+	}}, nil)
 }

--- a/controlplane/nats/publisher.go
+++ b/controlplane/nats/publisher.go
@@ -129,6 +129,17 @@ func categoryFor(eventType string) string {
 	switch prefix {
 	case "execution":
 		return "executions"
+	// llm.*, tool.* and checkpoint.* are execution-level detail — they describe
+	// what happened INSIDE a node — so they ride the EXECUTION stream rather
+	// than getting streams of their own. That also puts them where the SSE
+	// bridge already looks (it subscribes to duragraph.executions.>), which is
+	// the whole reason api.d2 lists them in the SSE catalogue.
+	//
+	// Without this they fell to the "events" default, and NO stream captures
+	// duragraph.events.> — publishing produced "no response from stream" and
+	// the event was retried forever in the outbox.
+	case "llm", "tool", "checkpoint":
+		return "executions"
 	case "run":
 		return "runs"
 	case "worker":

--- a/controlplane/worker/client.go
+++ b/controlplane/worker/client.go
@@ -107,6 +107,22 @@ func (c *Client) RunStarted(ctx context.Context, runID uuid.UUID) (int, error) {
 	return resp.LeaseEpoch, nil
 }
 
+// StreamDetail emits an in-node observability event — llm.completion,
+// tool.call or tool.result (api.d2's SSE catalogue). These describe what
+// happened inside a node; they carry no run state, so a failure to record one
+// must never fail the node that produced it.
+func (c *Client) StreamDetail(ctx context.Context, runID uuid.UUID, eventType, nodeID string, input, output json.RawMessage, durationMs *int) error {
+	body := eventsRequest{Events: []workerEvent{{
+		Type:       eventType,
+		NodeID:     nodeID,
+		Input:      input,
+		Output:     output,
+		DurationMs: durationMs,
+	}}}
+	_, err := c.doJSON(ctx, http.MethodPost, c.eventsPath(runID), body, nil)
+	return err
+}
+
 // NodeStarted opens a node's execution_history row before the node runs, fenced
 // on epoch. The completing call (NodeCompleted / NodeFailed) transitions that
 // same row rather than adding another — see the server's nodeEvent.

--- a/controlplane/worker/delegate.go
+++ b/controlplane/worker/delegate.go
@@ -72,6 +72,21 @@ type delegatingExecutor struct {
 	subject string
 	timeout time.Duration
 	inv     Invoker
+
+	// emit records the in-node observability events api.d2 declares
+	// (llm.completion, tool.call, tool.result). Optional: a nil emitter means
+	// the node still runs, it is just not narrated. These events must never be
+	// able to fail the node that produced them.
+	emit func(ctx context.Context, eventType, nodeID string, input, output json.RawMessage, durationMs *int)
+}
+
+// narrate emits an observability event if an emitter is wired, swallowing any
+// failure. A node must not fail because its narration did.
+func (d delegatingExecutor) narrate(ctx context.Context, eventType, nodeID string, input, output json.RawMessage, durationMs *int) {
+	if d.emit == nil {
+		return
+	}
+	d.emit(ctx, eventType, nodeID, input, output, durationMs)
 }
 
 func (d delegatingExecutor) Execute(ctx context.Context, node Node, channels map[string]any) (map[string]any, error) {
@@ -94,6 +109,14 @@ func (d delegatingExecutor) Execute(ctx context.Context, node Node, channels map
 		return configExecutor{}.Execute(ctx, node, channels)
 	}
 
+	// tool.call is emitted BEFORE the tool runs: a tool invocation is a side
+	// effect on the outside world, and a caller watching the stream needs to
+	// see that it was attempted even if it never returns.
+	if node.Type == "tool" {
+		d.narrate(ctx, "tool.call", node.ID, mustJSONRaw(node.Config), nil, nil)
+	}
+
+	startedAt := time.Now()
 	resp, err := d.inv.Invoke(ctx, d.subject, InvokeRequest{
 		RunID:    runIDFromContext(ctx),
 		NodeID:   node.ID,
@@ -101,6 +124,15 @@ func (d delegatingExecutor) Execute(ctx context.Context, node Node, channels map
 		Config:   node.Config,
 		Channels: channels,
 	}, d.timeout)
+	elapsed := int(time.Since(startedAt).Milliseconds())
+	if err == nil && resp.Error == "" {
+		// llm.completion / tool.result — the provider answered.
+		eventType := "llm.completion"
+		if node.Type == "tool" {
+			eventType = "tool.result"
+		}
+		d.narrate(ctx, eventType, node.ID, nil, mustJSONRaw(resp.Writes), &elapsed)
+	}
 	if err != nil {
 		// A transport failure is NOT a poison node: the provider may simply be
 		// slow or briefly unreachable, and failing the run would discard work
@@ -188,4 +220,18 @@ func outputKeyFrom(cfg map[string]any) string {
 		return k
 	}
 	return "completion"
+}
+
+// mustJSONRaw marshals a value for an observability payload. A value that will
+// not marshal becomes null rather than failing: narration must never break the
+// node it describes.
+func mustJSONRaw(v any) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
 }

--- a/controlplane/worker/delegate_integration_test.go
+++ b/controlplane/worker/delegate_integration_test.go
@@ -320,3 +320,94 @@ func TestDeclarativeNodesStillWorkWithAFleet(t *testing.T) {
 		t.Errorf("declarative write lost: %v", state.Values)
 	}
 }
+
+// TestDelegationEmitsStreamEvents: api.d2's SSE catalogue declares
+// tool.call ("tool invoked"), tool.result ("tool returned") and
+// llm.completion ("LLM generation done"). Nothing emitted any of them — before
+// delegation existed there was no provider call to narrate.
+//
+// Asserted at the events table rather than over SSE: these reach a subscriber
+// through the ordinary outbox → relay → NATS path already proven by
+// TestStreamEndToEnd, and asserting the durable record keeps this test about
+// whether they are PRODUCED, not about transport.
+func TestDelegationEmitsStreamEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	llm := &recordingLLM{}
+	api, tid, aid := delegationHarness(t, ctx, llm, mapTool{},
+		`[{"id":"T","type":"tool","config":{"tool":"search","args":{"q":"x"},"output_key":"r"}},
+		  {"id":"L","type":"llm","config":{"model":"m","prompt":"p","output_key":"a"}}]`,
+		`[{"source":"T","target":"L"}]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{"assistant_id": aid}, &run, http.StatusCreated)
+	rid := uuid.MustParse(run.RunID)
+	waitForRunStatus(t, ctx, pool, rid, "completed", 30*time.Second)
+
+	for _, want := range []string{"tool.call", "tool.result", "llm.completion", "checkpoint.saved"} {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type=$2`, rid, want).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n == 0 {
+			t.Errorf("api.d2 declares %q in the SSE catalogue, but none was emitted", want)
+		}
+	}
+
+	// tool.call must name the node, or a subscriber cannot tell which step of
+	// the graph reached out to the world.
+	var payload []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT payload FROM events WHERE aggregate_id=$1 AND event_type='tool.call' LIMIT 1`,
+		rid).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["node_id"] != "T" {
+		t.Errorf("tool.call must identify the node, got %s", payload)
+	}
+}
+
+// TestStreamDetailEventsCannotAlterRunState: these events are observability
+// only. A stale worker emitting one must be harmless noise — never able to move
+// a run — which is why they take no epoch guard and touch no run row.
+func TestStreamDetailEventsCannotAlterRunState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	_, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	_ = aid
+	seedCounterGraph(t, ctx, pool, aid, false)
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cl.RunStarted(ctx, rid); err != nil {
+		t.Fatal(err)
+	}
+
+	var before string
+	if err := pool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.StreamDetail(ctx, rid, "tool.call", "A", nil, nil, nil); err != nil {
+		t.Fatalf("StreamDetail: %v", err)
+	}
+	var after string
+	if err := pool.QueryRow(ctx, `SELECT status FROM runs WHERE id=$1`, rid).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Errorf("an observability event changed run status: %s -> %s", before, after)
+	}
+}

--- a/controlplane/worker/graph.go
+++ b/controlplane/worker/graph.go
@@ -424,15 +424,25 @@ func defaultExecutors() map[string]NodeExecutor {
 // nodes that were about to succeed, and one that waited longer would hold the
 // graph command past its own redelivery window.
 func executorsWithInvoker(inv Invoker) map[string]NodeExecutor {
+	return executorsWithInvokerAndEmitter(inv, nil)
+}
+
+// executorsWithInvokerAndEmitter additionally narrates delegated calls with the
+// in-node events api.d2's SSE catalogue declares (llm.completion, tool.call,
+// tool.result).
+func executorsWithInvokerAndEmitter(inv Invoker, emit detailEmitter) map[string]NodeExecutor {
 	return map[string]NodeExecutor{
 		"start":       passthroughExecutor{},
 		"end":         passthroughExecutor{},
 		"conditional": passthroughExecutor{},
 		nodeTypeHuman: passthroughExecutor{},
-		"llm":         delegatingExecutor{subject: SubjectLLMInvoke, timeout: 2 * time.Minute, inv: inv},
-		"tool":        delegatingExecutor{subject: SubjectToolExecute, timeout: 1 * time.Minute, inv: inv},
+		"llm":         delegatingExecutor{subject: SubjectLLMInvoke, timeout: 2 * time.Minute, inv: inv, emit: emit},
+		"tool":        delegatingExecutor{subject: SubjectToolExecute, timeout: 1 * time.Minute, inv: inv, emit: emit},
 	}
 }
+
+// detailEmitter records an in-node observability event.
+type detailEmitter func(ctx context.Context, eventType, nodeID string, input, output json.RawMessage, durationMs *int)
 
 // passthroughExecutor writes nothing and never fails.
 type passthroughExecutor struct{}

--- a/controlplane/worker/runner.go
+++ b/controlplane/worker/runner.go
@@ -95,6 +95,7 @@ type runClient interface {
 	NodeCompleted(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType string, durationMs *int) error
 	NodeFailed(ctx context.Context, runID uuid.UUID, epoch int, nodeID, nodeType, reason string, durationMs *int) error
 	RunCompletedWithOutput(ctx context.Context, runID uuid.UUID, epoch int, output json.RawMessage) error
+	StreamDetail(ctx context.Context, runID uuid.UUID, eventType, nodeID string, input, output json.RawMessage, durationMs *int) error
 	RunFailed(ctx context.Context, runID uuid.UUID, epoch int, reason string) error
 	RequiresAction(ctx context.Context, runID uuid.UUID, epoch int, nodeID, reason string, state, toolCalls []byte) error
 }
@@ -137,7 +138,23 @@ func NewRunner(js jetstream.JetStream, cl runClient, maxDeliver int) *Runner {
 // types can only run their declarative `set`/`fail` forms — enough for a
 // deterministic graph, not enough to call a model.
 func NewRunnerWithInvoker(js jetstream.JetStream, cl runClient, maxDeliver int, inv Invoker) *Runner {
-	return &Runner{js: js, cl: cl, execs: executorsWithInvoker(inv), MaxDeliver: maxDeliver, StopAfterNode: -1}
+	r := &Runner{js: js, cl: cl, MaxDeliver: maxDeliver, StopAfterNode: -1}
+	// The emitter closes over the client so delegated calls can narrate
+	// themselves (llm.completion, tool.call, tool.result). Failures are logged,
+	// never returned: a node must not fail because its narration did.
+	emit := func(ctx context.Context, eventType, nodeID string, input, output json.RawMessage, durationMs *int) {
+		runID := runIDFromContext(ctx)
+		id, err := uuid.Parse(runID)
+		if err != nil {
+			return
+		}
+		if derr := cl.StreamDetail(ctx, id, eventType, nodeID, input, output, durationMs); derr != nil {
+			slog.Warn("worker: stream detail event not recorded",
+				"event", eventType, "run_id", runID, "node_id", nodeID, "err", derr)
+		}
+	}
+	r.execs = executorsWithInvokerAndEmitter(inv, emit)
+	return r
 }
 
 // GraphCommand is the worker.graph.execute payload shape, matching what

--- a/controlplane/worker/runner_escalation_test.go
+++ b/controlplane/worker/runner_escalation_test.go
@@ -119,3 +119,7 @@ func TestEscalationWiring(t *testing.T) {
 		t.Errorf("RunFailed: want epoch=1, got %d", cl.failedEpoch)
 	}
 }
+
+func (c *stubEscalationClient) StreamDetail(ctx context.Context, runID uuid.UUID, eventType, nodeID string, input, output json.RawMessage, durationMs *int) error {
+	return nil
+}

--- a/controlplane/worker/stream_e2e_test.go
+++ b/controlplane/worker/stream_e2e_test.go
@@ -183,15 +183,18 @@ func TestStreamEndToEnd(t *testing.T) {
 
 	url := sseSrv.URL + "/api/v1/threads/" + uuid.Nil.String() + "/runs/" + rid.String() + "/stream"
 	done := make(chan []sseFrame, 1)
-	// Each node now streams a start AND a completion, so a consumer can see a
-	// node enter execution rather than only learning it finished.
-	go func() { done <- readSSE(t, url, 6, 15*time.Second) }()
+	// Each node streams a start, its checkpoint, and a completion, so a
+	// consumer sees a node enter execution, sees its state durably saved, and
+	// then sees it finish. checkpoint.saved lands BEFORE node_completed
+	// because the runner writes the checkpoint before announcing the node —
+	// state is durable before it is advertised.
+	go func() { done <- readSSE(t, url, 8, 15*time.Second) }()
 
 	frames := <-done
 	want := []string{
 		"run.started",
-		"execution.node_started", "execution.node_completed", // A
-		"execution.node_started", "execution.node_completed", // B
+		"execution.node_started", "checkpoint.saved", "execution.node_completed", // A
+		"execution.node_started", "checkpoint.saved", "execution.node_completed", // B
 		"run.completed",
 	}
 	if len(frames) != len(want) {


### PR DESCRIPTION
Block A3. `api.d2`'s SSE catalogue declares twelve events; four were emitted by nothing — and none of them had a route even if they had been.

## The blocker, which had to be fixed first

The relay derives a NATS subject from the event type's prefix, and `categoryFor` knew only `run`, `execution`, `interrupt`, `worker`, `user`, `tenant`. Anything else fell to a default category `events` — and **no stream captures `duragraph.events.>`**. Publishing there fails with `no response from stream` and the outbox row retries forever.

So `llm.*`, `tool.*` and `checkpoint.*` literally had nowhere to go. (This failure mode is visible in existing test logs: `publisher: publish "duragraph.events.thread.created": nats: no response from stream`.)

They now route to the **EXECUTION** stream. They're execution-level detail — they describe what happened *inside* a node — and that's also where the SSE bridge already looks (`duragraph.executions.>`), which is precisely why `api.d2` lists them in the SSE catalogue.

## What's emitted

- **`checkpoint.saved`** — after the snapshot **commits**, deliberately outside its transaction. The snapshot write is the epoch-fenced thing that must not be disturbed, and announcing a checkpoint that then failed to exist would be worse than one that exists unannounced. A failure to announce is logged, not returned: the checkpoint *is* saved, and failing the call would make the worker retry a write that already succeeded. The payload carries the checkpoint **id**, not the state — streaming full graph state at every node boundary would push the entire execution history through NATS twice.
- **`tool.call`** — *before* the tool runs. A tool invocation is a side effect on the outside world, so a subscriber must see it was attempted even if it never returns.
- **`tool.result`** / **`llm.completion`** — after the provider answers, with elapsed time.

## These are observability only

`streamDetailEvent` writes an event and **nothing else** — no run row is touched, so there's no state to fence. Deliberate: a stale worker emitting one must be harmless noise, where letting it move run state would not be. Narration failures are swallowed in the worker for the same reason — a node must never fail because its description did. There's a test asserting an observability event cannot change run status.

## Sequence change

`TestStreamEndToEnd` grows from 6 frames to 8. `checkpoint.saved` lands **before** `node_completed`, because the runner writes the checkpoint before announcing the node — state is durable before it's advertised, and the stream now shows that.

## `llm.token` is NOT included — and this is the honest blocker

Two reasons, and the second is the real one:

1. The `LLMProvider` seam returns a whole completion, so there's no token stream to forward.
2. **Every other event here goes through the event store** — one `events` row plus one `outbox` row each. Doing that per token is enormous write amplification for data the completion immediately supersedes, and it would put token-rate traffic through the durable outbox.

`llm.token` needs an *ephemeral* path (publish straight to NATS, no persistence, no catch-up replay). That's a different transport decision from the one this PR makes, so I've left it out rather than bolt a high-volume ephemeral stream onto the durable path.

`[spec-skip]` impl-only — emits events `api.d2` already declares, over the EXECUTION stream `nats.d2` already declares. No OpenAPI or schema change.