### PR TITLE
feat(controlplane): email + password authentication

### DIFF
--- a/controlplane/db/migrations/platform/004_user_password.down.sql
+++ b/controlplane/db/migrations/platform/004_user_password.down.sql
@@ -1,0 +1,20 @@
+-- Reverses 004_user_password.
+--
+-- Password-only users are deleted: without password_hash they would be
+-- rows with no way to authenticate at all. That is destructive and
+-- deliberate — a password-only account cannot be represented in the
+-- pre-004 schema, so there is no lossless way down.
+--
+-- The oauth columns are left nullable because 001 declared them that
+-- way; this migration never changed them.
+
+DROP INDEX IF EXISTS idx_users_lower_email;
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_at_least_one_auth_method;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_auth_method_check;
+
+DELETE FROM users WHERE oauth_provider IS NULL;
+
+ALTER TABLE users
+    DROP COLUMN IF EXISTS password_hash,
+    DROP COLUMN IF EXISTS auth_method;

--- a/controlplane/db/migrations/platform/004_user_password.up.sql
+++ b/controlplane/db/migrations/platform/004_user_password.up.sql
@@ -1,0 +1,53 @@
+-- 004_user_password.up.sql: email + password authentication.
+--
+-- 001_platform created users for OAuth only: oauth_provider and oauth_id
+-- are NOT NULL, and there is nowhere to put a password. Password auth
+-- needs both relaxed and a hash column.
+--
+-- Decisions:
+--
+-- 1. oauth_provider / oauth_id are ALREADY nullable in 001, and the
+--    unique index there is restricted to `WHERE oauth_provider IS NOT
+--    NULL`, so password-only rows neither violate it nor collide on it.
+--    No ALTER is needed for that — the equivalent legacy migration
+--    (internal/.../005_user_password) does drop NOT NULL, because the
+--    legacy schema declared it; this one does not.
+--
+-- 2. password_hash is NULLABLE — OAuth-only users have none. It holds a
+--    bcrypt digest, never a plaintext or reversible encoding.
+--
+-- 3. auth_method defaults to 'oauth' so rows written before this
+--    migration keep their meaning without a backfill.
+--
+-- 4. A row must carry at least one way to authenticate. Without this a
+--    bug could insert a user with neither an OAuth identity nor a
+--    password — an account nobody can ever sign in to, and which no
+--    login path would report as broken.
+--
+--    NOTE: this CHECK is validated against existing rows, so the
+--    migration fails if any user already has neither. Both code paths
+--    that insert users set one or the other (auth.go sets oauth_provider,
+--    auth_password.go sets password_hash), so such a row can only come
+--    from manual insertion — and it is an account that cannot be used.
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS password_hash TEXT NULL,
+    ADD COLUMN IF NOT EXISTS auth_method   VARCHAR(20) NOT NULL DEFAULT 'oauth';
+
+ALTER TABLE users
+    ADD CONSTRAINT users_auth_method_check
+    CHECK (auth_method IN ('oauth', 'password'));
+
+ALTER TABLE users
+    ADD CONSTRAINT users_at_least_one_auth_method
+    CHECK (oauth_provider IS NOT NULL OR password_hash IS NOT NULL);
+
+-- Login matches on LOWER(email) so addresses differing only in case
+-- resolve to one account. The UNIQUE constraint from 001 is
+-- case-SENSITIVE, so this index is both the lookup path and the thing
+-- that makes case-insensitive matching affordable.
+--
+-- Note this index is not UNIQUE: making it so would fail on any existing
+-- pair of rows differing only by case. Registration guards against new
+-- case-duplicates instead (see AuthRegister).
+CREATE INDEX IF NOT EXISTS idx_users_lower_email ON users (LOWER(email));

--- a/controlplane/endpoints/auth.go
+++ b/controlplane/endpoints/auth.go
@@ -322,34 +322,7 @@ func (s *Server) insertIdentity(ctx context.Context, provider, oauthID, email st
 		}
 		out.TenantID = &tid
 
-		evs := make([]eventstore.Event, 0, len(events))
-		for _, et := range events {
-			if strings.HasPrefix(et, "user.") {
-				evs = append(evs, eventstore.Event{
-					AggregateType: "User",
-					AggregateID:   out.ID,
-					EventType:     et,
-					Payload: mustJSON(map[string]any{
-						"user_id": out.ID.String(),
-						"email":   email,
-						"role":    role,
-						"status":  userStatus,
-					}),
-				})
-				continue
-			}
-			evs = append(evs, eventstore.Event{
-				AggregateType: "Tenant",
-				AggregateID:   tid,
-				EventType:     et,
-				Payload: mustJSON(map[string]any{
-					"tenant_id": tid.String(),
-					"user_id":   out.ID.String(),
-					"db_name":   dbName,
-				}),
-			})
-		}
-		return evs, nil
+		return platformSignupEvents(events, out.ID, tid, email, role, userStatus, dbName), nil
 	})
 	if err != nil {
 		return nil, err
@@ -453,4 +426,48 @@ func (s *Server) AuthRefresh(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, AuthRefreshResponse{Token: token, Exp: fresh.ExpiresAt.Unix()})
+}
+
+// platformSignupEvents builds the event set a new account emits, routing
+// each to the aggregate its name implies: user.* against the user,
+// everything else against the tenant.
+//
+// Shared by the OAuth callback and password registration so the two
+// cannot drift. That mattered enough to extract: if one path emitted a
+// different set, a consumer rebuilding state from the log would see
+// accounts that exist without having signed up, and the discrepancy would
+// depend on which door the user came in through.
+func platformSignupEvents(
+	events []string,
+	userID, tenantID uuid.UUID,
+	email, role, status, dbName string,
+) []eventstore.Event {
+	evs := make([]eventstore.Event, 0, len(events))
+	for _, et := range events {
+		if strings.HasPrefix(et, "user.") {
+			evs = append(evs, eventstore.Event{
+				AggregateType: "User",
+				AggregateID:   userID,
+				EventType:     et,
+				Payload: mustJSON(map[string]any{
+					"user_id": userID.String(),
+					"email":   email,
+					"role":    role,
+					"status":  status,
+				}),
+			})
+			continue
+		}
+		evs = append(evs, eventstore.Event{
+			AggregateType: "Tenant",
+			AggregateID:   tenantID,
+			EventType:     et,
+			Payload: mustJSON(map[string]any{
+				"tenant_id": tenantID.String(),
+				"user_id":   userID.String(),
+				"db_name":   dbName,
+			}),
+		})
+	}
+	return evs
 }

--- a/controlplane/endpoints/auth_gen.go
+++ b/controlplane/endpoints/auth_gen.go
@@ -11,6 +11,8 @@ import (
 func (s *Server) RegisterAuth(g *echo.Group) {
 	g.GET("/api/auth/:provider/login", s.AuthLogin)
 	g.GET("/api/auth/:provider/callback", s.AuthCallback)
+	g.POST("/api/auth/register", s.AuthRegister)
+	g.POST("/api/auth/login", s.AuthPasswordLogin)
 	g.POST("/api/auth/logout", s.AuthLogout)
 	g.POST("/api/auth/refresh", s.AuthRefresh)
 }
@@ -18,6 +20,10 @@ func (s *Server) RegisterAuth(g *echo.Group) {
 // AuthLogin — GET /api/auth/{provider}/login  (kind: special) — hand-written in auth.go
 
 // AuthCallback — GET /api/auth/{provider}/callback  (kind: write) — hand-written in auth.go
+
+// AuthRegister — POST /api/auth/register  (kind: write) — hand-written in auth.go
+
+// AuthPasswordLogin — POST /api/auth/login  (kind: special) — hand-written in auth.go
 
 // AuthLogout — POST /api/auth/logout  (kind: special) — hand-written in auth.go
 

--- a/controlplane/endpoints/auth_password.go
+++ b/controlplane/endpoints/auth_password.go
@@ -1,0 +1,314 @@
+// Email + password authentication for the rebuilt control plane.
+//
+// Kept beside the OAuth handlers rather than reusing the legacy
+// PasswordHandler (internal/infrastructure/http/handlers/auth): that type
+// is built on internal/application/command and its repository layer,
+// which would pull the whole legacy persistence stack into the rebuild.
+// What is genuinely shared is authpkg.IssueJWT — a pure function — so the
+// tokens minted here have exactly the shape the OAuth path produces and
+// the same middleware verifies them.
+//
+// Identity creation deliberately mirrors auth.go's callback: the same
+// bootstrap election, the same users+tenants insert, the same event set.
+// A user's rights must not depend on which door they came in through.
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/duragraph/duragraph/controlplane/eventstore"
+)
+
+const (
+	// minPasswordLength is the floor. Short passwords are the single
+	// largest contributor to credential stuffing success.
+	minPasswordLength = 8
+
+	// maxPasswordLength is bcrypt's hard limit, not a policy choice.
+	// bcrypt silently truncates at 72 BYTES, so a longer input would
+	// authenticate against only its first 72 bytes — two different
+	// passwords sharing a prefix would be the same credential. Rejecting
+	// is honest; truncating is a silent security downgrade.
+	maxPasswordLength = 72
+)
+
+type registerRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// authResponse is what both endpoints return. The token is echoed in the
+// body as well as the cookie so non-browser clients have something to
+// send as a Bearer credential.
+type authResponse struct {
+	UserID   string `json:"user_id"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+	Status   string `json:"status"`
+	TenantID string `json:"tenant_id,omitempty"`
+	Token    string `json:"token"`
+}
+
+// AuthRegister handles POST /api/auth/register.
+//
+//	201 — created, session issued
+//	400 — missing email, or password outside 8..72
+//	409 — email already registered
+//	503 — no JWTSecret configured
+//
+// The password is never logged, and never leaves this function except as
+// a bcrypt digest.
+func (s *Server) AuthRegister(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	// Fail closed before touching the database. Without a secret there is
+	// no session to issue, so creating the user would leave an account
+	// that cannot be signed in to.
+	if len(s.Auth.JWTSecret) == 0 {
+		return echo.NewHTTPError(http.StatusServiceUnavailable,
+			"password auth unavailable: server has no session secret configured")
+	}
+
+	var req registerRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
+	}
+	email := normalizeEmail(req.Email)
+	if email == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "email is required")
+	}
+	if !strings.Contains(email, "@") {
+		return echo.NewHTTPError(http.StatusBadRequest, "email is not a valid address")
+	}
+	if n := len(req.Password); n < minPasswordLength || n > maxPasswordLength {
+		// The message states the bounds rather than which one was
+		// violated for a too-short password — it is the same information
+		// and one fewer branch to get wrong.
+		return echo.NewHTTPError(http.StatusBadRequest,
+			"password must be between 8 and 72 bytes")
+	}
+
+	// Check before hashing: bcrypt is deliberately slow, and a duplicate
+	// registration should not cost a full KDF round.
+	taken, err := s.emailTaken(ctx, email)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if taken {
+		return echo.NewHTTPError(http.StatusConflict, "email already registered")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "could not hash password")
+	}
+
+	// Same election as the OAuth callback — the first account on an
+	// installation becomes the administrator, and the winner is decided by
+	// an insert rather than a count, so two simultaneous first
+	// registrations cannot both win.
+	bootstrap, err := s.claimBootstrap(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	user, err := s.insertPasswordIdentity(ctx, email, string(hash), bootstrap)
+	if err != nil {
+		// Lost a race between the check above and this insert. The email
+		// UNIQUE constraint is what actually guarantees uniqueness; the
+		// earlier check is only there to avoid the bcrypt cost.
+		if isUniqueViolation(err) {
+			return echo.NewHTTPError(http.StatusConflict, "email already registered")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return s.respondWithSession(c, user, http.StatusCreated)
+}
+
+// AuthPasswordLogin handles POST /api/auth/login.
+//
+//	200 — authenticated, session issued
+//	400 — malformed body
+//	401 — unknown email OR wrong password OR OAuth-only account
+//	403 — account suspended
+//	503 — no JWTSecret configured
+func (s *Server) AuthPasswordLogin(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	if len(s.Auth.JWTSecret) == 0 {
+		return echo.NewHTTPError(http.StatusServiceUnavailable,
+			"password auth unavailable: server has no session secret configured")
+	}
+
+	var req loginRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
+	}
+	email := normalizeEmail(req.Email)
+	if email == "" || req.Password == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "email and password are required")
+	}
+
+	user, hash, err := s.findUserByEmail(ctx, email)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// Every failure below answers identically, and all of them do the
+	// bcrypt work. Returning early on "no such user" would make the
+	// endpoint a membership oracle twice over: once in the response, and
+	// again in the response TIME, since the hash comparison is the
+	// expensive part. compareWithDummy keeps the cost flat.
+	if user == nil || hash == "" {
+		compareWithDummy(req.Password)
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid email or password")
+	}
+	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Password)) != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid email or password")
+	}
+
+	// Past this point the credential is proven, so the account's state can
+	// be reported honestly — saying "suspended" to someone who knows the
+	// password discloses nothing they could not already infer.
+	if user.Status == "suspended" {
+		return echo.NewHTTPError(http.StatusForbidden, "account suspended")
+	}
+
+	return s.respondWithSession(c, user, http.StatusOK)
+}
+
+// respondWithSession mints the cookie + token and renders the user.
+func (s *Server) respondWithSession(c echo.Context, u *platformUser, code int) error {
+	tenantID := ""
+	if u.TenantID != nil {
+		tenantID = u.TenantID.String()
+	}
+	token, err := s.issueSession(c, u.ID.String(), u.Email, u.Role, tenantID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(code, authResponse{
+		UserID:   u.ID.String(),
+		Email:    u.Email,
+		Role:     u.Role,
+		Status:   u.Status,
+		TenantID: tenantID,
+		Token:    token,
+	})
+}
+
+// normalizeEmail lowercases and trims. Addresses differing only in case
+// are the same account, so the stored form is canonical and lookups do
+// not depend on how the user typed it today.
+func normalizeEmail(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+// dummyHash is a real bcrypt digest of a value nobody can supply, used to
+// spend comparison time when no user matched. Computed once: generating
+// it per request would itself be a timing signal, since hashing costs
+// more than comparing.
+var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
+
+func compareWithDummy(password string) {
+	_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
+}
+
+// emailTaken reports whether an address is already registered, matching
+// case-insensitively so Alice@example.com cannot register alongside
+// alice@example.com.
+func (s *Server) emailTaken(ctx context.Context, email string) (bool, error) {
+	var exists bool
+	err := s.Platform.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM users WHERE LOWER(email) = $1)`,
+		email).Scan(&exists)
+	return exists, err
+}
+
+// findUserByEmail resolves an account and its password digest.
+//
+// A missing user is (nil, "", nil) rather than an error: "no such email"
+// is an ordinary outcome of a login attempt, not a failure of the query.
+func (s *Server) findUserByEmail(ctx context.Context, email string) (*platformUser, string, error) {
+	var u platformUser
+	var hash *string
+	err := s.Platform.QueryRow(ctx, `
+		SELECT u.id, u.email, u.role, u.status, u.password_hash, t.id
+		FROM users u
+		LEFT JOIN tenants t ON t.user_id = u.id
+		WHERE LOWER(u.email) = $1`,
+		email).Scan(&u.ID, &u.Email, &u.Role, &u.Status, &hash, &u.TenantID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", nil
+		}
+		return nil, "", err
+	}
+	if hash == nil {
+		// An OAuth-only account. Treated as "no password credential"
+		// rather than a distinct error, so an attacker cannot use the
+		// login endpoint to discover which accounts use SSO.
+		return &u, "", nil
+	}
+	return &u, *hash, nil
+}
+
+// insertPasswordIdentity creates the users + tenants rows and the same
+// events the OAuth callback emits, in one transaction.
+//
+// This duplicates the shape of insertIdentity rather than calling it,
+// because that function's INSERT names oauth_provider/oauth_id and this
+// one names password_hash/auth_method. Folding both into one function
+// would mean a column list assembled at runtime — harder to read, and
+// harder to be sure about, than two explicit statements.
+func (s *Server) insertPasswordIdentity(ctx context.Context, email, hash string, bootstrap bool) (*platformUser, error) {
+	role, userStatus := "user", "pending"
+	events := []string{"user.signed_up", "tenant.pending"}
+	if bootstrap {
+		role, userStatus = "admin", "approved"
+		events = []string{
+			"user.signed_up", "user.promoted_to_admin", "user.approved",
+			"tenant.pending", "tenant.provisioning",
+		}
+	}
+
+	out := &platformUser{Email: email, Role: role, Status: userStatus}
+	err := s.writeTxDeferred(ctx, s.Platform, func(tx pgx.Tx) ([]eventstore.Event, error) {
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO users (email, password_hash, auth_method, role, status)
+			VALUES ($1,$2,'password',$3,$4) RETURNING id`,
+			email, hash, role, userStatus).Scan(&out.ID); err != nil {
+			return nil, err
+		}
+
+		dbName := "tenant_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		var tid uuid.UUID
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO tenants (user_id, db_name, status)
+			VALUES ($1,$2,'pending') RETURNING id`,
+			out.ID, dbName).Scan(&tid); err != nil {
+			return nil, err
+		}
+		out.TenantID = &tid
+
+		return platformSignupEvents(events, out.ID, tid, email, role, userStatus, dbName), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/controlplane/endpoints/auth_password_integration_test.go
+++ b/controlplane/endpoints/auth_password_integration_test.go
@@ -1,0 +1,335 @@
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// passwordHarness mounts the auth surface against the platform database
+// with a session secret configured.
+func passwordHarness(t *testing.T) (*echo.Echo, *Server) {
+	t.Helper()
+	resetPasswordTables(t)
+
+	e := echo.New()
+	srv := &Server{
+		Platform: testPlatform,
+		Auth: AuthConfig{
+			JWTSecret: []byte("test-secret-not-for-production"),
+		},
+	}
+	srv.RegisterAuth(e.Group(""))
+	srv.RegisterPlatform(e.Group(""))
+	return e, srv
+}
+
+func postJSON(t *testing.T, e *echo.Echo, path string, body any) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(b)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	var out map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	return rec, out
+}
+
+// TestPasswordRegisterAndLogin is the round trip #251 exists for: the
+// rebuilt control plane served OAuth only, so a deployment relying on
+// email+password had no way in.
+func TestPasswordRegisterAndLogin(t *testing.T) {
+	e, _ := passwordHarness(t)
+
+	rec, body := postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "first@example.com", "password": "correct-horse-battery",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register: want 201, got %d: %s", rec.Code, rec.Body)
+	}
+	if body["token"] == "" || body["token"] == nil {
+		t.Error("register did not issue a token")
+	}
+	if body["user_id"] == nil {
+		t.Error("register did not return a user_id")
+	}
+
+	// The session cookie must be set, HttpOnly — a token readable by
+	// JavaScript is one XSS away from being stolen.
+	var session *http.Cookie
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == SessionCookieName {
+			session = ck
+		}
+	}
+	if session == nil {
+		t.Fatal("register set no session cookie")
+	}
+	if !session.HttpOnly {
+		t.Error("session cookie is not HttpOnly")
+	}
+
+	rec, body = postJSON(t, e, "/api/auth/login", map[string]string{
+		"email": "first@example.com", "password": "correct-horse-battery",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("login: want 200, got %d: %s", rec.Code, rec.Body)
+	}
+	if body["token"] == "" || body["token"] == nil {
+		t.Error("login did not issue a token")
+	}
+}
+
+// TestFirstRegisteredUserBecomesAdmin pins the bootstrap branch to the
+// same outcome the OAuth callback produces. An installation's first
+// account is its administrator regardless of which door it came in
+// through; anything else means the admin you get depends on your auth
+// method.
+func TestFirstRegisteredUserBecomesAdmin(t *testing.T) {
+	e, _ := passwordHarness(t)
+
+	_, first := postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "owner@example.com", "password": "correct-horse-battery",
+	})
+	if first["role"] != "admin" {
+		t.Errorf("first user role: want admin, got %v", first["role"])
+	}
+	if first["status"] != "approved" {
+		t.Errorf("first user status: want approved, got %v", first["status"])
+	}
+
+	_, second := postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "later@example.com", "password": "correct-horse-battery",
+	})
+	if second["role"] != "user" {
+		t.Errorf("second user role: want user, got %v", second["role"])
+	}
+	if second["status"] != "pending" {
+		t.Errorf("second user status: want pending, got %v", second["status"])
+	}
+}
+
+// TestRegisterValidation covers the input bounds. The 72-byte ceiling is
+// not a style choice: bcrypt truncates there, so accepting a longer
+// password would authenticate against only its first 72 bytes.
+func TestRegisterValidation(t *testing.T) {
+	e, _ := passwordHarness(t)
+
+	cases := []struct {
+		name     string
+		email    string
+		password string
+		want     int
+	}{
+		{"missing email", "", "correct-horse-battery", http.StatusBadRequest},
+		{"not an address", "nope", "correct-horse-battery", http.StatusBadRequest},
+		{"password too short", "a@example.com", "short", http.StatusBadRequest},
+		{"password at minimum", "min@example.com", "12345678", http.StatusCreated},
+		{"password over bcrypt limit", "b@example.com", strings.Repeat("x", 73), http.StatusBadRequest},
+		{"password at bcrypt limit", "max@example.com", strings.Repeat("x", 72), http.StatusCreated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, _ := postJSON(t, e, "/api/auth/register", map[string]string{
+				"email": tc.email, "password": tc.password,
+			})
+			if rec.Code != tc.want {
+				t.Errorf("want %d, got %d: %s", tc.want, rec.Code, rec.Body)
+			}
+		})
+	}
+}
+
+// TestDuplicateEmailIsRejected — including case variants, since an
+// address differing only in case is the same account to every mail
+// system and must not become a second login.
+func TestDuplicateEmailIsRejected(t *testing.T) {
+	e, _ := passwordHarness(t)
+
+	rec, _ := postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "dup@example.com", "password": "correct-horse-battery",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body)
+	}
+
+	for _, email := range []string{"dup@example.com", "DUP@example.com", "  Dup@Example.com  "} {
+		rec, _ := postJSON(t, e, "/api/auth/register", map[string]string{
+			"email": email, "password": "correct-horse-battery",
+		})
+		if rec.Code != http.StatusConflict {
+			t.Errorf("register %q: want 409, got %d: %s", email, rec.Code, rec.Body)
+		}
+	}
+}
+
+// TestLoginIsCaseInsensitive: the address stored is canonical, so the
+// casing a user types today must not decide whether they can sign in.
+func TestLoginIsCaseInsensitive(t *testing.T) {
+	e, _ := passwordHarness(t)
+
+	postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "Mixed@Example.com", "password": "correct-horse-battery",
+	})
+	for _, email := range []string{"mixed@example.com", "MIXED@EXAMPLE.COM", " Mixed@Example.com "} {
+		rec, _ := postJSON(t, e, "/api/auth/login", map[string]string{
+			"email": email, "password": "correct-horse-battery",
+		})
+		if rec.Code != http.StatusOK {
+			t.Errorf("login %q: want 200, got %d", email, rec.Code)
+		}
+	}
+}
+
+// TestLoginFailuresAreIndistinguishable is the security property worth
+// the most here. An unknown address and a wrong password must produce the
+// same status and the same message — otherwise the endpoint reports which
+// email addresses hold accounts, which is exactly the list an attacker
+// needs before spraying passwords.
+func TestLoginFailuresAreIndistinguishable(t *testing.T) {
+	e, _ := passwordHarness(t)
+
+	postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "real@example.com", "password": "correct-horse-battery",
+	})
+
+	wrongPassword, bodyWrong := postJSON(t, e, "/api/auth/login", map[string]string{
+		"email": "real@example.com", "password": "not-the-password",
+	})
+	noSuchUser, bodyMissing := postJSON(t, e, "/api/auth/login", map[string]string{
+		"email": "ghost@example.com", "password": "not-the-password",
+	})
+
+	if wrongPassword.Code != http.StatusUnauthorized || noSuchUser.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 for both, got %d and %d", wrongPassword.Code, noSuchUser.Code)
+	}
+	if fmt.Sprint(bodyWrong["message"]) != fmt.Sprint(bodyMissing["message"]) {
+		t.Errorf("failure messages differ and leak account existence:\n  wrong password: %v\n  unknown email:  %v",
+			bodyWrong["message"], bodyMissing["message"])
+	}
+}
+
+// TestSuspendedUserCannotLogIn — the credential is valid, so the account
+// state is reported honestly. Saying "suspended" to someone who proved
+// they know the password discloses nothing they could not already infer.
+func TestSuspendedUserCannotLogIn(t *testing.T) {
+	ctx := context.Background()
+	e, _ := passwordHarness(t)
+
+	postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "owner@example.com", "password": "correct-horse-battery",
+	})
+	_, second := postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "susp@example.com", "password": "correct-horse-battery",
+	})
+	if _, err := testPlatform.Exec(ctx,
+		`UPDATE users SET status='suspended' WHERE id=$1`, second["user_id"]); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, _ := postJSON(t, e, "/api/auth/login", map[string]string{
+		"email": "susp@example.com", "password": "correct-horse-battery",
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("suspended login: want 403, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// TestPasswordIsNeverStoredInPlaintext. Obvious, and exactly the kind of
+// thing worth asserting rather than assuming.
+func TestPasswordIsNeverStoredInPlaintext(t *testing.T) {
+	ctx := context.Background()
+	e, _ := passwordHarness(t)
+
+	const secret = "correct-horse-battery"
+	postJSON(t, e, "/api/auth/register", map[string]string{
+		"email": "hash@example.com", "password": secret,
+	})
+
+	var stored string
+	if err := testPlatform.QueryRow(ctx,
+		`SELECT password_hash FROM users WHERE email='hash@example.com'`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stored, secret) {
+		t.Fatal("the plaintext password is recoverable from password_hash")
+	}
+	if !strings.HasPrefix(stored, "$2") {
+		t.Errorf("password_hash is not a bcrypt digest: %q", stored)
+	}
+}
+
+// TestPasswordAuthWithoutSecretFailsClosed. With no JWTSecret there is no
+// session to issue, so registering would create an account nobody can
+// sign in to. 503 beats a user row that is dead on arrival.
+func TestPasswordAuthWithoutSecretFailsClosed(t *testing.T) {
+	resetPasswordTables(t)
+
+	e := echo.New()
+	srv := &Server{Platform: testPlatform} // no JWTSecret
+	srv.RegisterAuth(e.Group(""))
+
+	for _, path := range []string{"/api/auth/register", "/api/auth/login"} {
+		rec, _ := postJSON(t, e, path, map[string]string{
+			"email": "x@example.com", "password": "correct-horse-battery",
+		})
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("%s without a secret: want 503, got %d", path, rec.Code)
+		}
+	}
+
+	var n int
+	if err := testPlatform.QueryRow(context.Background(),
+		`SELECT count(*) FROM users`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("a user was created despite no session being issuable: %d row(s)", n)
+	}
+}
+
+// TestOAuthOnlyAccountCannotPasswordLogin: an account with no password
+// digest must fail exactly like an unknown address, so the login endpoint
+// cannot be used to discover which accounts use SSO.
+func TestOAuthOnlyAccountCannotPasswordLogin(t *testing.T) {
+	ctx := context.Background()
+	e, _ := passwordHarness(t)
+
+	if _, err := testPlatform.Exec(ctx, `
+		INSERT INTO users (oauth_provider, oauth_id, email, role, status, auth_method)
+		VALUES ('google','g-1','sso@example.com','user','approved','oauth')`); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, body := postJSON(t, e, "/api/auth/login", map[string]string{
+		"email": "sso@example.com", "password": "correct-horse-battery",
+	})
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", rec.Code, rec.Body)
+	}
+	if msg := fmt.Sprint(body["message"]); !strings.Contains(msg, "invalid email or password") {
+		t.Errorf("message discloses the account uses SSO: %q", msg)
+	}
+}
+
+// resetPasswordTables clears platform identity between tests. bootstrap_lock
+// must go too: it is a once-per-installation row, so leaving it set would make
+// every test after the first see a non-bootstrap world.
+func resetPasswordTables(t *testing.T) {
+	t.Helper()
+	if _, err := testPlatform.Exec(context.Background(),
+		"TRUNCATE users, tenants, bootstrap_lock CASCADE"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/controlplane/endpoints/platform_integration_test.go
+++ b/controlplane/endpoints/platform_integration_test.go
@@ -36,9 +36,16 @@ func newMeTestServer() *echo.Echo {
 func seedMeUser(t *testing.T, ctx context.Context, email, role, status string) string {
 	t.Helper()
 	var id string
+	// An OAuth identity is seeded, not omitted. Platform migration 004 adds
+	// users_at_least_one_auth_method, so a row with neither an OAuth
+	// identity nor a password is now rejected — correctly, since it is an
+	// account nobody could ever sign in to. This fixture was creating
+	// exactly that; giving it a provider makes it a realistic user rather
+	// than one the schema has to tolerate.
 	if err := testPlatform.QueryRow(ctx,
-		`INSERT INTO users (email, role, status) VALUES ($1,$2,$3) RETURNING id`,
-		email, role, status).Scan(&id); err != nil {
+		`INSERT INTO users (oauth_provider, oauth_id, email, role, status)
+		 VALUES ('google', $1, $2, $3, $4) RETURNING id`,
+		"oauth-"+email, email, role, status).Scan(&id); err != nil {
 		t.Fatal(err)
 	}
 	return id

--- a/controlplane/gen/endpoints.yaml
+++ b/controlplane/gen/endpoints.yaml
@@ -762,6 +762,35 @@ groups:
           - "branch: bootstrap | new_user | existing (see branches)"
           - "Set cookie duragraph_session = JWT"
           - "302 redirect to dashboard / awaiting-approval / suspended"
+      - name: register
+        method: POST
+        path: /api/auth/register
+        custom: true
+        kind: write
+        outbox: true
+        events: [user.signed_up, user.promoted_to_admin, user.approved, tenant.pending, tenant.provisioning]
+        nats: {subject: "user.* + tenant.*", stream: "PLATFORM_USERS + PLATFORM_TENANTS"}
+        branches:
+          bootstrap: "INSERT users (role='admin', status='approved', auth_method='password') + tenants + events(user.signed_up, user.promoted_to_admin, user.approved, tenant.pending, tenant.provisioning) + outbox + pg_notify"
+          new_user: "INSERT users (status='pending', auth_method='password') + tenants (status='pending') + events(user.signed_up, tenant.pending) + outbox + pg_notify"
+          duplicate: "409 — email already registered (no writes)"
+        steps:
+          - "Validate email + password (presence, password length 8..72)"
+          - "bcrypt hash the password (never logged)"
+          - "Claim bootstrap_lock: winner is admin+approved, loser is pending"
+          - "INSERT users + tenants + events (same shape as auth.callback)"
+          - "Set cookie duragraph_session = JWT"
+      - name: password_login
+        method: POST
+        path: /api/auth/login
+        custom: true
+        kind: special
+        outbox: false
+        steps:
+          - "Look up user by LOWER(email)"
+          - "bcrypt compare against password_hash (constant-time)"
+          - "Reject identically for unknown email and wrong password"
+          - "Set cookie duragraph_session = JWT"
       - name: logout
         method: POST
         path: /api/auth/logout


### PR DESCRIPTION
Closes #251.

The rebuilt control plane served **OAuth only**. Password signup is a shipped, documented feature — it's in the 0.8.0 changelog — so flipping the default (#249) without it would have deleted working authentication from live deployments.

## Implemented natively, not by reusing the legacy handler

The legacy `PasswordHandler` is built on `internal/application/command` and its repository layer, which would drag the whole legacy persistence stack into the rebuild. What *is* shared is `authpkg.IssueJWT` — a pure function — so tokens minted here have exactly the shape the OAuth path produces.

Verified end-to-end: logged in with a password, then called `/api/platform/me` with the resulting Bearer token → `200` with the right identity.

Identity creation mirrors the OAuth callback deliberately — same `bootstrap_lock` election, same users+tenants insert, same events. **A user's rights must not depend on which door they came in through.** The event construction is now a shared `platformSignupEvents` rather than duplicated: if one path emitted a different set, a consumer rebuilding state from the log would see accounts that exist without having signed up.

## Security decisions, each with a reason

**Unknown email and wrong password answer identically, and both pay the bcrypt cost.** Returning early on "no such user" makes the endpoint an account-enumeration oracle twice over — once in the response, and again in the response *time*, since hashing is the expensive part. An OAuth-only account answers the same way, so login can't be used to discover which accounts use SSO.

**Passwords over 72 bytes are rejected, not truncated.** bcrypt silently truncates there, so accepting them would mean two different passwords sharing a 72-byte prefix are the same credential.

**Suspended is reported only after the password is proven.** Saying "suspended" to someone who knows the password discloses nothing they couldn't already infer.

**No `JWTSecret` → 503, and nothing written.** Creating a user when no session can be issued leaves an account dead on arrival.

**Emails are canonicalised to lowercase**, so case variants can't become a second account.

## What the new CHECK caught

Migration `004` adds `users_at_least_one_auth_method` — and it immediately failed three existing `/me` tests. Their fixture inserted users with **neither an OAuth identity nor a password**: accounts nobody could ever sign in to.

The constraint was right and the fixture was wrong, so the fixture now seeds a realistic OAuth user. Both production insert paths already set one method, so no real row is affected — and the migration documents that the CHECK is validated against existing rows.

Also corrected while writing it: `004` originally carried `ALTER COLUMN oauth_provider DROP NOT NULL`, copied from the legacy migration. **v2's `001` never declared those columns `NOT NULL`**, so it was a no-op implying a constraint that never existed.

## Verification

Probes confirm the tests bite — different messages on the two failure paths fails the enumeration tests; skipping the bootstrap election fails first-user-is-admin. Both probes were checked to have *actually applied* before believing the result.

Against the real binary:

```
register(1st) -> 201   role/status: admin/approved     (bootstrap)
register(2nd) -> 201   role/status: user/pending
duplicate (OWNER@x.io vs owner@x.io) -> 409
bad password  -> 401
/me with password-issued token -> 200
```

Routes are generated from `endpoints.yaml`; regeneration is idempotent (verified by running it twice and diffing).