### PR TITLE
feat(controlplane): serve the embedded dashboard UI

### DIFF
--- a/controlplane/server/dashboard_integration_test.go
+++ b/controlplane/server/dashboard_integration_test.go
@@ -1,0 +1,193 @@
+package server_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	dgserver "github.com/duragraph/duragraph/controlplane/server"
+)
+
+// stubDashboard stands in for the built React app. Using a synthetic
+// filesystem rather than the real embed keeps these assertions about
+// routing, which is what the bug was — the real dashboard/dist carries a
+// placeholder index.html in git, so its contents prove nothing either way.
+func stubDashboard() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html":      &fstest.MapFile{Data: []byte("<html>DASHBOARD</html>")},
+		"assets/app.js":   &fstest.MapFile{Data: []byte("console.log(1)")},
+		"favicon.svg":     &fstest.MapFile{Data: []byte("<svg/>")},
+		"nested/page.txt": &fstest.MapFile{Data: []byte("nested")},
+	}
+}
+
+// startDashboardServer boots a control plane with the stub UI mounted and
+// returns its base URL.
+func startDashboardServer(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	addr, err := freeAddr()
+	if err != nil {
+		t.Fatalf("free addr: %v", err)
+	}
+	srv, err := dgserver.New(ctx, dgserver.Config{
+		Addr:         addr,
+		TenantDSN:    tenantDSN,
+		Migrate:      false, // applied once in TestMain
+		DashboardFS:  stubDashboard(),
+		DrainTimeout: 1 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("server: %v", err)
+	}
+	t.Cleanup(func() { srv.Close() })
+
+	go func() { _ = srv.Run(ctx) }()
+	waitForListen(t, addr)
+	return "http://" + addr
+}
+
+func get(t *testing.T, url string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestDashboardIsServed is the regression test for the gap this closes:
+// the rebuilt control plane mounted no static UI at all, so it answered
+// the API and nothing at "/". A route-by-route diff against the legacy
+// server could not surface it, because the dashboard is not a route.
+func TestDashboardIsServed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	base := startDashboardServer(t, ctx)
+
+	t.Run("root serves index.html", func(t *testing.T) {
+		code, body := get(t, base+"/")
+		if code != http.StatusOK {
+			t.Fatalf("GET /: want 200, got %d", code)
+		}
+		if !strings.Contains(body, "DASHBOARD") {
+			t.Errorf("GET / did not serve the dashboard: %q", body)
+		}
+	})
+
+	t.Run("static assets are served", func(t *testing.T) {
+		code, body := get(t, base+"/assets/app.js")
+		if code != http.StatusOK {
+			t.Fatalf("want 200, got %d", code)
+		}
+		if !strings.Contains(body, "console.log") {
+			t.Errorf("asset body wrong: %q", body)
+		}
+	})
+
+	t.Run("unknown path falls back to index.html for client routing", func(t *testing.T) {
+		// TanStack Router owns these paths in the browser; the server has
+		// to hand back the shell rather than 404, or a deep link breaks.
+		for _, p := range []string{"/playground", "/builder", "/deployments", "/inspector"} {
+			code, body := get(t, base+p)
+			if code != http.StatusOK {
+				t.Errorf("GET %s: want 200, got %d", p, code)
+				continue
+			}
+			if !strings.Contains(body, "DASHBOARD") {
+				t.Errorf("GET %s did not fall back to the SPA shell", p)
+			}
+		}
+	})
+}
+
+// TestDashboardDoesNotShadowTheAPI pins the boundary between the SPA
+// catch-all and the API.
+//
+// Note what this does NOT test: registration order. Echo prefers static
+// and parameterised routes over a catch-all whichever order they are
+// registered in — mounting the dashboard before the API still leaves
+// every API route reachable, which I confirmed rather than assumed.
+//
+// What it does catch is the handler's /api/ guard. Without it an
+// unmatched /api/... path returns 200 and the SPA shell to a client
+// expecting JSON, which is considerably more confusing than a 404.
+func TestDashboardDoesNotShadowTheAPI(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	base := startDashboardServer(t, ctx)
+
+	t.Run("system routes still answer", func(t *testing.T) {
+		for _, p := range []string{"/ok", "/info"} {
+			code, body := get(t, base+p)
+			if code != http.StatusOK {
+				t.Errorf("GET %s: want 200, got %d", p, code)
+			}
+			if strings.Contains(body, "DASHBOARD") {
+				t.Errorf("GET %s was swallowed by the SPA catch-all", p)
+			}
+		}
+	})
+
+	t.Run("api routes still answer", func(t *testing.T) {
+		code, body := get(t, base+"/api/v1/assistants/count")
+		if strings.Contains(body, "DASHBOARD") {
+			t.Fatalf("GET /api/v1/assistants/count served the SPA shell (status %d)", code)
+		}
+		// The status depends on request validation; what matters is that a
+		// real handler answered rather than the catch-all.
+		if code == http.StatusNotFound {
+			t.Errorf("assistants/count returned 404 — route not reached")
+		}
+	})
+
+	t.Run("unmatched api paths get a clean 404, not the SPA", func(t *testing.T) {
+		code, body := get(t, base+"/api/v1/definitely-not-a-route")
+		if code != http.StatusNotFound {
+			t.Errorf("want 404, got %d", code)
+		}
+		if strings.Contains(body, "DASHBOARD") {
+			t.Error("unmatched /api/ path fell through to the SPA shell")
+		}
+	})
+}
+
+// TestDashboardAbsentDoesNotBlockTheAPI: a control plane with no usable UI
+// must still serve. Failing to boot over a missing dashboard would turn a
+// cosmetic problem into an outage for a headless deployment.
+func TestDashboardAbsentDoesNotBlockTheAPI(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr, err := freeAddr()
+	if err != nil {
+		t.Fatalf("free addr: %v", err)
+	}
+	srv, err := dgserver.New(ctx, dgserver.Config{
+		Addr:      addr,
+		TenantDSN: tenantDSN,
+		Migrate:   false,
+		// No index.html — mounting must fail, and be survivable.
+		DashboardFS:  fstest.MapFS{"readme.txt": &fstest.MapFile{Data: []byte("x")}},
+		DrainTimeout: 1 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("server must start without a usable dashboard: %v", err)
+	}
+	defer srv.Close()
+
+	go func() { _ = srv.Run(ctx) }()
+	waitForListen(t, addr)
+
+	base := "http://" + addr
+	code, _ := get(t, base+"/ok")
+	if code != http.StatusOK {
+		t.Errorf("API must serve without a dashboard: /ok returned %d", code)
+	}
+}

--- a/controlplane/server/server.go
+++ b/controlplane/server/server.go
@@ -22,10 +22,12 @@ import (
 	"syscall"
 	"time"
 
+	duragraph "github.com/duragraph/duragraph"
 	"github.com/duragraph/duragraph/controlplane/cron"
 	"github.com/duragraph/duragraph/controlplane/endpoints"
 	"github.com/duragraph/duragraph/controlplane/nats"
 	"github.com/duragraph/duragraph/controlplane/reaper"
+	"github.com/duragraph/duragraph/internal/infrastructure/http/dashboard"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 )
@@ -102,6 +104,12 @@ type Config struct {
 	// Default false; set true when NATSURL is non-empty to enable
 	// event publishing.
 	Relays bool
+
+	// DashboardFS overrides the embedded React UI. Nil — the normal case —
+	// serves the dashboard embedded in the binary. Supplying one lets a
+	// deployment ship its own build, and lets tests assert routing without
+	// depending on whether pnpm ran.
+	DashboardFS fs.FS
 
 	// DrainTimeout caps how long Shutdown waits for in-flight HTTP
 	// requests + relay goroutines to drain. Default 15s.
@@ -320,7 +328,49 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 
 	ep.RegisterSystem(e) // root-level: /ok, /info, /metrics
 
+	// The embedded React dashboard. Without it the rebuilt control plane
+	// serves the API and nothing at "/" — the entire UI missing, which a
+	// route-by-route diff against the legacy server cannot surface because
+	// the dashboard is not a route.
+	//
+	// Mounted last to mirror the legacy server, but NOT because ordering is
+	// load-bearing: Echo's radix router prefers static and parameterised
+	// routes over a catch-all regardless of registration order, and mounting
+	// this first leaves every API route reachable (verified). The legacy
+	// comment claims otherwise; it is wrong on this point.
+	//
+	// What IS load-bearing is the /api/ guard inside the handler, which
+	// turns an unmatched /api/... path into a clean 404 instead of serving
+	// the SPA shell to a client expecting JSON.
+	if err := mountDashboard(e, cfg.DashboardFS); err != nil {
+		// A missing UI must not stop the control plane from serving the
+		// API — an operator running headless is a legitimate deployment,
+		// and failing here would turn a cosmetic problem into an outage.
+		slog.Warn("dashboard not mounted; API-only", "err", err)
+	}
+
 	return s, nil
+}
+
+// mountDashboard serves the embedded UI, or the caller's filesystem when
+// one is supplied (tests, and any deployment shipping its own build).
+func mountDashboard(e *echo.Echo, override fs.FS) error {
+	distFS := override
+	if distFS == nil {
+		var err error
+		distFS, err = duragraph.DashboardFS()
+		if err != nil {
+			return fmt.Errorf("embedded dashboard: %w", err)
+		}
+	}
+	// A placeholder index.html ships in git so `go build` works without
+	// pnpm, so the tree existing does not prove the UI was built. Checking
+	// for index.html at least distinguishes "no UI" from "broken embed".
+	if _, err := fs.Stat(distFS, "index.html"); err != nil {
+		return fmt.Errorf("dashboard index.html: %w", err)
+	}
+	dashboard.Register(e, distFS)
+	return nil
 }
 
 // Run blocks until ctx is canceled or a SIGINT/SIGTERM arrives, then


### PR DESCRIPTION
Closes #250.

The rebuilt control plane mounted **no static UI at all**. `serve --control-plane=v2` answered the API and returned nothing at `/` — the entire React dashboard absent.

A route-by-route diff against the legacy server couldn't surface this, because the dashboard **isn't a route**; it's a catch-all under everything else. That's why it went unnoticed until after the surface comparison in #249 was already written.

## Approach

Reuses `internal/infrastructure/http/dashboard` rather than moving or duplicating it. The handler is already generic — it takes an `fs.FS` and an `*echo.Echo` — and `controlplane/` **already** imports `internal/infrastructure/auth` for exactly this kind of shared primitive, so this follows existing practice rather than introducing a new coupling.

`DashboardFS` on `Config` overrides the embedded build. Nil (the normal case) serves the UI embedded in the binary; supplying one lets a deployment ship its own build, and lets tests assert routing without depending on whether `pnpm` has run — the committed `dashboard/dist/index.html` is a *"not built"* placeholder, so the real tree proves nothing on its own.

A missing or unusable dashboard **logs a warning and leaves the API serving**. Failing to boot would turn a cosmetic problem into an outage, and running headless is a legitimate configuration.

## A claim I made and then disproved

I first wrote that the dashboard must mount last or its catch-all would shadow the API — echoing the comment in the legacy server:

> `// Must be registered after API routes so Echo's router prioritises exact /api/v1/... matches over the wildcard.`

**I probed it by mounting the dashboard before every API route. The whole API stayed reachable.** Echo's radix router prefers static and parameterised routes over a catch-all whichever order they're registered in. Ordering is not load-bearing here, and the legacy comment is wrong on that point. It still mounts last to mirror legacy, but the comment now says that's a convention, not a requirement.

What *is* load-bearing is the handler's `/api/` guard, so the tests were rewritten to target that instead. Removing it makes an unmatched `/api/...` path return `200` and the SPA shell to a client expecting JSON — the test then fails with `want 404, got 200`.

That probe was wrong twice before it was right — once editing a filename that didn't exist, so the suite passed **without testing anything**. The probe now verifies the edit applied before the result is believed.

## Verified beyond the suite

With a real `pnpm -C dashboard build`, against the built binary:

```
GET /              -> 200  <title>dashboard      (real build, not the placeholder)
GET /playground    -> 200  SPA deep-link fallback
GET /assets/index-CSWZNAA3.js -> 200
GET /ok            -> {"status":"ok"}
GET /api/v1/nope   -> 404  (not the SPA shell)
```

Build artifacts are not committed — `dashboard/dist/` is restored to the placeholder.