### PR TITLE
feat(sse): stream llm.token over an ephemeral path

### DIFF
--- a/controlplane/endpoints/runs_stream.go
+++ b/controlplane/endpoints/runs_stream.go
@@ -118,6 +118,14 @@ func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTer
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
+	// Ephemeral detail (llm.token). Deliberately NOT part of the catch-up
+	// replay below: these are never persisted, so there is nothing to catch up
+	// on. A client that connects mid-generation sees the remaining tokens and
+	// then the completion — which is what it actually needs.
+	ephCh, err := s.Subscriber.Subscribe(ctx, nats.EphemeralSubjectPrefix+">")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 
 	// SSE headers.
 	h := c.Response().Header()
@@ -182,6 +190,26 @@ func (s *Server) streamRun(c echo.Context, runIDs map[uuid.UUID]bool, closeOnTer
 		case <-beat.C:
 			// A failed write means the client is gone; stop rather than spin.
 			if writeSSEFrame(c, "heartbeat", nil) != nil {
+				return nil
+			}
+			continue
+		case msg = <-ephCh:
+			// Ephemeral events carry no event_id, so there is nothing to dedup
+			// on and nothing to replay — at-most-once is the contract. Handled
+			// separately rather than squeezed into relayEnvelope, so that
+			// absence stays explicit instead of looking like a missing field.
+			if msg == nil {
+				return nil
+			}
+			var eph nats.EphemeralEnvelope
+			if json.Unmarshal(msg.Payload, &eph) != nil {
+				continue
+			}
+			aid, err := uuid.Parse(eph.AggregateID)
+			if err != nil || !runIDs[aid] {
+				continue
+			}
+			if writeSSEFrame(c, eph.EventType, eph.Payload) != nil {
 				return nil
 			}
 			continue

--- a/controlplane/nats/ephemeral.go
+++ b/controlplane/nats/ephemeral.go
@@ -1,0 +1,69 @@
+// Ephemeral fan-out — the transport for high-rate, disposable stream detail.
+//
+// Everything else in this system is durable: an event is written to the events
+// table, mirrored to the outbox, relayed to a JetStream stream, and replayable
+// by an SSE client that reconnects. That is the right shape for anything a run's
+// history depends on.
+//
+// It is the wrong shape for llm.token. A token is superseded by the completion
+// that contains it seconds later, so persisting one events row plus one outbox
+// row PER TOKEN would multiply write volume by the length of every generation
+// to store data nobody reads twice. Tokens are also worthless late: a client
+// that reconnects mid-generation wants the completion, not a replay of the
+// tokens it missed.
+//
+// So tokens take a separate path with deliberately weaker guarantees:
+//
+//	at-most-once, no persistence, no replay, no dedup
+//
+// The subject prefix duragraph.ephemeral.> is captured by NO JetStream stream
+// (see streams.go — runs, executions, interrupts, worker_commands,
+// platform_users, platform_tenants). That is what makes it ephemeral: a core
+// NATS publish with no stream behind it reaches whoever is listening right now
+// and is then gone. Adding a stream over this prefix would silently reintroduce
+// the storage cost this exists to avoid.
+package nats
+
+import (
+	"encoding/json"
+
+	"github.com/nats-io/nats.go"
+)
+
+// EphemeralSubjectPrefix is the root of the non-persisted fan-out space. It
+// MUST NOT overlap any stream's subject pattern.
+const EphemeralSubjectPrefix = "duragraph.ephemeral."
+
+// EphemeralSubjectFor builds the subject for one ephemeral event type.
+func EphemeralSubjectFor(eventType string) string {
+	return EphemeralSubjectPrefix + eventType
+}
+
+// EphemeralEnvelope is the wire shape for a non-persisted stream event.
+//
+// It carries no event_id, and that absence is meaningful: there is no dedup and
+// no replay, so there is nothing for an id to key. AggregateID is the run, so a
+// subscriber can filter to the runs it is watching — the same filtering the
+// durable path does.
+type EphemeralEnvelope struct {
+	AggregateID string          `json:"aggregate_id"`
+	EventType   string          `json:"event_type"`
+	NodeID      string          `json:"node_id,omitempty"`
+	Payload     json.RawMessage `json:"payload"`
+}
+
+// PublishEphemeral fans out one event with no persistence.
+//
+// Errors are returned but callers are expected to ignore them: a failed token
+// publish must never disturb the generation that produced it, and there is no
+// retry that would make sense for data this short-lived.
+func PublishEphemeral(nc *nats.Conn, env EphemeralEnvelope) error {
+	if nc == nil {
+		return nil
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+	return nc.Publish(EphemeralSubjectFor(env.EventType), b)
+}

--- a/controlplane/worker/delegate.go
+++ b/controlplane/worker/delegate.go
@@ -176,6 +176,23 @@ type LLMProvider interface {
 	Complete(ctx context.Context, model, prompt string, cfg map[string]any) (string, error)
 }
 
+// StreamingLLMProvider is an OPTIONAL capability on top of LLMProvider: a
+// provider that can deliver a generation token by token implements it, and the
+// LLM sub-worker then emits api.d2's llm.token as they arrive.
+//
+// Kept separate from LLMProvider rather than widening it, so a provider that
+// cannot stream — or a deployment that does not want to — needs no change and
+// no stub method. The sub-worker type-asserts for it.
+//
+// onToken is called synchronously for each token, so an implementation must not
+// block in it. The final return is still the complete text: the caller needs
+// the whole completion for the node's writes regardless of whether anyone was
+// watching the tokens.
+type StreamingLLMProvider interface {
+	LLMProvider
+	CompleteStream(ctx context.Context, model, prompt string, cfg map[string]any, onToken func(string)) (string, error)
+}
+
 // ToolProvider executes a named tool.
 type ToolProvider interface {
 	Execute(ctx context.Context, name string, args map[string]any) (any, error)

--- a/controlplane/worker/delegate_integration_test.go
+++ b/controlplane/worker/delegate_integration_test.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	natsgo "github.com/nats-io/nats.go"
 
 	"github.com/duragraph/duragraph/controlplane/endpoints"
 	dnats "github.com/duragraph/duragraph/controlplane/nats"
@@ -409,5 +411,250 @@ func TestStreamDetailEventsCannotAlterRunState(t *testing.T) {
 	}
 	if before != after {
 		t.Errorf("an observability event changed run status: %s -> %s", before, after)
+	}
+}
+
+// streamingLLM implements the optional StreamingLLMProvider capability.
+type streamingLLM struct{ tokens []string }
+
+func (s streamingLLM) Complete(_ context.Context, _, _ string, _ map[string]any) (string, error) {
+	return strings.Join(s.tokens, ""), nil
+}
+
+func (s streamingLLM) CompleteStream(_ context.Context, _, _ string, _ map[string]any, onToken func(string)) (string, error) {
+	for _, tok := range s.tokens {
+		onToken(tok)
+	}
+	return strings.Join(s.tokens, ""), nil
+}
+
+// TestLLMTokensStreamEphemerally is api.d2's llm.token — "single token
+// (streaming)".
+//
+// The transport is the point. Every other stream event is durable: an events
+// row, an outbox row, a relay hop, and replay on reconnect. A token is
+// superseded by the completion seconds later, so persisting one row per token
+// would multiply write volume by the length of every generation to store data
+// nobody reads twice. Tokens therefore take a separate at-most-once path with
+// no persistence — and this test asserts BOTH halves: they reach a live
+// subscriber, and they leave nothing behind.
+func TestLLMTokensStreamEphemerally(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	nc, js, err := dnats.Connect(ctx, natsURL)
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+	if err := dnats.EnsureConsumers(ctx, js); err != nil {
+		t.Fatal(err)
+	}
+	purgeStream(t, ctx, js, "RUNS")
+	purgeStream(t, ctx, js, "WORKER_COMMANDS")
+
+	e := echo.New()
+	srv := &endpoints.Server{Tenant: pool, Subscriber: dnats.NewSubscriberFromConn(nc)}
+	g := e.Group("/api/v1")
+	srv.RegisterAssistants(g)
+	srv.RegisterThreads(g)
+	srv.RegisterRuns(g)
+	srv.RegisterWorkers(g)
+	apiSrv := httptest.NewServer(e)
+	defer apiSrv.Close()
+	api := &apiClient{t: t, base: apiSrv.URL}
+
+	relay := dnats.NewRelay(dnats.NewOutboxDrain(pool), dnats.NewPublisher(js),
+		listenerDSNFromPool(), 200*time.Millisecond, 20)
+	go func() { _ = relay.Start(ctx) }()
+	defer relay.Stop()
+	rp := dnats.NewRunProcessor(js, dnats.NewPublisher(js), pool)
+	go func() { _ = rp.Start(ctx) }()
+	defer rp.Stop()
+
+	lw := worker.NewLLMSubWorker(nc, streamingLLM{tokens: []string{"Hello", ", ", "world"}})
+	go func() { _ = lw.Start(ctx) }()
+	defer lw.Stop()
+
+	graphName := "tok-" + uuid.NewString()[:8]
+	cl := worker.NewClient(apiSrv.URL, uuid.New(), nil)
+	if err := cl.RegisterWithGraphs(ctx, []string{graphName}, 1, []worker.GraphDefinition0{{
+		Name: graphName, Version: "1",
+		Nodes: json.RawMessage(`[{"id":"L","type":"llm","config":{"model":"m","prompt":"hi","output_key":"a"}}]`),
+		Edges: json.RawMessage(`[]`),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	runner := worker.NewRunnerWithInvoker(js, cl, dnats.GraphExecutorMaxDeliver, worker.NewNATSInvoker(nc))
+	go func() { _ = runner.Start(ctx) }()
+
+	var assistant struct {
+		AssistantID string `json:"assistant_id"`
+	}
+	api.mustDo("POST", "/api/v1/assistants", map[string]any{
+		"graph_id": graphName, "name": "tok-assistant",
+	}, &assistant, http.StatusCreated)
+	var thread struct {
+		ThreadID string `json:"thread_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads", map[string]any{}, &thread, http.StatusCreated)
+
+	// Subscribe to the ephemeral subject directly. Tokens are at-most-once, so
+	// a subscriber has to exist BEFORE the generation starts — which is exactly
+	// the contract, and asserting it over raw NATS keeps this test about the
+	// transport rather than about SSE timing.
+	tokens := make(chan string, 32)
+	sub, err := nc.Subscribe(dnats.EphemeralSubjectPrefix+">", func(m *natsgo.Msg) {
+		var env dnats.EphemeralEnvelope
+		if json.Unmarshal(m.Data, &env) != nil || env.EventType != "llm.token" {
+			return
+		}
+		var p struct {
+			Token string `json:"token"`
+			Seq   int    `json:"seq"`
+		}
+		if json.Unmarshal(env.Payload, &p) != nil {
+			return
+		}
+		select {
+		case tokens <- p.Token:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe() //nolint:errcheck
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+thread.ThreadID+"/runs", map[string]any{
+		"assistant_id": assistant.AssistantID,
+	}, &run, http.StatusCreated)
+	rid := uuid.MustParse(run.RunID)
+	waitForRunStatus(t, ctx, pool, rid, "completed", 30*time.Second)
+
+	var got []string
+	deadline := time.After(5 * time.Second)
+collect:
+	for len(got) < 3 {
+		select {
+		case tok := <-tokens:
+			got = append(got, tok)
+		case <-deadline:
+			break collect
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 streamed tokens, got %d: %v", len(got), got)
+	}
+	if strings.Join(got, "") != "Hello, world" {
+		t.Errorf("tokens did not reassemble into the completion: %v", got)
+	}
+
+	// The completion still lands on the graph's channels — streaming is
+	// observation, not a replacement for the node's writes.
+	var state struct {
+		Values map[string]any `json:"values"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+thread.ThreadID+"/state", nil, &state, http.StatusOK)
+	if state.Values["a"] != "Hello, world" {
+		t.Errorf("values.a: want the full completion, got %v", state.Values["a"])
+	}
+
+	// THE EPHEMERAL GUARANTEE: nothing persisted. A token in the events table
+	// would mean the write amplification this design exists to avoid.
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM events WHERE event_type = 'llm.token'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("llm.token must NOT be persisted, found %d row(s) in events", n)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM outbox WHERE event_type = 'llm.token'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("llm.token must NOT reach the outbox, found %d row(s)", n)
+	}
+	// And llm.completion IS still durable — the two paths coexist.
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM events WHERE aggregate_id=$1 AND event_type='llm.completion'`, rid).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Error("llm.completion must still be durable")
+	}
+}
+
+// TestNonStreamingProviderEmitsNoTokens: streaming is an OPTIONAL capability. A
+// provider that cannot stream must still work, and must not fabricate tokens.
+func TestNonStreamingProviderEmitsNoTokens(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newPool(t)
+
+	llm := &recordingLLM{}
+	api, tid, aid := delegationHarness(t, ctx, llm, nil,
+		`[{"id":"L","type":"llm","config":{"model":"m","prompt":"p","output_key":"a"}}]`, `[]`)
+
+	var run struct {
+		RunID string `json:"run_id"`
+	}
+	api.mustDo("POST", "/api/v1/threads/"+tid+"/runs", map[string]any{"assistant_id": aid}, &run, http.StatusCreated)
+	waitForRunStatus(t, ctx, pool, uuid.MustParse(run.RunID), "completed", 30*time.Second)
+
+	if llm.calls != 1 {
+		t.Errorf("non-streaming provider should still be called once, got %d", llm.calls)
+	}
+	var state struct {
+		Values map[string]any `json:"values"`
+	}
+	api.mustDo("GET", "/api/v1/threads/"+tid+"/state", nil, &state, http.StatusOK)
+	if state.Values["a"] != "answered: p" {
+		t.Errorf("completion missing from channels: %v", state.Values)
+	}
+}
+
+// TestTokensCannotEnterTheDurablePath is the structural half of the ephemeral
+// guarantee. Counting rows proves tokens did not happen to be persisted in one
+// run; this proves they CANNOT be, because the durable events endpoint refuses
+// the type outright. Someone routing llm.token through StreamDetail to "make it
+// replayable" hits a 400 rather than quietly multiplying write volume by the
+// length of every generation.
+func TestTokensCannotEnterTheDurablePath(t *testing.T) {
+	ctx := context.Background()
+	pool := newPool(t)
+
+	_, aid, rid := seedThreadAssistantRun(t, ctx, pool)
+	seedCounterGraph(t, ctx, pool, aid, false)
+
+	cl := worker.NewClient(serverURL, uuid.New(), nil)
+	if err := cl.Register(ctx, []string{"counter"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cl.RunStarted(ctx, rid); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cl.StreamDetail(ctx, rid, "llm.token", "L", nil, nil, nil)
+	if err == nil {
+		t.Fatal("llm.token must be refused by the durable events endpoint; it is ephemeral by design")
+	}
+	if !contains(err.Error(), "unknown event type") {
+		t.Errorf("want a rejection naming the unknown type, got: %v", err)
+	}
+
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM events WHERE event_type='llm.token'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("a refused event still reached the store: %d row(s)", n)
 	}
 }

--- a/controlplane/worker/subworker.go
+++ b/controlplane/worker/subworker.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+
+	dnats "github.com/duragraph/duragraph/controlplane/nats"
 )
 
 // SubWorker answers invocation requests on one subject.
@@ -42,7 +44,38 @@ func NewLLMSubWorker(nc *nats.Conn, p LLMProvider) *SubWorker {
 		stopCh:  make(chan struct{}),
 		handle: func(ctx context.Context, req InvokeRequest) InvokeResponse {
 			model := modelFrom(req.Config)
-			text, err := p.Complete(ctx, model, promptFrom(req.Config, req.Channels), req.Config)
+			prompt := promptFrom(req.Config, req.Channels)
+
+			var text string
+			var err error
+			// Stream when the provider can, so api.d2's llm.token
+			// ("single token (streaming)") reaches a watching client as the
+			// generation happens. Tokens go out on the EPHEMERAL path — no
+			// events row, no outbox row — because a token is superseded by the
+			// completion seconds later and persisting one per token would
+			// multiply write volume by the length of every generation.
+			if sp, ok := p.(StreamingLLMProvider); ok {
+				var seq int
+				text, err = sp.CompleteStream(ctx, model, prompt, req.Config, func(tok string) {
+					// Best-effort by design: a failed token publish must never
+					// disturb the generation that produced it.
+					_ = dnats.PublishEphemeral(nc, dnats.EphemeralEnvelope{
+						AggregateID: req.RunID,
+						EventType:   "llm.token",
+						NodeID:      req.NodeID,
+						Payload: mustJSONRaw(map[string]any{
+							"token": tok,
+							// seq lets a client order tokens without relying on
+							// arrival order, which at-most-once delivery does
+							// not promise.
+							"seq": seq,
+						}),
+					})
+					seq++
+				})
+			} else {
+				text, err = p.Complete(ctx, model, prompt, req.Config)
+			}
 			if err != nil {
 				return InvokeResponse{Error: err.Error()}
 			}


### PR DESCRIPTION
`api.d2`'s last unemitted SSE event — *"single token (streaming)"*. **The transport is the substance of this change**, not the emission.

## Why not the durable path

Every other stream event is written to `events`, mirrored to `outbox`, relayed to a JetStream stream, and replayable on reconnect. That's right for anything a run's history depends on.

It's wrong for a token. The completion supersedes it seconds later, so one `events` row **plus** one `outbox` row *per token* multiplies write volume by the length of every generation — to store data nobody reads twice. Tokens are also worthless late: a client reconnecting mid-generation wants the completion, not a replay of what it missed.

## The mechanism

Tokens take a path with deliberately weaker guarantees: **at-most-once, no persistence, no replay, no dedup.**

The prefix `duragraph.ephemeral.>` is captured by **no** JetStream stream (`streams.go` covers runs, executions, interrupts, worker_commands, platform_users, platform_tenants). That absence *is* the mechanism — a core NATS publish with no stream behind it reaches whoever is listening now and is then gone. Adding a stream over this prefix would silently reintroduce the storage cost it exists to avoid, so the package doc says that out loud.

The envelope carries **no `event_id`**, and that absence is meaningful: with no replay and no dedup there's nothing for an id to key. It's handled separately in the SSE loop rather than squeezed into `relayEnvelope`, so the difference stays explicit instead of looking like a missing field. A `seq` number lets a client order tokens without relying on arrival order, which at-most-once doesn't promise.

## Streaming is an optional capability

`StreamingLLMProvider` sits *on top of* `LLMProvider` rather than widening it — a provider that can't stream needs no change and no stub method; the sub-worker type-asserts. The full completion is still returned and still written to the node's channels: **streaming is observation, never a replacement for the node's writes.**

## Tests — both halves of the guarantee

- tokens reach a live subscriber and reassemble into the completion
- **nothing** is left behind in `events` or `outbox`
- the structural half: the durable events endpoint **refuses** `llm.token` with `400 unknown event type`, so someone routing it through `StreamDetail` to "make it replayable" gets an error rather than quietly multiplying write volume
- a non-streaming provider still works and fabricates no tokens
- `llm.completion` remains durable — the two paths coexist

**One honest note:** flipping the subject prefix to an existing stream does *not* fail these tests, because that moves tokens between NATS streams rather than between the durable and ephemeral paths. The property that actually matters is never going through `writeTx` — which is what the rejection test pins. I checked this rather than assuming my first probe was meaningful.

## Block A is now complete

All twelve events in `api.d2`'s SSE catalogue are emitted. Runs return results, thread state is unwrapped, `next` reports where a paused run resumes, llm/tool nodes delegate to real sub-workers, and tokens stream.

`[spec-skip]` impl-only — emits the last event `api.d2` declares. No OpenAPI or schema change, and no new stream.