### PR TITLE
feat(cmd): wire the rebuilt control plane into the binary

### DIFF
--- a/cmd/duragraph/cmd/serve.go
+++ b/cmd/duragraph/cmd/serve.go
@@ -83,6 +83,20 @@ func runServe(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
+	// The rebuilt control plane is a separate composition root
+	// (controlplane/server) rather than a variation on the wiring below,
+	// so the branch is here at the top and the two share only config.
+	// See serve_controlplane.go for why this is opt-in.
+	which, err := selectedControlPlane()
+	if err != nil {
+		return err
+	}
+	if which == controlPlaneV2 {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		return runServeV2(ctx, cfg)
+	}
+
 	slog.Info("DuraGraph server starting",
 		"addr", cfg.ServerAddr(),
 		"db_host", cfg.Database.Host,

--- a/cmd/duragraph/cmd/serve_controlplane.go
+++ b/cmd/duragraph/cmd/serve_controlplane.go
@@ -1,0 +1,136 @@
+package cmd
+
+// Wiring for the rebuilt control plane (controlplane/…) into the shipped
+// binary.
+//
+// Until this file existed, `go list -deps ./cmd/duragraph` contained no
+// controlplane package at all: the rebuild was reachable only from tests.
+// GoReleaser builds ./cmd/duragraph and nothing else, so every release
+// shipped the legacy internal/ stack while the rebuild rode along as dead
+// weight in the repo.
+//
+// WHY THIS IS OPT-IN RATHER THAN A SWAP. The two stacks do not serve the
+// same surface. Comparing routes, the rebuild is missing sixteen that the
+// legacy server answers today, including:
+//
+//	POST /api/auth/register, POST /api/auth/login   (password auth —
+//	                                                 shipped and documented)
+//	GET  /health                                    (container/k8s probes)
+//	GET  /assistants/{id}/schemas, …/subgraphs      (declared in api.d2)
+//	POST /mcp
+//	the legacy poll-based worker protocol
+//
+// Flipping the default would silently delete those. So `--control-plane`
+// selects, the default stays legacy, and the gap is closed before the
+// default moves. Making it reachable is worth doing now regardless: an
+// opt-in path can be deployed, exercised, and fixed, whereas unreachable
+// code cannot.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	cpserver "github.com/duragraph/duragraph/controlplane/server"
+	"github.com/duragraph/duragraph/internal/config"
+)
+
+// controlPlaneFlag selects the implementation `serve` runs.
+var controlPlaneFlag string
+
+const (
+	controlPlaneLegacy = "legacy"
+	controlPlaneV2     = "v2"
+)
+
+func init() {
+	serveCmd.Flags().StringVar(&controlPlaneFlag, "control-plane", "",
+		`which control-plane implementation to run: "legacy" (default) or "v2".
+"v2" is the rebuilt control plane. It is not yet a drop-in replacement —
+password auth, /health, /mcp and the assistant schema/subgraph endpoints
+are not implemented there yet. Also settable via DURAGRAPH_CONTROL_PLANE.`)
+}
+
+// selectedControlPlane resolves the flag, falling back to the environment
+// and then to legacy. An unrecognised value is an error rather than a
+// silent fallback: someone who typed --control-plane=V2 and got the legacy
+// stack would have no way to tell.
+func selectedControlPlane() (string, error) {
+	v := controlPlaneFlag
+	if v == "" {
+		v = os.Getenv("DURAGRAPH_CONTROL_PLANE")
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", controlPlaneLegacy:
+		return controlPlaneLegacy, nil
+	case controlPlaneV2:
+		return controlPlaneV2, nil
+	default:
+		return "", fmt.Errorf(
+			"unknown --control-plane %q: expected %q or %q",
+			v, controlPlaneLegacy, controlPlaneV2)
+	}
+}
+
+// runServeV2 builds the rebuilt control plane from the same environment
+// configuration the legacy path reads, so switching implementations does
+// not also mean rewriting a deployment's config.
+func runServeV2(ctx context.Context, cfg *config.Config) error {
+	dsn := postgresDSN(cfg, cfg.Database.Database)
+
+	// The platform database holds users and tenants. The rebuild tolerates
+	// its absence (the auth/admin/platform groups then answer 500), so this
+	// is passed through rather than required — a single-tenant bootstrap
+	// should not need it.
+	platformDSN := os.Getenv("DURAGRAPH_PLATFORM_DSN")
+
+	// LISTEN/NOTIFY needs a session-affine connection, so it must not go
+	// through PgBouncer. RelayDSN is the escape hatch for pooler-fronted
+	// deployments; without one, the ordinary DSN is right for dev and for
+	// any deploy that talks to Postgres directly.
+	listenerDSN := cfg.Database.RelayDSN
+	if listenerDSN == "" {
+		listenerDSN = dsn
+	}
+
+	scfg := cpserver.Config{
+		Addr:        cfg.ServerAddr(),
+		TenantDSN:   dsn,
+		PlatformDSN: platformDSN,
+		NATSURL:     cfg.NATS.URL,
+		ListenerDSN: listenerDSN,
+		// Relays publish the event stream. They need JetStream, so they
+		// follow NATS being configured at all.
+		Relays: cfg.NATS.URL != "",
+		// Migrations are embedded in the binary and idempotent, so running
+		// them on every boot is safe and makes first boot work with no
+		// separate step.
+		Migrate: true,
+	}
+
+	slog.Info("starting rebuilt control plane",
+		"addr", scfg.Addr,
+		"nats", scfg.NATSURL != "",
+		"platform_db", scfg.PlatformDSN != "",
+	)
+
+	srv, err := cpserver.New(ctx, scfg)
+	if err != nil {
+		return fmt.Errorf("control plane: %w", err)
+	}
+	return srv.Run(ctx)
+}
+
+// postgresDSN renders the connection string for a database on the
+// configured host. Kept here so both serve paths agree on how the
+// discrete DB_* settings become a DSN.
+func postgresDSN(cfg *config.Config, database string) string {
+	return fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		cfg.Database.User, cfg.Database.Password,
+		cfg.Database.Host, cfg.Database.Port,
+		database, cfg.Database.SSLMode,
+	)
+}

--- a/cmd/duragraph/cmd/serve_controlplane_test.go
+++ b/cmd/duragraph/cmd/serve_controlplane_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import "testing"
+
+// TestSelectedControlPlane covers the switch that decides which control
+// plane `serve` runs. The default must stay legacy: the rebuilt stack does
+// not yet serve password auth, /health, /mcp or the assistant
+// schema/subgraph endpoints, so defaulting to it would silently drop
+// routes that deployments depend on.
+func TestSelectedControlPlane(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		env     string
+		want    string
+		wantErr bool
+	}{
+		{name: "unset defaults to legacy", want: controlPlaneLegacy},
+		{name: "explicit legacy", flag: "legacy", want: controlPlaneLegacy},
+		{name: "explicit v2", flag: "v2", want: controlPlaneV2},
+		{name: "case insensitive", flag: "V2", want: controlPlaneV2},
+		{name: "surrounding space", flag: "  v2 ", want: controlPlaneV2},
+		{name: "env selects v2", env: "v2", want: controlPlaneV2},
+		{name: "flag beats env", flag: "legacy", env: "v2", want: controlPlaneLegacy},
+		{name: "empty env is legacy", env: "", want: controlPlaneLegacy},
+
+		// A typo must be loud. Falling back to legacy would leave the
+		// operator watching the stack they were trying to replace, with
+		// nothing in the output to explain why.
+		{name: "unknown value errors", flag: "v3", wantErr: true},
+		{name: "near miss errors", flag: "leagcy", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := controlPlaneFlag
+			controlPlaneFlag = tc.flag
+			defer func() { controlPlaneFlag = old }()
+			t.Setenv("DURAGRAPH_CONTROL_PLANE", tc.env)
+
+			got, err := selectedControlPlane()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want an error for %q, got %q", tc.flag, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/controlplane/db/embed.go
+++ b/controlplane/db/embed.go
@@ -1,0 +1,37 @@
+// Package db carries the control-plane's SQL migrations as embedded
+// files.
+//
+// They are embedded rather than read from disk because the shipped
+// artifact is a single binary. `controlplane/server` previously defaulted
+// to reading "controlplane/db/migrations" relative to the process working
+// directory — a path that exists in a source checkout and nowhere else, so
+// an installed binary (Homebrew, a container, anything run from $HOME)
+// could not migrate at all. Tests never noticed: they set Migrate:false and
+// applied the SQL themselves.
+//
+// go:embed only reads files at or below the package directory, which is
+// why this file lives at controlplane/db rather than next to the server.
+package db
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed migrations
+var migrationsFS embed.FS
+
+// FS returns the migration tree rooted so that "tenant" and "platform"
+// are its top-level directories — the same shape os.DirFS over
+// controlplane/db/migrations gives, so callers can treat an embedded and
+// an on-disk tree identically.
+func FS() fs.FS {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		// Unreachable: the embed directive above guarantees the path.
+		// A panic here means the tree was restructured without updating
+		// this file, which is a build-time mistake, not a runtime one.
+		panic("controlplane/db: migrations subtree missing: " + err.Error())
+	}
+	return sub
+}

--- a/controlplane/server/migrate.go
+++ b/controlplane/server/migrate.go
@@ -13,51 +13,161 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/duragraph/duragraph/controlplane/db"
 )
 
-// ApplyMigrations runs every *.up.sql in dir against pool, in lexical
-// order (the rebuild's migrations are zero-padded NN_name.up.sql so
-// lexical == numeric). Idempotent only insofar as the SQL itself is —
-// migrations use CREATE TABLE (no IF NOT EXISTS) so a second run on a
-// non-empty DB errors out, which is the correct behaviour for a
-// first-boot vs upgrade decision (the relay/event-store doesn't yet
-// track schema_version).
+// migrationsTable records which migrations have run.
 //
-// Mirrors the applyTenantMigrations helpers in the endpoints +
-// controlplane/nats test files; this is the production version that
-// runs from disk paths resolved at startup.
+// Without it every restart re-executed 001, hit "relation already
+// exists" on a plain CREATE TABLE, and the process refused to start. The
+// server could be started exactly once per database. No test caught it
+// because every test either sets Migrate:false or gets a fresh container,
+// which is precisely the shape of bug that only appears in production.
+const migrationsTable = `
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version     TEXT PRIMARY KEY,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+)`
+
+// ApplyMigrations runs every *.up.sql under dir against pool. It is a
+// thin wrapper over ApplyMigrationsFS for callers that genuinely have a
+// directory — tests pointing at a checkout, or an operator overriding
+// MigrateDir. Production uses the embedded tree.
 func ApplyMigrations(ctx context.Context, pool *pgxpool.Pool, dir string) error {
+	if _, err := os.Stat(dir); err != nil {
+		return fmt.Errorf("migrate: stat %q: %w", dir, err)
+	}
+	return ApplyMigrationsFS(ctx, pool, os.DirFS(dir))
+}
+
+// ApplyMigrationsFS runs every *.up.sql at the root of fsys against pool
+// in lexical order (migrations are zero-padded NN_name.up.sql, so lexical
+// equals numeric).
+//
+// It is IDEMPOTENT, which the previous version was not. Each migration is
+// applied inside its own transaction together with the row recording it,
+// so a migration and the fact of that migration commit or roll back as
+// one — a crash between the two cannot leave the database claiming work
+// it did not do, or hide work it did. Already-recorded versions are
+// skipped, so a restart is a no-op rather than a fatal error.
+//
+// One transaction per migration rather than one for all of them: Postgres
+// rolls back the entire transaction on any error, so a single wrapping
+// transaction would discard successful earlier migrations and re-run them
+// next boot. Per-migration means a failure at 004 leaves 001-003 durably
+// applied and recorded, and the next start resumes at 004.
+func ApplyMigrationsFS(ctx context.Context, pool *pgxpool.Pool, fsys fs.FS) error {
 	if pool == nil {
 		return errors.New("migrate: nil pool")
 	}
-	entries, err := os.ReadDir(dir)
+	entries, err := fs.ReadDir(fsys, ".")
 	if err != nil {
-		return fmt.Errorf("migrate: read dir %q: %w", dir, err)
+		return fmt.Errorf("migrate: read migrations: %w", err)
 	}
 	var ups []string
 	for _, e := range entries {
-		if strings.HasSuffix(e.Name(), ".up.sql") {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".up.sql") {
 			ups = append(ups, e.Name())
 		}
 	}
 	sort.Strings(ups)
 	if len(ups) == 0 {
-		return fmt.Errorf("migrate: no *.up.sql migrations found in %q", dir)
+		return errors.New("migrate: no *.up.sql migrations found")
 	}
+
+	if _, err := pool.Exec(ctx, migrationsTable); err != nil {
+		return fmt.Errorf("migrate: ensure schema_migrations: %w", err)
+	}
+
+	applied, err := appliedVersions(ctx, pool)
+	if err != nil {
+		return err
+	}
+
 	for _, name := range ups {
-		sqlBytes, err := os.ReadFile(filepath.Join(dir, name))
+		version := strings.TrimSuffix(name, ".up.sql")
+		if applied[version] {
+			continue
+		}
+		sqlBytes, err := fs.ReadFile(fsys, name)
 		if err != nil {
 			return fmt.Errorf("migrate: read %s: %w", name, err)
 		}
-		if _, err := pool.Exec(ctx, string(sqlBytes)); err != nil {
-			return fmt.Errorf("migrate: apply %s: %w", name, err)
+		if err := applyOne(ctx, pool, version, string(sqlBytes)); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// appliedVersions reads the set of migrations already recorded.
+func appliedVersions(ctx context.Context, pool *pgxpool.Pool) (map[string]bool, error) {
+	rows, err := pool.Query(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		return nil, fmt.Errorf("migrate: read schema_migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("migrate: scan schema_migrations: %w", err)
+		}
+		applied[v] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("migrate: iterate schema_migrations: %w", err)
+	}
+	return applied, nil
+}
+
+// applyOne runs a single migration and records it in the same
+// transaction, so the schema change and the claim that it happened share
+// one fate.
+func applyOne(ctx context.Context, pool *pgxpool.Pool, version, sql string) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("migrate: begin %s: %w", version, err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op once committed
+
+	if _, err := tx.Exec(ctx, sql); err != nil {
+		return fmt.Errorf("migrate: apply %s: %w", version, err)
+	}
+	// ON CONFLICT DO NOTHING covers two servers booting against the same
+	// fresh database at once. The loser's INSERT is a no-op rather than a
+	// unique-violation that would crash an otherwise healthy process.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING`,
+		version); err != nil {
+		return fmt.Errorf("migrate: record %s: %w", version, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("migrate: commit %s: %w", version, err)
+	}
+	return nil
+}
+
+// migrationRoot resolves where migrations come from.
+//
+// The embedded tree is the default so the server works from any working
+// directory — the shipped binary has no source checkout to read. An
+// explicit MigrateDir still wins, for an operator who needs to apply SQL
+// this build does not carry.
+func migrationRoot(dir string) (fs.FS, error) {
+	if dir == "" {
+		return db.FS(), nil
+	}
+	if _, err := os.Stat(dir); err != nil {
+		return nil, fmt.Errorf("MigrateDir %q: %w", dir, err)
+	}
+	return os.DirFS(dir), nil
 }

--- a/controlplane/server/migrate_integration_test.go
+++ b/controlplane/server/migrate_integration_test.go
@@ -1,0 +1,222 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/duragraph/duragraph/controlplane/db"
+	dgserver "github.com/duragraph/duragraph/controlplane/server"
+)
+
+// freshDatabase creates an empty database on the test container and
+// returns a DSN for it. Migrations have to be exercised against a
+// database that has never seen them, which the shared TestMain one has.
+func freshDatabase(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	admin, err := pgxpool.New(ctx, tenantDSN)
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	defer admin.Close()
+
+	name := fmt.Sprintf("mig_%d", time.Now().UnixNano())
+	if _, err := admin.Exec(ctx, "CREATE DATABASE "+name); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	u, err := url.Parse(tenantDSN)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	u.Path = "/" + name
+	return u.String()
+}
+
+func tenantMigrations(t *testing.T) fs.FS {
+	t.Helper()
+	sub, err := fs.Sub(db.FS(), "tenant")
+	if err != nil {
+		t.Fatalf("tenant subtree: %v", err)
+	}
+	return sub
+}
+
+// TestMigrationsAreIdempotent is the regression test for a bug that made
+// the rebuilt control plane unable to restart.
+//
+// Migrations use plain CREATE TABLE and nothing recorded which had run,
+// so the second boot against the same database re-executed 001, hit
+// "relation already exists", and the process refused to start. The server
+// could be started exactly once per database. Every test set
+// Migrate:false or got a fresh container, so nothing caught it — the
+// failure was reachable only by restarting a real deployment.
+func TestMigrationsAreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	dsn := freshDatabase(t, ctx)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	migrations := tenantMigrations(t)
+
+	if err := dgserver.ApplyMigrationsFS(ctx, pool, migrations); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	var afterFirst int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM schema_migrations`).Scan(&afterFirst); err != nil {
+		t.Fatal(err)
+	}
+	if afterFirst == 0 {
+		t.Fatal("first apply recorded no migrations")
+	}
+
+	// THE BUG: this second call used to fail with "relation already exists".
+	if err := dgserver.ApplyMigrationsFS(ctx, pool, migrations); err != nil {
+		t.Fatalf("second apply must be a no-op, got: %v", err)
+	}
+
+	var afterSecond int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM schema_migrations`).Scan(&afterSecond); err != nil {
+		t.Fatal(err)
+	}
+	if afterSecond != afterFirst {
+		t.Errorf("second apply changed the recorded set: %d -> %d", afterFirst, afterSecond)
+	}
+
+	// A third, to catch anything that only breaks once state exists.
+	if err := dgserver.ApplyMigrationsFS(ctx, pool, migrations); err != nil {
+		t.Fatalf("third apply: %v", err)
+	}
+
+	// The schema is really there, not merely claimed.
+	for _, table := range []string{"events", "outbox", "assistants", "threads", "runs"} {
+		var exists bool
+		if err := pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+			                WHERE table_schema='public' AND table_name=$1)`,
+			table).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Errorf("table %q missing after migrations", table)
+		}
+	}
+}
+
+// TestMigrationsRecordEveryVersion pins the recorded name to the file
+// name. If a migration were recorded under a different key than the one
+// the skip-check computes, every boot would re-run it — the original bug
+// wearing a bookkeeping table as a disguise.
+func TestMigrationsRecordEveryVersion(t *testing.T) {
+	ctx := context.Background()
+	dsn := freshDatabase(t, ctx)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	migrations := tenantMigrations(t)
+	if err := dgserver.ApplyMigrationsFS(ctx, pool, migrations); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	entries, err := fs.ReadDir(migrations, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			want[strings.TrimSuffix(e.Name(), ".up.sql")] = true
+		}
+	}
+	if len(want) == 0 {
+		t.Fatal("no migrations found in the embedded tree")
+	}
+
+	rows, err := pool.Query(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	got := map[string]bool{}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatal(err)
+		}
+		got[v] = true
+	}
+	for v := range want {
+		if !got[v] {
+			t.Errorf("migration %q ran but was not recorded", v)
+		}
+	}
+	for v := range got {
+		if !want[v] {
+			t.Errorf("recorded %q which is not a migration file", v)
+		}
+	}
+}
+
+// TestEmbeddedMigrationsAreComplete guards the go:embed directive. A
+// mistyped pattern yields an empty tree that fails only at deploy time,
+// so assert the shape here where it is cheap.
+func TestEmbeddedMigrationsAreComplete(t *testing.T) {
+	for _, dir := range []string{"tenant", "platform"} {
+		sub, err := fs.Sub(db.FS(), dir)
+		if err != nil {
+			t.Fatalf("%s subtree: %v", dir, err)
+		}
+		entries, err := fs.ReadDir(sub, ".")
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		var ups int
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".up.sql") {
+				ups++
+			}
+		}
+		if ups == 0 {
+			t.Errorf("embedded %s tree carries no *.up.sql migrations", dir)
+		}
+	}
+}
+
+// TestServerMigratesOnBootTwice is the end-to-end form: the composition
+// root itself, with Migrate:true, started twice against one database.
+// This is what a restart does, and what used to fail.
+func TestServerMigratesOnBootTwice(t *testing.T) {
+	ctx := context.Background()
+	dsn := freshDatabase(t, ctx)
+
+	for i := 1; i <= 2; i++ {
+		srv, err := dgserver.New(ctx, dgserver.Config{
+			Addr:      "127.0.0.1:0",
+			TenantDSN: dsn,
+			Migrate:   true, // embedded tree; no MigrateDir, no CWD dependency
+			// Nothing is in flight; do not sit through the default drain.
+			DrainTimeout: 2 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("boot %d: %v", i, err)
+		}
+		if err := srv.Shutdown(ctx); err != nil {
+			t.Fatalf("boot %d shutdown: %v", i, err)
+		}
+	}
+}

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -13,11 +13,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -34,7 +34,6 @@ import (
 const (
 	DefaultAddr         = ":8081"
 	DefaultDrainTimeout = 15 * time.Second
-	DefaultMigrateDir   = "controlplane/db/migrations"
 )
 
 // Config carries the runtime knobs the composition root needs. Zero
@@ -86,9 +85,13 @@ type Config struct {
 	// pooler-fronted production deploy.
 	ListenerDSN string
 
-	// MigrateDir is the parent dir holding tenant/ + platform/
-	// subdirectories of *.up.sql migrations. Default
-	// controlplane/db/migrations (resolved relative to CWD at runtime).
+	// MigrateDir overrides where migrations are read from: a parent dir
+	// holding tenant/ + platform/ subdirectories of *.up.sql files.
+	//
+	// EMPTY IS THE NORMAL CASE and means the migrations embedded in the
+	// binary (controlplane/db). This used to default to a source-tree
+	// path resolved against the process working directory, which meant an
+	// installed binary could not migrate at all.
 	MigrateDir string
 
 	// Migrate controls whether ApplyMigrations runs on startup. Default
@@ -111,9 +114,6 @@ func (c *Config) defaults() {
 	}
 	if c.DrainTimeout == 0 {
 		c.DrainTimeout = DefaultDrainTimeout
-	}
-	if c.MigrateDir == "" {
-		c.MigrateDir = DefaultMigrateDir
 	}
 }
 
@@ -187,14 +187,22 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 
 	// --- migrations ---
 	if cfg.Migrate {
-		tenantDir := filepath.Join(cfg.MigrateDir, "tenant")
-		if err := ApplyMigrations(ctx, s.tenant, tenantDir); err != nil {
+		root, err := migrationRoot(cfg.MigrateDir)
+		if err != nil {
+			s.Close()
+			return nil, fmt.Errorf("server: migrations: %w", err)
+		}
+		tenantFS, err := fs.Sub(root, "tenant")
+		if err != nil {
 			s.Close()
 			return nil, fmt.Errorf("server: tenant migrations: %w", err)
 		}
-		platDir := filepath.Join(cfg.MigrateDir, "platform")
-		if _, err := os.Stat(platDir); err == nil && s.plat != nil {
-			if err := ApplyMigrations(ctx, s.plat, platDir); err != nil {
+		if err := ApplyMigrationsFS(ctx, s.tenant, tenantFS); err != nil {
+			s.Close()
+			return nil, fmt.Errorf("server: tenant migrations: %w", err)
+		}
+		if platFS, err := fs.Sub(root, "platform"); err == nil && s.plat != nil {
+			if err := ApplyMigrationsFS(ctx, s.plat, platFS); err != nil {
 				s.Close()
 				return nil, fmt.Errorf("server: platform migrations: %w", err)
 			}

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -7,6 +7,11 @@ RUN go mod download
 
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
+# controlplane/ is the rebuilt control plane. cmd/ imports it for
+# `serve --control-plane=v2`, so omitting it here breaks the build
+# outright rather than degrading — this COPY list is an allowlist, and a
+# new top-level package that cmd depends on has to be added to it.
+COPY controlplane/ ./controlplane/
 # embeds.go (//go:embed all:dashboard/dist) lives at module root. The
 # dist/ tree ships with a placeholder index.html so the build works
 # without pnpm; production images use Dockerfile.server which actually


### PR DESCRIPTION
Until now, `go list -deps ./cmd/duragraph` contained **no controlplane package at all**. GoReleaser builds `./cmd/duragraph` and nothing else, so every release — **v0.8.0 included** — shipped the legacy `internal/` stack while the rebuild rode along as dead weight, reachable only from tests. A user installing via Homebrew got none of it.

Three things had to be true for the rebuild to run from a binary.

## 1. Migrations had to be embedded

`controlplane/server` defaulted `MigrateDir` to `"controlplane/db/migrations"`, resolved against the process working directory — a path that exists in a source checkout and **nowhere else**. They're now embedded in `controlplane/db`, which is also why `MigrateDir` no longer has a default: an explicit directory still wins, but the normal case carries its own SQL.

## 2. Migrations had to be idempotent — this is the bug that mattered

The SQL uses plain `CREATE TABLE` and **nothing recorded what had run**, so the second boot against a database re-executed `001`, hit `relation "event_streams" already exists`, and the process refused to start. **The server could be started exactly once per database.**

Nothing caught it because every test either sets `Migrate:false` or gets a fresh container. The failure was reachable only by restarting a real deployment — which no test does, and no release ever could, since the code was unreachable.

Each migration now applies inside **one transaction together with the row recording it**, so a migration and the claim that it happened commit or roll back as one. Per-migration rather than one wrapping transaction: Postgres discards the whole transaction on error, so a single one would undo successful earlier migrations and re-run them next boot. A failure at `004` now leaves `001`–`003` durably applied and resumes there.

## 3. It had to be selectable without breaking anyone

The two stacks **do not serve the same surface**. The rebuild is missing sixteen routes the legacy server answers today:

- `POST /api/auth/register`, `POST /api/auth/login` — password auth, shipped and documented in the 0.8.0 changelog
- `GET /health` — container/k8s probes
- `POST /mcp`, `GET /assistants/{id}/schemas`, `…/subgraphs`
- the legacy poll-based worker protocol

Flipping the default would delete those silently. So `--control-plane` selects, **legacy stays the default**, and the gap gets closed before the default moves. An unknown value is an error rather than a fallback — someone who typed `--control-plane=V3` and silently got legacy would have nothing to explain why.

## Verification

Tests: migrations applied two and three times over are no-ops; every version is recorded under the key the skip-check computes (a mismatch would re-run everything forever *while looking fixed*); the embedded tree is non-empty for both subtrees; and the composition root itself boots twice against one database.

**I confirmed these bite** rather than assuming — making `appliedVersions` return an empty set fails both with exactly the production symptom, `relation "event_streams" already exists`.

Also verified outside the test suite, with the built binary run from a directory containing no source tree:

```
/ok  -> 200 {"status":"ok"}
/info -> {"git_sha":"none","uptime_seconds":1,"version":"dev"}
relay: LISTEN established  channel=outbox_new
```

17 tables created, all 8 migrations recorded, and **three consecutive boots against the same database** — the thing that was previously impossible.

One note on the full suite: `controlplane/worker` and `tests/smoke` can fail together with `bind: address already in use` when the whole tree runs in parallel — testcontainer port collisions, not a regression. Both pass with `-p 1`.

`[spec-skip]` impl-only. No API, schema, or wire change; the rebuilt surface is unchanged, only *reachable*.